### PR TITLE
fix: avoid single-entry TLS cache misses for dynamic metrics

### DIFF
--- a/crates/fast-telemetry/benches/fast_vs_otel.rs
+++ b/crates/fast-telemetry/benches/fast_vs_otel.rs
@@ -394,6 +394,55 @@ fn bench_record_dynamic_counter(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_record_dynamic_counter_cache_pattern(c: &mut Criterion) {
+    let mut group = c.benchmark_group("record/dynamic_counter_cache_pattern");
+
+    for cardinality in [1usize, 4, 8, 16, 64] {
+        let counter = DynamicCounter::new(8);
+        let label_strs: Vec<String> = (0..cardinality).map(|i| format!("ep{i}")).collect();
+        for label in &label_strs {
+            counter.inc(&[("endpoint", label.as_str())]);
+        }
+
+        group.bench_with_input(
+            BenchmarkId::new("rotating_hot_set", cardinality),
+            &cardinality,
+            |b, &n| {
+                let mut i = 0usize;
+                b.iter(|| {
+                    let label = label_strs[i % n].as_str();
+                    counter.inc(black_box(&[("endpoint", label)]));
+                    i = i.wrapping_add(1);
+                });
+            },
+        );
+    }
+
+    let counter = DynamicCounter::new(8);
+    counter.inc(&[("endpoint", "ep0")]);
+    group.bench_function("same_label", |b| {
+        b.iter(|| {
+            counter.inc(black_box(&[("endpoint", "ep0")]));
+        });
+    });
+
+    let counter = DynamicCounter::with_max_series(8, 32);
+    let churn_labels: Vec<String> = (0..256).map(|i| format!("ep{i}")).collect();
+    for label in &churn_labels[..32] {
+        counter.inc(&[("endpoint", label.as_str())]);
+    }
+    group.bench_function("overflow_churn", |b| {
+        let mut i = 0usize;
+        b.iter(|| {
+            let label = churn_labels[i % churn_labels.len()].as_str();
+            counter.inc(black_box(&[("endpoint", label)]));
+            i = i.wrapping_add(1);
+        });
+    });
+
+    group.finish();
+}
+
 fn bench_record_dynamic_distribution(c: &mut Criterion) {
     let mut group = c.benchmark_group("record/dynamic_distribution");
 
@@ -1304,6 +1353,7 @@ criterion_group!(
     bench_record_labeled_counter,
     bench_record_labeled_histogram,
     bench_record_dynamic_counter,
+    bench_record_dynamic_counter_cache_pattern,
     bench_record_dynamic_distribution,
     bench_record_dynamic_counter_first_touch,
 );

--- a/crates/fast-telemetry/src/metric/dynamic/cache.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/cache.rs
@@ -1,0 +1,220 @@
+//! Shared thread-local label-cache machinery for dynamic metrics.
+//!
+//! This module owns the small fixed-size cache used by the dynamic metric
+//! types to avoid repeated label canonicalization and index lookups on hot
+//! paths. The cache is intentionally narrow in scope:
+//!
+//! - it caches only exact ordered input label sequences
+//! - it stores weak references so cached entries do not keep series alive
+//! - it validates the upgraded series on read so eviction tombstones are
+//!   respected
+//!
+//! The metric-specific code still owns slow-path lookup, overflow handling,
+//! series construction, and update semantics.
+
+use std::sync::Arc;
+
+/// Number of per-thread cache slots used by dynamic metrics.
+///
+/// This must remain a power of two because slot selection is mask-based.
+pub(crate) const SERIES_CACHE_SIZE: usize = 16;
+
+/// Payload contract for entries stored in [`LabelCache`].
+///
+/// A cache entry may hold just a `Weak<Series>` or a richer metric-specific
+/// payload. On lookup, the cache upgrades the entry into a strong value and
+/// then asks the payload whether the upgraded value is still valid.
+pub(crate) trait CacheValue {
+    /// Strong value returned to the caller on a cache hit.
+    type Strong;
+
+    /// Upgrade the cached payload into a strong value, if it is still live.
+    fn upgrade(&self) -> Option<Self::Strong>;
+
+    /// Check whether the upgraded value is still valid for hot-path use.
+    fn is_valid(strong: &Self::Strong) -> bool;
+}
+
+/// Exact-match cache entry for one metric id plus one ordered label sequence.
+pub(crate) struct LabelCacheEntry<T> {
+    metric_id: usize,
+    fingerprint: u64,
+    ordered_labels: Vec<(String, String)>,
+    value: T,
+}
+
+impl<T> LabelCacheEntry<T> {
+    fn matches_ordered(&self, metric_id: usize, labels: &[(&str, &str)]) -> bool {
+        if self.metric_id != metric_id || self.ordered_labels.len() != labels.len() {
+            return false;
+        }
+
+        labels.iter().enumerate().all(|(idx, (k, v))| {
+            let (ek, ev) = &self.ordered_labels[idx];
+            ek == k && ev == v
+        })
+    }
+
+    fn matches(&self, metric_id: usize, fingerprint: u64, labels: &[(&str, &str)]) -> bool {
+        if self.metric_id != metric_id
+            || self.fingerprint != fingerprint
+            || self.ordered_labels.len() != labels.len()
+        {
+            return false;
+        }
+
+        labels.iter().enumerate().all(|(idx, (k, v))| {
+            let (ek, ev) = &self.ordered_labels[idx];
+            ek == k && ev == v
+        })
+    }
+}
+
+/// Small fixed-size direct-mapped cache for dynamic metric label lookups.
+///
+/// The cache keeps a single "last hit" fast path and then falls back to a
+/// direct-mapped probe keyed by a lightweight fingerprint of the ordered input
+/// labels. This preserves the previous best case for repeated identical calls
+/// while substantially improving workloads that rotate across a small hot set.
+pub(crate) struct LabelCache<T, const N: usize> {
+    last: Option<usize>,
+    entries: [Option<LabelCacheEntry<T>>; N],
+}
+
+impl<T, const N: usize> LabelCache<T, N>
+where
+    T: CacheValue,
+{
+    /// Create an empty cache.
+    pub(crate) fn new() -> Self {
+        debug_assert!(N.is_power_of_two());
+        Self {
+            last: None,
+            entries: std::array::from_fn(|_| None),
+        }
+    }
+
+    /// Look up a cached payload for `metric_id` and the exact ordered `labels`.
+    pub(crate) fn get(
+        &mut self,
+        metric_id: usize,
+        labels: &[(&str, &str)],
+    ) -> Option<<T as CacheValue>::Strong> {
+        if let Some(index) = self.last {
+            if let Some(value) = self.get_at(index, metric_id, labels) {
+                return Some(value);
+            }
+        }
+
+        let fingerprint = label_fingerprint(labels);
+        let index = cache_index::<N>(fingerprint);
+        let value = self.get_at_with_fingerprint(index, metric_id, fingerprint, labels)?;
+        self.last = Some(index);
+        Some(value)
+    }
+
+    /// Replace the cached entry for the slot selected by `labels`.
+    pub(crate) fn insert(&mut self, metric_id: usize, labels: &[(&str, &str)], value: T) {
+        let fingerprint = label_fingerprint(labels);
+        let index = cache_index::<N>(fingerprint);
+        let ordered_labels = labels
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        self.entries[index] = Some(LabelCacheEntry {
+            metric_id,
+            fingerprint,
+            ordered_labels,
+            value,
+        });
+        self.last = Some(index);
+    }
+
+    fn get_at(
+        &self,
+        index: usize,
+        metric_id: usize,
+        labels: &[(&str, &str)],
+    ) -> Option<<T as CacheValue>::Strong> {
+        let entry = self.entries[index].as_ref()?;
+        if !entry.matches_ordered(metric_id, labels) {
+            return None;
+        }
+        let strong = entry.value.upgrade()?;
+        if !T::is_valid(&strong) {
+            return None;
+        }
+        Some(strong)
+    }
+
+    fn get_at_with_fingerprint(
+        &self,
+        index: usize,
+        metric_id: usize,
+        fingerprint: u64,
+        labels: &[(&str, &str)],
+    ) -> Option<<T as CacheValue>::Strong> {
+        let entry = self.entries[index].as_ref()?;
+        if !entry.matches(metric_id, fingerprint, labels) {
+            return None;
+        }
+        let strong = entry.value.upgrade()?;
+        if !T::is_valid(&strong) {
+            return None;
+        }
+        Some(strong)
+    }
+}
+
+fn cache_index<const N: usize>(fingerprint: u64) -> usize {
+    debug_assert!(N.is_power_of_two());
+    (fingerprint as usize) & (N - 1)
+}
+
+/// Fingerprint an ordered borrowed label slice for direct-mapped slot lookup.
+///
+/// This is deliberately cheaper than full canonicalization and is only used to
+/// select a cache slot. Exact key/value matching still happens before a hit is
+/// accepted.
+pub(crate) fn label_fingerprint(labels: &[(&str, &str)]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = FNV_OFFSET;
+    for (k, v) in labels {
+        for byte in k.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        hash ^= 0xff;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        for byte in v.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        hash ^= 0xfe;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+impl<T> CacheValue for std::sync::Weak<T>
+where
+    T: CacheableSeries,
+{
+    type Strong = Arc<T>;
+
+    fn upgrade(&self) -> Option<Self::Strong> {
+        self.upgrade()
+    }
+
+    fn is_valid(strong: &Self::Strong) -> bool {
+        !strong.is_evicted()
+    }
+}
+
+/// Shared validity hook for series types that expose an eviction tombstone.
+pub(crate) trait CacheableSeries {
+    /// Return `true` once the series has been evicted from its metric index.
+    fn is_evicted(&self) -> bool;
+}

--- a/crates/fast-telemetry/src/metric/dynamic/counter.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/counter.rs
@@ -1,5 +1,6 @@
 //! Runtime-labeled counter for dynamic dimensions.
 
+use super::cache::{CacheableSeries, LabelCache, SERIES_CACHE_SIZE};
 #[cfg(feature = "eviction")]
 use super::current_cycle;
 use super::{COUNTER_IDS, DynamicLabelSet, thread_id};
@@ -85,6 +86,12 @@ impl CounterSeries {
     }
 }
 
+impl CacheableSeries for CounterSeries {
+    fn is_evicted(&self) -> bool {
+        self.is_evicted()
+    }
+}
+
 /// A reusable handle to a dynamic-label counter series.
 ///
 /// Use this for hot paths to avoid per-update label canonicalization and map
@@ -127,14 +134,9 @@ impl DynamicCounterSeries {
     }
 }
 
-struct SeriesCacheEntry {
-    counter_id: usize,
-    ordered_labels: Vec<(String, String)>,
-    series: Weak<CounterSeries>,
-}
-
 thread_local! {
-    static SERIES_CACHE: RefCell<Option<SeriesCacheEntry>> = const { RefCell::new(None) };
+    static SERIES_CACHE: RefCell<LabelCache<Weak<CounterSeries>, SERIES_CACHE_SIZE>> =
+        RefCell::new(LabelCache::new());
 }
 
 /// Counter keyed by runtime label sets.
@@ -377,24 +379,7 @@ impl DynamicCounter {
 
     fn cached_series(&self, labels: &[(&str, &str)]) -> Option<Arc<CounterSeries>> {
         SERIES_CACHE.with(|cache| {
-            let cache_ref = cache.borrow();
-            let entry = cache_ref.as_ref()?;
-            if entry.counter_id != self.id {
-                return None;
-            }
-            if entry.ordered_labels.len() != labels.len() {
-                return None;
-            }
-            for (idx, (k, v)) in labels.iter().enumerate() {
-                let (ek, ev) = &entry.ordered_labels[idx];
-                if ek != k || ev != v {
-                    return None;
-                }
-            }
-            let series = entry.series.upgrade()?;
-            if series.is_evicted() {
-                return None;
-            }
+            let series = cache.borrow_mut().get(self.id, labels)?;
             #[cfg(feature = "eviction")]
             series.touch(current_cycle());
             Some(series)
@@ -403,15 +388,9 @@ impl DynamicCounter {
 
     fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<CounterSeries>) {
         SERIES_CACHE.with(|cache| {
-            let ordered_labels = labels
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-                .collect();
-            *cache.borrow_mut() = Some(SeriesCacheEntry {
-                counter_id: self.id,
-                ordered_labels,
-                series: Arc::downgrade(series),
-            });
+            cache
+                .borrow_mut()
+                .insert(self.id, labels, Arc::downgrade(series));
         });
     }
 }

--- a/crates/fast-telemetry/src/metric/dynamic/distribution.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/distribution.rs
@@ -4,6 +4,7 @@
 //! `Distribution` implementation.  Each label set × thread gets its own
 //! fixed-size bucket array.
 
+use super::cache::{CacheValue, LabelCache, SERIES_CACHE_SIZE};
 #[cfg(feature = "eviction")]
 use super::current_cycle;
 use super::{DISTRIBUTION_IDS, DynamicLabelSet};
@@ -114,6 +115,23 @@ impl DistributionSeries {
     }
 }
 
+struct DistributionCacheValue {
+    series: Weak<DistributionSeries>,
+    buf: Arc<ExpBuckets>,
+}
+
+impl CacheValue for DistributionCacheValue {
+    type Strong = (Arc<DistributionSeries>, Arc<ExpBuckets>);
+
+    fn upgrade(&self) -> Option<Self::Strong> {
+        Some((self.series.upgrade()?, Arc::clone(&self.buf)))
+    }
+
+    fn is_valid(strong: &Self::Strong) -> bool {
+        !strong.0.is_evicted()
+    }
+}
+
 /// A reusable handle to a dynamic-label distribution series.
 ///
 /// Use this for hot paths to avoid per-update label canonicalization and map
@@ -149,15 +167,9 @@ impl DynamicDistributionSeries {
     }
 }
 
-struct SeriesCacheEntry {
-    distribution_id: usize,
-    ordered_labels: Vec<(String, String)>,
-    series: Weak<DistributionSeries>,
-    buf: Arc<ExpBuckets>,
-}
-
 thread_local! {
-    static SERIES_CACHE: RefCell<Option<SeriesCacheEntry>> = const { RefCell::new(None) };
+    static SERIES_CACHE: RefCell<LabelCache<DistributionCacheValue, SERIES_CACHE_SIZE>> =
+        RefCell::new(LabelCache::new());
     static SERIES_BUF_CACHE: RefCell<Vec<(usize, usize, Weak<ExpBuckets>)>> = const { RefCell::new(Vec::new()) };
 }
 
@@ -390,28 +402,10 @@ impl DynamicDistribution {
         labels: &[(&str, &str)],
     ) -> Option<(Arc<DistributionSeries>, Arc<ExpBuckets>)> {
         SERIES_CACHE.with(|cache| {
-            let cache_ref = cache.borrow();
-            let entry = cache_ref.as_ref()?;
-            if entry.distribution_id != self.id {
-                return None;
-            }
-            if entry.ordered_labels.len() != labels.len() {
-                return None;
-            }
-            for (idx, (k, v)) in labels.iter().enumerate() {
-                let (ek, ev) = &entry.ordered_labels[idx];
-                if ek != k || ev != v {
-                    return None;
-                }
-            }
-            let series = entry.series.upgrade()?;
-            // Check tombstone - forces re-lookup if series was evicted
-            if series.is_evicted() {
-                return None;
-            }
+            let (series, buf) = cache.borrow_mut().get(self.id, labels)?;
             #[cfg(feature = "eviction")]
             series.touch(current_cycle());
-            Some((series, Arc::clone(&entry.buf)))
+            Some((series, buf))
         })
     }
 
@@ -422,16 +416,14 @@ impl DynamicDistribution {
         buf: Arc<ExpBuckets>,
     ) {
         SERIES_CACHE.with(|cache| {
-            let ordered_labels = labels
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-                .collect();
-            *cache.borrow_mut() = Some(SeriesCacheEntry {
-                distribution_id: self.id,
-                ordered_labels,
-                series: Arc::downgrade(series),
-                buf,
-            });
+            cache.borrow_mut().insert(
+                self.id,
+                labels,
+                DistributionCacheValue {
+                    series: Arc::downgrade(series),
+                    buf,
+                },
+            );
         });
     }
 

--- a/crates/fast-telemetry/src/metric/dynamic/gauge.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/gauge.rs
@@ -1,5 +1,6 @@
 //! Runtime-labeled gauge for dynamic dimensions.
 
+use super::cache::{CacheableSeries, LabelCache, SERIES_CACHE_SIZE};
 #[cfg(feature = "eviction")]
 use super::current_cycle;
 use super::{DynamicLabelSet, GAUGE_IDS};
@@ -76,6 +77,12 @@ impl GaugeSeries {
     }
 }
 
+impl CacheableSeries for GaugeSeries {
+    fn is_evicted(&self) -> bool {
+        self.is_evicted()
+    }
+}
+
 /// A reusable handle to a dynamic-label gauge series.
 ///
 /// Use this for hot paths to avoid per-update label canonicalization and map
@@ -106,14 +113,9 @@ impl DynamicGaugeSeries {
     }
 }
 
-struct SeriesCacheEntry {
-    gauge_id: usize,
-    ordered_labels: Vec<(String, String)>,
-    series: Weak<GaugeSeries>,
-}
-
 thread_local! {
-    static SERIES_CACHE: RefCell<Option<SeriesCacheEntry>> = const { RefCell::new(None) };
+    static SERIES_CACHE: RefCell<LabelCache<Weak<GaugeSeries>, SERIES_CACHE_SIZE>> =
+        RefCell::new(LabelCache::new());
 }
 
 /// Gauge keyed by runtime label sets.
@@ -329,24 +331,7 @@ impl DynamicGauge {
 
     fn cached_series(&self, labels: &[(&str, &str)]) -> Option<Arc<GaugeSeries>> {
         SERIES_CACHE.with(|cache| {
-            let cache_ref = cache.borrow();
-            let entry = cache_ref.as_ref()?;
-            if entry.gauge_id != self.id {
-                return None;
-            }
-            if entry.ordered_labels.len() != labels.len() {
-                return None;
-            }
-            for (idx, (k, v)) in labels.iter().enumerate() {
-                let (ek, ev) = &entry.ordered_labels[idx];
-                if ek != k || ev != v {
-                    return None;
-                }
-            }
-            let series = entry.series.upgrade()?;
-            if series.is_evicted() {
-                return None;
-            }
+            let series = cache.borrow_mut().get(self.id, labels)?;
             #[cfg(feature = "eviction")]
             series.touch(current_cycle());
             Some(series)
@@ -355,15 +340,9 @@ impl DynamicGauge {
 
     fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<GaugeSeries>) {
         SERIES_CACHE.with(|cache| {
-            let ordered_labels = labels
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-                .collect();
-            *cache.borrow_mut() = Some(SeriesCacheEntry {
-                gauge_id: self.id,
-                ordered_labels,
-                series: Arc::downgrade(series),
-            });
+            cache
+                .borrow_mut()
+                .insert(self.id, labels, Arc::downgrade(series));
         });
     }
 }

--- a/crates/fast-telemetry/src/metric/dynamic/gauge_i64.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/gauge_i64.rs
@@ -4,6 +4,7 @@
 //! that need atomic add/sub semantics but should export as absolute gauge values
 //! (not counter deltas).
 
+use super::cache::{CacheableSeries, LabelCache, SERIES_CACHE_SIZE};
 #[cfg(feature = "eviction")]
 use super::current_cycle;
 use super::{DynamicLabelSet, thread_id};
@@ -102,6 +103,12 @@ impl GaugeI64Series {
     }
 }
 
+impl CacheableSeries for GaugeI64Series {
+    fn is_evicted(&self) -> bool {
+        self.is_evicted()
+    }
+}
+
 /// A reusable handle to a dynamic-label i64 gauge series.
 ///
 /// Use this for hot paths to avoid per-update label canonicalization and map
@@ -153,14 +160,9 @@ impl DynamicGaugeI64Series {
     }
 }
 
-struct SeriesCacheEntry {
-    gauge_id: usize,
-    ordered_labels: Vec<(String, String)>,
-    series: Weak<GaugeI64Series>,
-}
-
 thread_local! {
-    static SERIES_CACHE: RefCell<Option<SeriesCacheEntry>> = const { RefCell::new(None) };
+    static SERIES_CACHE: RefCell<LabelCache<Weak<GaugeI64Series>, SERIES_CACHE_SIZE>> =
+        RefCell::new(LabelCache::new());
 }
 
 /// Signed integer gauge keyed by runtime label sets.
@@ -419,24 +421,7 @@ impl DynamicGaugeI64 {
 
     fn cached_series(&self, labels: &[(&str, &str)]) -> Option<Arc<GaugeI64Series>> {
         SERIES_CACHE.with(|cache| {
-            let cache_ref = cache.borrow();
-            let entry = cache_ref.as_ref()?;
-            if entry.gauge_id != self.id {
-                return None;
-            }
-            if entry.ordered_labels.len() != labels.len() {
-                return None;
-            }
-            for (idx, (k, v)) in labels.iter().enumerate() {
-                let (ek, ev) = &entry.ordered_labels[idx];
-                if ek != k || ev != v {
-                    return None;
-                }
-            }
-            let series = entry.series.upgrade()?;
-            if series.is_evicted() {
-                return None;
-            }
+            let series = cache.borrow_mut().get(self.id, labels)?;
             #[cfg(feature = "eviction")]
             series.touch(current_cycle());
             Some(series)
@@ -445,15 +430,9 @@ impl DynamicGaugeI64 {
 
     fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<GaugeI64Series>) {
         SERIES_CACHE.with(|cache| {
-            let ordered_labels = labels
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-                .collect();
-            *cache.borrow_mut() = Some(SeriesCacheEntry {
-                gauge_id: self.id,
-                ordered_labels,
-                series: Arc::downgrade(series),
-            });
+            cache
+                .borrow_mut()
+                .insert(self.id, labels, Arc::downgrade(series));
         });
     }
 }

--- a/crates/fast-telemetry/src/metric/dynamic/histogram.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/histogram.rs
@@ -1,5 +1,6 @@
 //! Runtime-labeled histogram for dynamic dimensions.
 
+use super::cache::{CacheableSeries, LabelCache, SERIES_CACHE_SIZE};
 #[cfg(feature = "eviction")]
 use super::current_cycle;
 use super::{DynamicLabelSet, HISTOGRAM_IDS, thread_id};
@@ -155,6 +156,12 @@ impl HistogramSeries {
     }
 }
 
+impl CacheableSeries for HistogramSeries {
+    fn is_evicted(&self) -> bool {
+        self.is_evicted()
+    }
+}
+
 /// A reusable handle to a dynamic-label histogram series.
 ///
 /// Use this for hot paths to avoid per-update label canonicalization and map
@@ -220,14 +227,9 @@ impl DynamicHistogramSeries {
     }
 }
 
-struct SeriesCacheEntry {
-    histogram_id: usize,
-    ordered_labels: Vec<(String, String)>,
-    series: Weak<HistogramSeries>,
-}
-
 thread_local! {
-    static SERIES_CACHE: RefCell<Option<SeriesCacheEntry>> = const { RefCell::new(None) };
+    static SERIES_CACHE: RefCell<LabelCache<Weak<HistogramSeries>, SERIES_CACHE_SIZE>> =
+        RefCell::new(LabelCache::new());
 }
 
 /// Histogram keyed by runtime label sets.
@@ -517,24 +519,7 @@ impl DynamicHistogram {
 
     fn cached_series(&self, labels: &[(&str, &str)]) -> Option<Arc<HistogramSeries>> {
         SERIES_CACHE.with(|cache| {
-            let cache_ref = cache.borrow();
-            let entry = cache_ref.as_ref()?;
-            if entry.histogram_id != self.id {
-                return None;
-            }
-            if entry.ordered_labels.len() != labels.len() {
-                return None;
-            }
-            for (idx, (k, v)) in labels.iter().enumerate() {
-                let (ek, ev) = &entry.ordered_labels[idx];
-                if ek != k || ev != v {
-                    return None;
-                }
-            }
-            let series = entry.series.upgrade()?;
-            if series.is_evicted() {
-                return None;
-            }
+            let series = cache.borrow_mut().get(self.id, labels)?;
             #[cfg(feature = "eviction")]
             series.touch(current_cycle());
             Some(series)
@@ -543,15 +528,9 @@ impl DynamicHistogram {
 
     fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<HistogramSeries>) {
         SERIES_CACHE.with(|cache| {
-            let ordered_labels = labels
-                .iter()
-                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-                .collect();
-            *cache.borrow_mut() = Some(SeriesCacheEntry {
-                histogram_id: self.id,
-                ordered_labels,
-                series: Arc::downgrade(series),
-            });
+            cache
+                .borrow_mut()
+                .insert(self.id, labels, Arc::downgrade(series));
         });
     }
 }

--- a/crates/fast-telemetry/src/metric/dynamic/mod.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/mod.rs
@@ -10,6 +10,7 @@
 //! - Series handles for zero-lookup repeated access
 //! - Access-timestamp eviction for bounded cardinality
 
+mod cache;
 mod counter;
 mod distribution;
 mod gauge;


### PR DESCRIPTION
Dynamic runtime-labeled metrics were using a one-entry per-thread cache, so rotating across a small hot set of label combinations missed the fast path almost every call.

Replace the per-metric one-off cache code with a shared bounded TLS label cache helper, keep distribution's per-thread buffer handling intact, and add a focused dynamic counter cache-pattern benchmark to profile the issue before and after the change.

  Observed results on new benchmark:
    - rotating_hot_set/4: ~138 ns -> ~25 ns
    - rotating_hot_set/8: ~137 ns -> ~25 ns
    - rotating_hot_set/16: ~135 ns -> ~54 ns
    - same_label stayed ~15 ns
    - overflow_churn stayed ~209 ns

Fixes #2