### PR TITLE
feat: add extrema gauge metric types

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ fast-telemetry = "0.1"
 ### Define Metrics
 
 ```rust
-use fast_telemetry::{Counter, Histogram, Gauge, ExportMetrics};
+use fast_telemetry::{Counter, ExportMetrics, Gauge, Histogram, MaxGauge};
 
 #[derive(ExportMetrics)]
 #[metric_prefix = "myapp"]
@@ -116,6 +116,9 @@ pub struct AppMetrics {
 
     #[help = "Current queue depth"]
     pub queue_depth: Gauge,
+
+    #[help = "Peak queue depth seen during the current export window"]
+    pub queue_depth_peak: MaxGauge,
 }
 
 impl AppMetrics {
@@ -124,6 +127,7 @@ impl AppMetrics {
             requests: Counter::new(4),     // use available_parallelism() in production
             latency: Histogram::with_latency_buckets(4),
             queue_depth: Gauge::new(),
+            queue_depth_peak: MaxGauge::new(4),
         }
     }
 }
@@ -135,6 +139,7 @@ impl AppMetrics {
 metrics.requests.inc();
 metrics.latency.record(elapsed_us);
 metrics.queue_depth.set(queue.len() as i64);
+metrics.queue_depth_peak.observe(queue.len() as i64);
 ```
 
 ### Export
@@ -148,6 +153,39 @@ metrics.export_prometheus( & mut output);
 let mut output = String::new();
 metrics.export_dogstatsd( & mut output, & [("env", "prod")]);
 ```
+
+### Extrema Gauges
+
+Use extrema gauges when you want peak/trough tracking without putting a single
+contended atomic on the hot path.
+
+```rust
+use fast_telemetry::{MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64};
+
+let queue_peak = MaxGauge::new(4);
+queue_peak.observe(queue.len() as i64);
+
+let min_free_slots = MinGauge::with_value(4, i64::MAX);
+min_free_slots.observe(free_slots as i64);
+
+let cpu_peak = MaxGaugeF64::new(4);
+cpu_peak.observe(cpu_utilization);
+
+let cheapest_latency_ms = MinGaugeF64::with_value(4, f64::INFINITY);
+cheapest_latency_ms.observe(latency_ms);
+```
+
+For interval export, call `swap_reset()` in your sampler/exporter task:
+
+```rust
+let peak_in_window = queue_peak.swap_reset();
+let min_in_window = cheapest_latency_ms.swap_reset();
+```
+
+`observe()` is hot-path safe and shard-friendly. `get()` returns the current
+extremum across shards, and `swap_reset()` gives you the previous window's
+extremum while resetting back to the constructor's initial value. The `f64`
+variants ignore `NaN` observations.
 
 ## Labeled Metrics
 
@@ -380,6 +418,8 @@ let request = otlp::build_export_request( & resource, "fast-telemetry", metrics)
 | `Histogram`          | Latency distributions with fixed buckets | ~2ns + bucket lookup      |
 | `Distribution`       | Exponential-bucket distributions         | ~2ns + bucket lookup      |
 | `Gauge` / `GaugeF64` | Point-in-time values                     | ~2ns (single atomic)      |
+| `MaxGauge` / `MinGauge` | Peak/trough of integer observations   | ~2ns (sharded min/max)    |
+| `MaxGaugeF64` / `MinGaugeF64` | Peak/trough of float observations | ~2ns (sharded min/max)    |
 
 ### Labeled Variants
 

--- a/crates/fast-telemetry-macros/src/lib.rs
+++ b/crates/fast-telemetry-macros/src/lib.rs
@@ -24,6 +24,10 @@ enum MetricKind {
     Gauge,
     GaugeF64,
     Histogram,
+    MaxGauge,
+    MaxGaugeF64,
+    MinGauge,
+    MinGaugeF64,
     LabeledCounter(Type),
     LabeledGauge,
     LabeledHistogram(Type),
@@ -60,6 +64,10 @@ fn metric_kind(ty: &Type) -> Option<MetricKind> {
         "Gauge" => Some(MetricKind::Gauge),
         "GaugeF64" => Some(MetricKind::GaugeF64),
         "Histogram" => Some(MetricKind::Histogram),
+        "MaxGauge" => Some(MetricKind::MaxGauge),
+        "MaxGaugeF64" => Some(MetricKind::MaxGaugeF64),
+        "MinGauge" => Some(MetricKind::MinGauge),
+        "MinGaugeF64" => Some(MetricKind::MinGaugeF64),
         "LabeledCounter" => {
             let PathArguments::AngleBracketed(args) = &segment.arguments else {
                 return None;
@@ -245,6 +253,10 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
             MetricKind::Counter
             | MetricKind::Gauge
             | MetricKind::GaugeF64
+            | MetricKind::MaxGauge
+            | MetricKind::MaxGaugeF64
+            | MetricKind::MinGauge
+            | MetricKind::MinGaugeF64
             | MetricKind::Distribution
             | MetricKind::DynamicCounter
             | MetricKind::DynamicGauge
@@ -262,7 +274,13 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
         }
 
         match &metric_kind {
-            MetricKind::Counter | MetricKind::Gauge | MetricKind::GaugeF64 => {
+            MetricKind::Counter
+            | MetricKind::Gauge
+            | MetricKind::GaugeF64
+            | MetricKind::MaxGauge
+            | MetricKind::MaxGaugeF64
+            | MetricKind::MinGauge
+            | MetricKind::MinGaugeF64 => {
                 dogstatsd_reserve_hint +=
                     statsd_metric_name.len() + DOGSTATSD_SIMPLE_LINE_OVERHEAD_BYTES;
                 dogstatsd_delta_reserve_hint +=
@@ -622,7 +640,12 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     state.#sum_state_field.retain(|k, _| current_keys.contains(k));
                 });
             }
-            MetricKind::Gauge | MetricKind::GaugeF64 => {
+            MetricKind::Gauge
+            | MetricKind::GaugeF64
+            | MetricKind::MaxGauge
+            | MetricKind::MaxGaugeF64
+            | MetricKind::MinGauge
+            | MetricKind::MinGaugeF64 => {
                 state_label_count_exprs.push(quote! { 0usize });
                 // Gauges are point-in-time, no delta tracking needed (always export current value)
                 delta_exports.push(quote! {

--- a/crates/fast-telemetry/src/export/otlp.rs
+++ b/crates/fast-telemetry/src/export/otlp.rs
@@ -10,7 +10,7 @@ use crate::exp_buckets::ExpBucketsSnapshot;
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram,
+    LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
 };
 
 /// Re-export proto types so downstream crates (and the derive macro) can reference them.
@@ -221,6 +221,82 @@ impl OtlpExport for Gauge {
 }
 
 impl OtlpExport for GaugeF64 {
+    fn export_otlp(
+        &self,
+        metrics: &mut Vec<pb::Metric>,
+        name: &str,
+        description: &str,
+        time_unix_nano: u64,
+    ) {
+        metrics.push(pb::Metric {
+            name: name.to_string(),
+            description: description.to_string(),
+            data: Some(pb::metric::Data::Gauge(pb::OtlpGauge {
+                data_points: vec![double_data_point(self.get(), Vec::new(), time_unix_nano)],
+            })),
+            ..Default::default()
+        });
+    }
+}
+
+impl OtlpExport for MaxGauge {
+    fn export_otlp(
+        &self,
+        metrics: &mut Vec<pb::Metric>,
+        name: &str,
+        description: &str,
+        time_unix_nano: u64,
+    ) {
+        metrics.push(pb::Metric {
+            name: name.to_string(),
+            description: description.to_string(),
+            data: Some(pb::metric::Data::Gauge(pb::OtlpGauge {
+                data_points: vec![int_data_point(self.get(), Vec::new(), time_unix_nano)],
+            })),
+            ..Default::default()
+        });
+    }
+}
+
+impl OtlpExport for MaxGaugeF64 {
+    fn export_otlp(
+        &self,
+        metrics: &mut Vec<pb::Metric>,
+        name: &str,
+        description: &str,
+        time_unix_nano: u64,
+    ) {
+        metrics.push(pb::Metric {
+            name: name.to_string(),
+            description: description.to_string(),
+            data: Some(pb::metric::Data::Gauge(pb::OtlpGauge {
+                data_points: vec![double_data_point(self.get(), Vec::new(), time_unix_nano)],
+            })),
+            ..Default::default()
+        });
+    }
+}
+
+impl OtlpExport for MinGauge {
+    fn export_otlp(
+        &self,
+        metrics: &mut Vec<pb::Metric>,
+        name: &str,
+        description: &str,
+        time_unix_nano: u64,
+    ) {
+        metrics.push(pb::Metric {
+            name: name.to_string(),
+            description: description.to_string(),
+            data: Some(pb::metric::Data::Gauge(pb::OtlpGauge {
+                data_points: vec![int_data_point(self.get(), Vec::new(), time_unix_nano)],
+            })),
+            ..Default::default()
+        });
+    }
+}
+
+impl OtlpExport for MinGaugeF64 {
     fn export_otlp(
         &self,
         metrics: &mut Vec<pb::Metric>,

--- a/crates/fast-telemetry/src/export/text/dogstatsd.rs
+++ b/crates/fast-telemetry/src/export/text/dogstatsd.rs
@@ -1,7 +1,8 @@
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, DynamicLabelSet, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter,
-    LabeledGauge, LabeledHistogram, exp_buckets::ExpBucketsSnapshot,
+    LabeledGauge, LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    exp_buckets::ExpBucketsSnapshot,
 };
 use std::fmt::{Display, Write as _};
 
@@ -356,6 +357,50 @@ impl DogStatsDExport for Gauge {
         output.push_str(name);
         output.push(':');
         push_display(output, self.get());
+        output.push_str("|g");
+        append_tags(output, tags);
+        output.push('\n');
+    }
+}
+
+impl DogStatsDExport for MaxGauge {
+    fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
+        output.push_str(name);
+        output.push(':');
+        push_display(output, self.get());
+        output.push_str("|g");
+        append_tags(output, tags);
+        output.push('\n');
+    }
+}
+
+impl DogStatsDExport for MaxGaugeF64 {
+    fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
+        output.push_str(name);
+        output.push(':');
+        write_gauge_f64_value(output, self.get());
+        output.push_str("|g");
+        append_tags(output, tags);
+        output.push('\n');
+    }
+}
+
+impl DogStatsDExport for MinGauge {
+    fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
+        output.push_str(name);
+        output.push(':');
+        push_display(output, self.get());
+        output.push_str("|g");
+        append_tags(output, tags);
+        output.push('\n');
+    }
+}
+
+impl DogStatsDExport for MinGaugeF64 {
+    fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
+        output.push_str(name);
+        output.push(':');
+        write_gauge_f64_value(output, self.get());
         output.push_str("|g");
         append_tags(output, tags);
         output.push('\n');

--- a/crates/fast-telemetry/src/export/text/prometheus.rs
+++ b/crates/fast-telemetry/src/export/text/prometheus.rs
@@ -1,7 +1,7 @@
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram,
+    LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
 };
 use std::fmt::Write as _;
 
@@ -64,6 +64,70 @@ impl PrometheusExport for Gauge {
 }
 
 impl PrometheusExport for GaugeF64 {
+    fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
+        output.push_str("# HELP ");
+        output.push_str(name);
+        output.push(' ');
+        output.push_str(help);
+        output.push_str("\n# TYPE ");
+        output.push_str(name);
+        output.push_str(" gauge\n");
+        output.push_str(name);
+        output.push(' ');
+        push_display(output, self.get());
+        output.push('\n');
+    }
+}
+
+impl PrometheusExport for MaxGauge {
+    fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
+        output.push_str("# HELP ");
+        output.push_str(name);
+        output.push(' ');
+        output.push_str(help);
+        output.push_str("\n# TYPE ");
+        output.push_str(name);
+        output.push_str(" gauge\n");
+        output.push_str(name);
+        output.push(' ');
+        push_display(output, self.get());
+        output.push('\n');
+    }
+}
+
+impl PrometheusExport for MaxGaugeF64 {
+    fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
+        output.push_str("# HELP ");
+        output.push_str(name);
+        output.push(' ');
+        output.push_str(help);
+        output.push_str("\n# TYPE ");
+        output.push_str(name);
+        output.push_str(" gauge\n");
+        output.push_str(name);
+        output.push(' ');
+        push_display(output, self.get());
+        output.push('\n');
+    }
+}
+
+impl PrometheusExport for MinGauge {
+    fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
+        output.push_str("# HELP ");
+        output.push_str(name);
+        output.push(' ');
+        output.push_str(help);
+        output.push_str("\n# TYPE ");
+        output.push_str(name);
+        output.push_str(" gauge\n");
+        output.push_str(name);
+        output.push(' ');
+        push_display(output, self.get());
+        output.push('\n');
+    }
+}
+
+impl PrometheusExport for MinGaugeF64 {
     fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
         output.push_str("# HELP ");
         output.push_str(name);

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -51,7 +51,7 @@ pub use metric::{
     DynamicDistributionSeries, DynamicGauge, DynamicGaugeI64, DynamicGaugeI64Series,
     DynamicGaugeSeries, DynamicHistogram, DynamicHistogramSeries, DynamicHistogramSeriesView,
     DynamicLabelSet, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram,
+    LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
 };
 #[cfg(feature = "eviction")]
 pub use metric::{advance_cycle, current_cycle};

--- a/crates/fast-telemetry/src/metric/max_gauge.rs
+++ b/crates/fast-telemetry/src/metric/max_gauge.rs
@@ -1,0 +1,155 @@
+//! Thread-sharded maximum gauge.
+//!
+//! Records the maximum observed value without introducing a single contended
+//! atomic on the hot path. Each thread updates its own shard with `fetch_max`,
+//! and reads aggregate by taking the maximum across shards.
+
+use crate::thread_id::thread_id;
+use crossbeam_utils::CachePadded;
+use std::fmt;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+fn make_padded_cell(initial: i64) -> CachePadded<AtomicI64> {
+    CachePadded::new(AtomicI64::new(initial))
+}
+
+/// A thread-sharded maximum tracker exported as a gauge.
+///
+/// This is useful for recording peaks such as maximum queue depth or the
+/// highest number of in-flight requests seen during an export interval.
+///
+/// Unlike [`crate::Gauge`], this is not a point-in-time `set()` value.
+/// Writers call [`observe`](Self::observe), and readers aggregate by taking
+/// the maximum across shards.
+pub struct MaxGauge {
+    cells: Vec<CachePadded<AtomicI64>>,
+    reset_value: i64,
+}
+
+impl MaxGauge {
+    /// Create a new max gauge with all shards initialized to zero.
+    ///
+    /// This is appropriate for metrics that are naturally non-negative.
+    pub fn new(shard_count: usize) -> Self {
+        Self::with_value(shard_count, 0)
+    }
+
+    /// Create a new max gauge with all shards initialized to `initial`.
+    pub fn with_value(shard_count: usize, initial: i64) -> Self {
+        let shard_count = shard_count.next_power_of_two();
+        Self {
+            cells: (0..shard_count)
+                .map(|_| make_padded_cell(initial))
+                .collect(),
+            reset_value: initial,
+        }
+    }
+
+    /// Record a candidate value for the maximum.
+    #[inline]
+    pub fn observe(&self, value: i64) {
+        let idx = thread_id() & (self.cells.len() - 1);
+        let cell = if cfg!(debug_assertions) {
+            self.cells.get(idx).expect("index out of bounds")
+        } else {
+            unsafe { self.cells.get_unchecked(idx) }
+        };
+        cell.fetch_max(value, Ordering::Relaxed);
+    }
+
+    /// Return the current maximum across all shards.
+    #[inline]
+    pub fn get(&self) -> i64 {
+        self.cells
+            .iter()
+            .map(|cell| cell.load(Ordering::Relaxed))
+            .max()
+            .unwrap_or(self.reset_value)
+    }
+
+    /// Reset all shards to the original value configured at construction.
+    ///
+    /// This is intended for export/sampling code, not the hot path.
+    pub fn reset(&self) {
+        for cell in &self.cells {
+            cell.store(self.reset_value, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset all shards and return the previous maximum.
+    ///
+    /// Concurrent observations that land on already-reset shards may be
+    /// attributed to the next window rather than the current one. No maxima
+    /// are lost, but timing near the reset boundary is eventually consistent
+    /// in the same way as [`crate::Counter::swap`].
+    pub fn swap_reset(&self) -> i64 {
+        self.cells
+            .iter()
+            .map(|cell| cell.swap(self.reset_value, Ordering::Relaxed))
+            .max()
+            .unwrap_or(self.reset_value)
+    }
+}
+
+impl Default for MaxGauge {
+    fn default() -> Self {
+        Self::new(4)
+    }
+}
+
+impl fmt::Debug for MaxGauge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MaxGauge")
+            .field("max", &self.get())
+            .field("cells", &self.cells.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_observe() {
+        let gauge = MaxGauge::new(4);
+        gauge.observe(3);
+        gauge.observe(7);
+        gauge.observe(5);
+        assert_eq!(gauge.get(), 7);
+    }
+
+    #[test]
+    fn initial_value_is_respected() {
+        let gauge = MaxGauge::with_value(4, -10);
+        assert_eq!(gauge.get(), -10);
+        gauge.observe(-3);
+        assert_eq!(gauge.get(), -3);
+    }
+
+    #[test]
+    fn reset_and_swap_reset() {
+        let gauge = MaxGauge::with_value(4, 0);
+        gauge.observe(9);
+        gauge.observe(4);
+        assert_eq!(gauge.swap_reset(), 9);
+        assert_eq!(gauge.get(), 0);
+        gauge.observe(2);
+        gauge.reset();
+        assert_eq!(gauge.get(), 0);
+    }
+
+    #[test]
+    fn concurrent_observe() {
+        let gauge = MaxGauge::with_value(8, 0);
+        std::thread::scope(|s| {
+            for value in [10, 30, 20, 40, 15, 25, 35, 5] {
+                let gauge = &gauge;
+                s.spawn(move || {
+                    gauge.observe(value);
+                });
+            }
+        });
+        assert_eq!(gauge.get(), 40);
+    }
+}

--- a/crates/fast-telemetry/src/metric/max_gauge_f64.rs
+++ b/crates/fast-telemetry/src/metric/max_gauge_f64.rs
@@ -1,0 +1,150 @@
+//! Thread-sharded maximum gauge for `f64` values.
+//!
+//! Values are encoded into a sortable `u64` representation so the hot path can
+//! use atomic min/max operations while preserving numeric ordering, including
+//! for negative values.
+
+use crate::thread_id::thread_id;
+use crossbeam_utils::CachePadded;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const SIGN_MASK: u64 = 1u64 << 63;
+
+#[inline]
+fn encode_ordered_f64(value: f64) -> u64 {
+    let bits = value.to_bits();
+    if bits & SIGN_MASK != 0 {
+        !bits
+    } else {
+        bits ^ SIGN_MASK
+    }
+}
+
+#[inline]
+fn decode_ordered_f64(encoded: u64) -> f64 {
+    let bits = if encoded & SIGN_MASK != 0 {
+        encoded ^ SIGN_MASK
+    } else {
+        !encoded
+    };
+    f64::from_bits(bits)
+}
+
+/// A thread-sharded maximum tracker for floating-point values.
+///
+/// `NaN` observations are ignored.
+pub struct MaxGaugeF64 {
+    cells: Vec<CachePadded<AtomicU64>>,
+    reset_value: u64,
+}
+
+impl MaxGaugeF64 {
+    /// Create a new max gauge with all shards initialized to zero.
+    pub fn new(shard_count: usize) -> Self {
+        Self::with_value(shard_count, 0.0)
+    }
+
+    /// Create a new max gauge with all shards initialized to `initial`.
+    pub fn with_value(shard_count: usize, initial: f64) -> Self {
+        let shard_count = shard_count.next_power_of_two();
+        let reset_value = encode_ordered_f64(initial);
+        Self {
+            cells: (0..shard_count)
+                .map(|_| CachePadded::new(AtomicU64::new(reset_value)))
+                .collect(),
+            reset_value,
+        }
+    }
+
+    /// Record a candidate value for the maximum.
+    ///
+    /// `NaN` is ignored.
+    #[inline]
+    pub fn observe(&self, value: f64) {
+        if value.is_nan() {
+            return;
+        }
+        let idx = thread_id() & (self.cells.len() - 1);
+        let cell = if cfg!(debug_assertions) {
+            self.cells.get(idx).expect("index out of bounds")
+        } else {
+            unsafe { self.cells.get_unchecked(idx) }
+        };
+        cell.fetch_max(encode_ordered_f64(value), Ordering::Relaxed);
+    }
+
+    /// Return the current maximum across all shards.
+    #[inline]
+    pub fn get(&self) -> f64 {
+        decode_ordered_f64(
+            self.cells
+                .iter()
+                .map(|cell| cell.load(Ordering::Relaxed))
+                .max()
+                .unwrap_or(self.reset_value),
+        )
+    }
+
+    /// Reset all shards to the original value configured at construction.
+    pub fn reset(&self) {
+        for cell in &self.cells {
+            cell.store(self.reset_value, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset all shards and return the previous maximum.
+    pub fn swap_reset(&self) -> f64 {
+        decode_ordered_f64(
+            self.cells
+                .iter()
+                .map(|cell| cell.swap(self.reset_value, Ordering::Relaxed))
+                .max()
+                .unwrap_or(self.reset_value),
+        )
+    }
+}
+
+impl Default for MaxGaugeF64 {
+    fn default() -> Self {
+        Self::new(4)
+    }
+}
+
+impl fmt::Debug for MaxGaugeF64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MaxGaugeF64")
+            .field("max", &self.get())
+            .field("cells", &self.cells.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_observe() {
+        let gauge = MaxGaugeF64::new(4);
+        gauge.observe(3.5);
+        gauge.observe(7.25);
+        gauge.observe(5.0);
+        assert!((gauge.get() - 7.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn negative_values_order_correctly() {
+        let gauge = MaxGaugeF64::with_value(4, -10.0);
+        gauge.observe(-3.25);
+        gauge.observe(-8.0);
+        assert!((gauge.get() - (-3.25)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn nan_is_ignored() {
+        let gauge = MaxGaugeF64::with_value(4, 1.0);
+        gauge.observe(f64::NAN);
+        assert!((gauge.get() - 1.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/fast-telemetry/src/metric/min_gauge.rs
+++ b/crates/fast-telemetry/src/metric/min_gauge.rs
@@ -1,0 +1,109 @@
+//! Thread-sharded minimum gauge.
+
+use crate::thread_id::thread_id;
+use crossbeam_utils::CachePadded;
+use std::fmt;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+fn make_padded_cell(initial: i64) -> CachePadded<AtomicI64> {
+    CachePadded::new(AtomicI64::new(initial))
+}
+
+/// A thread-sharded minimum tracker exported as a gauge.
+pub struct MinGauge {
+    cells: Vec<CachePadded<AtomicI64>>,
+    reset_value: i64,
+}
+
+impl MinGauge {
+    /// Create a new min gauge with all shards initialized to zero.
+    pub fn new(shard_count: usize) -> Self {
+        Self::with_value(shard_count, 0)
+    }
+
+    /// Create a new min gauge with all shards initialized to `initial`.
+    pub fn with_value(shard_count: usize, initial: i64) -> Self {
+        let shard_count = shard_count.next_power_of_two();
+        Self {
+            cells: (0..shard_count)
+                .map(|_| make_padded_cell(initial))
+                .collect(),
+            reset_value: initial,
+        }
+    }
+
+    /// Record a candidate value for the minimum.
+    #[inline]
+    pub fn observe(&self, value: i64) {
+        let idx = thread_id() & (self.cells.len() - 1);
+        let cell = if cfg!(debug_assertions) {
+            self.cells.get(idx).expect("index out of bounds")
+        } else {
+            unsafe { self.cells.get_unchecked(idx) }
+        };
+        cell.fetch_min(value, Ordering::Relaxed);
+    }
+
+    /// Return the current minimum across all shards.
+    #[inline]
+    pub fn get(&self) -> i64 {
+        self.cells
+            .iter()
+            .map(|cell| cell.load(Ordering::Relaxed))
+            .min()
+            .unwrap_or(self.reset_value)
+    }
+
+    /// Reset all shards to the original value configured at construction.
+    pub fn reset(&self) {
+        for cell in &self.cells {
+            cell.store(self.reset_value, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset all shards and return the previous minimum.
+    pub fn swap_reset(&self) -> i64 {
+        self.cells
+            .iter()
+            .map(|cell| cell.swap(self.reset_value, Ordering::Relaxed))
+            .min()
+            .unwrap_or(self.reset_value)
+    }
+}
+
+impl Default for MinGauge {
+    fn default() -> Self {
+        Self::new(4)
+    }
+}
+
+impl fmt::Debug for MinGauge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MinGauge")
+            .field("min", &self.get())
+            .field("cells", &self.cells.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_observe() {
+        let gauge = MinGauge::new(4);
+        gauge.observe(3);
+        gauge.observe(-7);
+        gauge.observe(5);
+        assert_eq!(gauge.get(), -7);
+    }
+
+    #[test]
+    fn initial_value_is_respected() {
+        let gauge = MinGauge::with_value(4, 10);
+        assert_eq!(gauge.get(), 10);
+        gauge.observe(3);
+        assert_eq!(gauge.get(), 3);
+    }
+}

--- a/crates/fast-telemetry/src/metric/min_gauge_f64.rs
+++ b/crates/fast-telemetry/src/metric/min_gauge_f64.rs
@@ -1,0 +1,138 @@
+//! Thread-sharded minimum gauge for `f64` values.
+
+use crate::thread_id::thread_id;
+use crossbeam_utils::CachePadded;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const SIGN_MASK: u64 = 1u64 << 63;
+
+#[inline]
+fn encode_ordered_f64(value: f64) -> u64 {
+    let bits = value.to_bits();
+    if bits & SIGN_MASK != 0 {
+        !bits
+    } else {
+        bits ^ SIGN_MASK
+    }
+}
+
+#[inline]
+fn decode_ordered_f64(encoded: u64) -> f64 {
+    let bits = if encoded & SIGN_MASK != 0 {
+        encoded ^ SIGN_MASK
+    } else {
+        !encoded
+    };
+    f64::from_bits(bits)
+}
+
+/// A thread-sharded minimum tracker for floating-point values.
+///
+/// `NaN` observations are ignored.
+pub struct MinGaugeF64 {
+    cells: Vec<CachePadded<AtomicU64>>,
+    reset_value: u64,
+}
+
+impl MinGaugeF64 {
+    /// Create a new min gauge with all shards initialized to zero.
+    pub fn new(shard_count: usize) -> Self {
+        Self::with_value(shard_count, 0.0)
+    }
+
+    /// Create a new min gauge with all shards initialized to `initial`.
+    pub fn with_value(shard_count: usize, initial: f64) -> Self {
+        let shard_count = shard_count.next_power_of_two();
+        let reset_value = encode_ordered_f64(initial);
+        Self {
+            cells: (0..shard_count)
+                .map(|_| CachePadded::new(AtomicU64::new(reset_value)))
+                .collect(),
+            reset_value,
+        }
+    }
+
+    /// Record a candidate value for the minimum.
+    ///
+    /// `NaN` is ignored.
+    #[inline]
+    pub fn observe(&self, value: f64) {
+        if value.is_nan() {
+            return;
+        }
+        let idx = thread_id() & (self.cells.len() - 1);
+        let cell = if cfg!(debug_assertions) {
+            self.cells.get(idx).expect("index out of bounds")
+        } else {
+            unsafe { self.cells.get_unchecked(idx) }
+        };
+        cell.fetch_min(encode_ordered_f64(value), Ordering::Relaxed);
+    }
+
+    /// Return the current minimum across all shards.
+    #[inline]
+    pub fn get(&self) -> f64 {
+        decode_ordered_f64(
+            self.cells
+                .iter()
+                .map(|cell| cell.load(Ordering::Relaxed))
+                .min()
+                .unwrap_or(self.reset_value),
+        )
+    }
+
+    /// Reset all shards to the original value configured at construction.
+    pub fn reset(&self) {
+        for cell in &self.cells {
+            cell.store(self.reset_value, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset all shards and return the previous minimum.
+    pub fn swap_reset(&self) -> f64 {
+        decode_ordered_f64(
+            self.cells
+                .iter()
+                .map(|cell| cell.swap(self.reset_value, Ordering::Relaxed))
+                .min()
+                .unwrap_or(self.reset_value),
+        )
+    }
+}
+
+impl Default for MinGaugeF64 {
+    fn default() -> Self {
+        Self::new(4)
+    }
+}
+
+impl fmt::Debug for MinGaugeF64 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MinGaugeF64")
+            .field("min", &self.get())
+            .field("cells", &self.cells.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_observe() {
+        let gauge = MinGaugeF64::new(4);
+        gauge.observe(3.5);
+        gauge.observe(-7.25);
+        gauge.observe(5.0);
+        assert!((gauge.get() - (-7.25)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn nan_is_ignored() {
+        let gauge = MinGaugeF64::with_value(4, 1.0);
+        gauge.observe(f64::NAN);
+        assert!((gauge.get() - 1.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/fast-telemetry/src/metric/mod.rs
+++ b/crates/fast-telemetry/src/metric/mod.rs
@@ -8,6 +8,10 @@ pub(crate) mod label;
 mod labeled_counter;
 mod labeled_gauge;
 mod labeled_histogram;
+mod max_gauge;
+mod max_gauge_f64;
+mod min_gauge;
+mod min_gauge_f64;
 
 pub use counter::Counter;
 pub use distribution::Distribution;
@@ -25,3 +29,7 @@ pub use label::LabelEnum;
 pub use labeled_counter::LabeledCounter;
 pub use labeled_gauge::LabeledGauge;
 pub use labeled_histogram::LabeledHistogram;
+pub use max_gauge::MaxGauge;
+pub use max_gauge_f64::MaxGaugeF64;
+pub use min_gauge::MinGauge;
+pub use min_gauge_f64::MinGaugeF64;

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 | Example        | Crates used                             | What it shows                                                                                         |
 |----------------|-----------------------------------------|-------------------------------------------------------------------------------------------------------|
-| [`demo`](demo) | fast-telemetry, fast-telemetry-macros, fast-telemetry-export | Full pipeline: define metrics with derive macros, record, export via Prometheus/DogStatsD/OTLP, spans |
+| [`demo`](demo) | fast-telemetry, fast-telemetry-macros, fast-telemetry-export | Full pipeline: define metrics with derive macros, record counters/gauges/extrema, export via Prometheus/DogStatsD/OTLP, spans |
 
 Run with:
 

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use fast_telemetry::{
     Counter, DeriveLabel, Distribution, DynamicCounter, ExportMetrics, Gauge, Histogram, LabelEnum,
-    LabeledCounter, LabeledHistogram, SpanCollector, SpanKind, SpanStatus,
+    LabeledCounter, LabeledHistogram, MaxGauge, MinGauge, SpanCollector, SpanKind, SpanStatus,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -65,6 +65,12 @@ pub struct AppMetrics {
     #[help = "Current in-flight requests"]
     pub in_flight: Gauge,
 
+    #[help = "Peak in-flight requests seen during the current run"]
+    pub in_flight_peak: MaxGauge,
+
+    #[help = "Smallest response size seen during the current run"]
+    pub min_response_bytes: MinGauge,
+
     #[help = "Requests by endpoint (runtime labels)"]
     pub requests_by_endpoint: DynamicCounter,
 }
@@ -89,6 +95,8 @@ impl AppMetrics {
             latency_by_method: LabeledHistogram::with_latency_buckets(shards),
             response_bytes: Distribution::new(shards),
             in_flight: Gauge::new(),
+            in_flight_peak: MaxGauge::new(shards),
+            min_response_bytes: MinGauge::with_value(shards, i64::MAX),
             requests_by_endpoint: DynamicCounter::new(shards),
         }
     }
@@ -107,6 +115,8 @@ fn simulate_requests(metrics: &AppMetrics) {
     metrics.latency_by_method.record(HttpMethod::Get, 150);
     metrics.response_bytes.record(4096);
     metrics.in_flight.set(3);
+    metrics.in_flight_peak.observe(3);
+    metrics.min_response_bytes.observe(4096);
 
     // Dynamic labels -- runtime endpoint tracking
     metrics
@@ -131,12 +141,15 @@ fn simulate_requests(metrics: &AppMetrics) {
     metrics.latency.record(2500); // 2.5ms
     metrics.latency_by_method.record(HttpMethod::Post, 2500);
     metrics.response_bytes.record(128);
+    metrics.in_flight_peak.observe(8);
+    metrics.min_response_bytes.observe(128);
 
     // Simulate a failed request
     metrics.requests.inc();
     metrics.requests_by_method.inc(HttpMethod::Get);
     metrics.requests_by_status.inc(StatusClass::ServerError5xx);
     metrics.latency.record(50_000); // 50ms timeout
+    metrics.in_flight_peak.observe(11);
 }
 
 fn simulate_spans(collector: Arc<SpanCollector>) {


### PR DESCRIPTION
Add sharded max/min gauge types for i64 and f64 observations.

Wire the new metrics through Prometheus, DogStatsD, OTLP, and ExportMetrics so they behave like first-class gauge fields.

Update the README and demo example to show peak/trough recording and interval-style swap_reset() usage.