### PR TITLE
cleanup: pass series Arc by ref in dynamic update_cache

### DIFF
--- a/crates/fast-telemetry/src/metric/dynamic/counter.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/counter.rs
@@ -193,7 +193,7 @@ impl DynamicCounter {
             };
         }
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         DynamicCounterSeries {
             series,
             shard_mask: self.shard_mask,
@@ -216,7 +216,7 @@ impl DynamicCounter {
         }
 
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         let shard_idx = thread_id() & self.shard_mask;
         series.add_at(shard_idx, value);
     }
@@ -401,7 +401,7 @@ impl DynamicCounter {
         })
     }
 
-    fn update_cache(&self, labels: &[(&str, &str)], series: Arc<CounterSeries>) {
+    fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<CounterSeries>) {
         SERIES_CACHE.with(|cache| {
             let ordered_labels = labels
                 .iter()
@@ -410,7 +410,7 @@ impl DynamicCounter {
             *cache.borrow_mut() = Some(SeriesCacheEntry {
                 counter_id: self.id,
                 ordered_labels,
-                series: Arc::downgrade(&series),
+                series: Arc::downgrade(series),
             });
         });
     }

--- a/crates/fast-telemetry/src/metric/dynamic/distribution.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/distribution.rs
@@ -206,7 +206,7 @@ impl DynamicDistribution {
         }
         let series = self.lookup_or_create(labels);
         let buf = self.get_or_create_thread_buf(&series);
-        self.update_cache(labels, Arc::clone(&series), Arc::clone(&buf));
+        self.update_cache(labels, &series, Arc::clone(&buf));
         DynamicDistributionSeries { series, buf }
     }
 
@@ -220,7 +220,7 @@ impl DynamicDistribution {
 
         let series = self.lookup_or_create(labels);
         let buf = self.get_or_create_thread_buf(&series);
-        self.update_cache(labels, Arc::clone(&series), Arc::clone(&buf));
+        self.update_cache(labels, &series, Arc::clone(&buf));
         buf.record(value);
     }
 
@@ -418,7 +418,7 @@ impl DynamicDistribution {
     fn update_cache(
         &self,
         labels: &[(&str, &str)],
-        series: Arc<DistributionSeries>,
+        series: &Arc<DistributionSeries>,
         buf: Arc<ExpBuckets>,
     ) {
         SERIES_CACHE.with(|cache| {
@@ -429,7 +429,7 @@ impl DynamicDistribution {
             *cache.borrow_mut() = Some(SeriesCacheEntry {
                 distribution_id: self.id,
                 ordered_labels,
-                series: Arc::downgrade(&series),
+                series: Arc::downgrade(series),
                 buf,
             });
         });

--- a/crates/fast-telemetry/src/metric/dynamic/gauge.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/gauge.rs
@@ -166,7 +166,7 @@ impl DynamicGauge {
             return DynamicGaugeSeries { series };
         }
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         DynamicGaugeSeries { series }
     }
 
@@ -179,7 +179,7 @@ impl DynamicGauge {
         }
 
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         series.set(value);
     }
 
@@ -353,7 +353,7 @@ impl DynamicGauge {
         })
     }
 
-    fn update_cache(&self, labels: &[(&str, &str)], series: Arc<GaugeSeries>) {
+    fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<GaugeSeries>) {
         SERIES_CACHE.with(|cache| {
             let ordered_labels = labels
                 .iter()
@@ -362,7 +362,7 @@ impl DynamicGauge {
             *cache.borrow_mut() = Some(SeriesCacheEntry {
                 gauge_id: self.id,
                 ordered_labels,
-                series: Arc::downgrade(&series),
+                series: Arc::downgrade(series),
             });
         });
     }

--- a/crates/fast-telemetry/src/metric/dynamic/gauge_i64.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/gauge_i64.rs
@@ -219,7 +219,7 @@ impl DynamicGaugeI64 {
             };
         }
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         DynamicGaugeI64Series {
             series,
             shard_mask: self.shard_mask,
@@ -248,7 +248,7 @@ impl DynamicGaugeI64 {
         }
 
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         let shard_idx = thread_id() & self.shard_mask;
         series.add_at(shard_idx, value);
     }
@@ -263,7 +263,7 @@ impl DynamicGaugeI64 {
         }
 
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         let shard_idx = thread_id() & self.shard_mask;
         series.set_at(shard_idx, value);
     }
@@ -443,7 +443,7 @@ impl DynamicGaugeI64 {
         })
     }
 
-    fn update_cache(&self, labels: &[(&str, &str)], series: Arc<GaugeI64Series>) {
+    fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<GaugeI64Series>) {
         SERIES_CACHE.with(|cache| {
             let ordered_labels = labels
                 .iter()
@@ -452,7 +452,7 @@ impl DynamicGaugeI64 {
             *cache.borrow_mut() = Some(SeriesCacheEntry {
                 gauge_id: self.id,
                 ordered_labels,
-                series: Arc::downgrade(&series),
+                series: Arc::downgrade(series),
             });
         });
     }

--- a/crates/fast-telemetry/src/metric/dynamic/histogram.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/histogram.rs
@@ -311,7 +311,7 @@ impl DynamicHistogram {
             };
         }
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         DynamicHistogramSeries {
             series,
             shard_mask: self.shard_mask,
@@ -328,7 +328,7 @@ impl DynamicHistogram {
         }
 
         let series = self.lookup_or_create(labels);
-        self.update_cache(labels, Arc::clone(&series));
+        self.update_cache(labels, &series);
         let shard_idx = thread_id() & self.shard_mask;
         series.record_at(shard_idx, value);
     }
@@ -541,7 +541,7 @@ impl DynamicHistogram {
         })
     }
 
-    fn update_cache(&self, labels: &[(&str, &str)], series: Arc<HistogramSeries>) {
+    fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<HistogramSeries>) {
         SERIES_CACHE.with(|cache| {
             let ordered_labels = labels
                 .iter()
@@ -550,7 +550,7 @@ impl DynamicHistogram {
             *cache.borrow_mut() = Some(SeriesCacheEntry {
                 histogram_id: self.id,
                 ordered_labels,
-                series: Arc::downgrade(&series),
+                series: Arc::downgrade(series),
             });
         });
     }


### PR DESCRIPTION
`update_cache` in the five dynamic metric types doesn't consume its `series` param, switched to `&Arc<...>` and dropped the `Arc::clone(&series)` at each call site, saving an atomic refcount bump + drop per cache insert.