### PR TITLE
feat: Add sampled timer metrics and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ fast-telemetry = "0.1"
 ### Define Metrics
 
 ```rust
-use fast_telemetry::{Counter, ExportMetrics, Gauge, Histogram, MaxGauge};
+use fast_telemetry::{Counter, ExportMetrics, Gauge, Histogram, MaxGauge, SampledTimer};
 
 #[derive(ExportMetrics)]
 #[metric_prefix = "myapp"]
@@ -113,6 +113,9 @@ pub struct AppMetrics {
 
     #[help = "Request latency in microseconds"]
     pub latency: Histogram,
+
+    #[help = "Hot path latency"]
+    pub hot_path_latency: SampledTimer,
 
     #[help = "Current queue depth"]
     pub queue_depth: Gauge,
@@ -126,6 +129,7 @@ impl AppMetrics {
         Self {
             requests: Counter::new(4),     // use available_parallelism() in production
             latency: Histogram::with_latency_buckets(4),
+            hot_path_latency: SampledTimer::with_latency_buckets(4, 64),
             queue_depth: Gauge::new(),
             queue_depth_peak: MaxGauge::new(4),
         }
@@ -138,9 +142,65 @@ impl AppMetrics {
 ```rust
 metrics.requests.inc();
 metrics.latency.record(elapsed_us);
+metrics.hot_path_latency.record_elapsed(std::time::Duration::from_nanos(125_000));
 metrics.queue_depth.set(queue.len() as i64);
 metrics.queue_depth_peak.observe(queue.len() as i64);
 ```
+
+### Sampled Timers
+
+`SampledTimer` is for measuring elapsed time around an operation. You can start
+timing with an RAII guard and let it record on drop, or record a pre-measured
+`Duration` directly.
+
+It is designed for hot paths where you want timing instrumentation to stay
+cheap. Every use increments a total call counter, while elapsed-time
+measurements are sampled at the configured stride before being recorded into the
+latency histogram.
+
+```rust
+use std::time::Duration;
+use fast_telemetry::{DeriveLabel, LabeledSampledTimer, SampledTimer};
+
+let timer = SampledTimer::with_latency_buckets(4, 64);
+
+// Record a duration you already measured elsewhere.
+timer.record_elapsed(Duration::from_nanos(180_000));
+
+{
+    // Time this scope with an RAII guard.
+    let _guard = timer.start();
+    // timed work
+}
+
+#[derive(Copy, Clone, Debug, DeriveLabel)]
+#[label_name = "phase"]
+enum Phase {
+    Parse,
+    Execute,
+}
+
+let labeled = LabeledSampledTimer::<Phase>::with_latency_buckets(4, 32);
+
+{
+    // Time a labeled scope with the same guard pattern.
+    let _guard = labeled.start(Phase::Parse);
+    // timed parse work
+}
+
+// Or record a pre-measured labeled duration directly.
+labeled.record_elapsed(Phase::Parse, Duration::from_nanos(90_000));
+```
+
+Sampled timers record durations in **nanoseconds**. They export as a composite
+metric:
+
+- Prometheus: `name_calls` and `name_samples`
+- DogStatsD / OTLP: `name.calls` and `name.samples`
+
+`name_calls` / `name.calls` is the total operation count. `name_samples` is the
+sampled latency histogram. The timer/guard API is the instrumentation surface;
+sampling is how it keeps that instrumentation cheap enough for hot code.
 
 ### Export
 

--- a/crates/fast-telemetry-macros/src/lib.rs
+++ b/crates/fast-telemetry-macros/src/lib.rs
@@ -24,6 +24,7 @@ enum MetricKind {
     Gauge,
     GaugeF64,
     Histogram,
+    SampledTimer,
     MaxGauge,
     MaxGaugeF64,
     MinGauge,
@@ -31,6 +32,7 @@ enum MetricKind {
     LabeledCounter(Type),
     LabeledGauge,
     LabeledHistogram(Type),
+    LabeledSampledTimer(Type),
 }
 
 // Output reserve heuristics for derive-generated exporters.
@@ -39,6 +41,7 @@ const PROM_COMPLEX_METRIC_OVERHEAD_BYTES: usize = 128;
 const DOGSTATSD_SIMPLE_LINE_OVERHEAD_BYTES: usize = 24;
 const DOGSTATSD_HISTOGRAM_LINE_OVERHEAD_BYTES: usize = 30;
 const DOGSTATSD_HISTOGRAM_LINES: usize = 2;
+const DOGSTATSD_SAMPLED_TIMER_LINES: usize = 3;
 const DOGSTATSD_TAG_PREFIX_BYTES: usize = 2; // "|#"
 const DOGSTATSD_TAG_PAIR_OVERHEAD_BYTES: usize = 2; // ":" plus separator/comma budget
 const DYNAMIC_LABELS_PER_SERIES_ESTIMATE: usize = 10;
@@ -64,6 +67,7 @@ fn metric_kind(ty: &Type) -> Option<MetricKind> {
         "Gauge" => Some(MetricKind::Gauge),
         "GaugeF64" => Some(MetricKind::GaugeF64),
         "Histogram" => Some(MetricKind::Histogram),
+        "SampledTimer" => Some(MetricKind::SampledTimer),
         "MaxGauge" => Some(MetricKind::MaxGauge),
         "MaxGaugeF64" => Some(MetricKind::MaxGaugeF64),
         "MinGauge" => Some(MetricKind::MinGauge),
@@ -98,6 +102,16 @@ fn metric_kind(ty: &Type) -> Option<MetricKind> {
             };
             Some(MetricKind::LabeledHistogram(label_ty.clone()))
         }
+        "LabeledSampledTimer" => {
+            let PathArguments::AngleBracketed(args) = &segment.arguments else {
+                return None;
+            };
+            let arg = args.args.first()?;
+            let GenericArgument::Type(label_ty) = arg else {
+                return None;
+            };
+            Some(MetricKind::LabeledSampledTimer(label_ty.clone()))
+        }
         _ => None,
     }
 }
@@ -112,10 +126,10 @@ fn metric_kind(ty: &Type) -> Option<MetricKind> {
 /// - `export_otlp(...)` — OTLP protobuf (only when `#[otlp]` attribute is present)
 ///
 /// Supports unlabeled metrics (`Counter`, `Gauge`, `GaugeF64`, `Histogram`,
-/// `Distribution`), compile-time labeled metrics (`LabeledCounter<L>`,
-/// `LabeledGauge<L>`, `LabeledHistogram<L>`), and runtime-labeled metrics
-/// (`DynamicCounter`, `DynamicGauge`, `DynamicGaugeI64`, `DynamicHistogram`,
-/// `DynamicDistribution`).
+/// `Distribution`, `SampledTimer`), compile-time labeled metrics
+/// (`LabeledCounter<L>`, `LabeledGauge<L>`, `LabeledHistogram<L>`,
+/// `LabeledSampledTimer<L>`), and runtime-labeled metrics (`DynamicCounter`,
+/// `DynamicGauge`, `DynamicGaugeI64`, `DynamicHistogram`, `DynamicDistribution`).
 ///
 /// # Example
 ///
@@ -266,9 +280,11 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 prom_reserve_hint += PROM_BASE_FIELD_OVERHEAD_BYTES;
             }
             MetricKind::Histogram
+            | MetricKind::SampledTimer
             | MetricKind::DynamicHistogram
             | MetricKind::DynamicDistribution
-            | MetricKind::LabeledHistogram(_) => {
+            | MetricKind::LabeledHistogram(_)
+            | MetricKind::LabeledSampledTimer(_) => {
                 prom_reserve_hint += PROM_COMPLEX_METRIC_OVERHEAD_BYTES;
             }
         }
@@ -297,6 +313,16 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     * DOGSTATSD_HISTOGRAM_LINES;
                 dogstatsd_tag_line_hint += DOGSTATSD_HISTOGRAM_LINES;
                 dogstatsd_delta_tag_line_hint += DOGSTATSD_HISTOGRAM_LINES;
+            }
+            MetricKind::SampledTimer => {
+                dogstatsd_reserve_hint += (statsd_metric_name.len()
+                    + DOGSTATSD_HISTOGRAM_LINE_OVERHEAD_BYTES)
+                    * DOGSTATSD_SAMPLED_TIMER_LINES;
+                dogstatsd_delta_reserve_hint += (statsd_metric_name.len()
+                    + DOGSTATSD_HISTOGRAM_LINE_OVERHEAD_BYTES)
+                    * DOGSTATSD_SAMPLED_TIMER_LINES;
+                dogstatsd_tag_line_hint += DOGSTATSD_SAMPLED_TIMER_LINES;
+                dogstatsd_delta_tag_line_hint += DOGSTATSD_SAMPLED_TIMER_LINES;
             }
             MetricKind::Distribution => {
                 dogstatsd_reserve_hint +=
@@ -336,6 +362,14 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 dogstatsd_delta_reserve_hint += (statsd_metric_name.len()
                     + DOGSTATSD_HISTOGRAM_LINE_OVERHEAD_BYTES)
                     * DOGSTATSD_HISTOGRAM_LINES;
+            }
+            MetricKind::LabeledSampledTimer(_) => {
+                dogstatsd_reserve_hint += (statsd_metric_name.len()
+                    + DOGSTATSD_HISTOGRAM_LINE_OVERHEAD_BYTES)
+                    * DOGSTATSD_SAMPLED_TIMER_LINES;
+                dogstatsd_delta_reserve_hint += (statsd_metric_name.len()
+                    + DOGSTATSD_HISTOGRAM_LINE_OVERHEAD_BYTES)
+                    * DOGSTATSD_SAMPLED_TIMER_LINES;
             }
         }
 
@@ -681,6 +715,47 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     fast_telemetry::__macro_support::__write_dogstatsd(output, #sum_metric_name, delta_sum, "c", tags);
                 });
             }
+            MetricKind::SampledTimer => {
+                let calls_state_field = format_ident!("{}_calls", field_name);
+                let count_state_field = format_ident!("{}_sample_count", field_name);
+                let sum_state_field = format_ident!("{}_sample_sum", field_name);
+                let calls_metric_name = format!("{}.calls", statsd_metric_name);
+                let count_metric_name = format!("{}.samples.count", statsd_metric_name);
+                let sum_metric_name = format!("{}.samples.sum", statsd_metric_name);
+                state_label_count_exprs.push(quote! { 0usize });
+                state_fields.push(quote! { #calls_state_field: u64, });
+                state_fields.push(quote! { #count_state_field: u64, });
+                state_fields.push(quote! { #sum_state_field: u64, });
+                state_inits.push(quote! { #calls_state_field: 0, });
+                state_inits.push(quote! { #count_state_field: 0, });
+                state_inits.push(quote! { #sum_state_field: 0, });
+                delta_exports.push(quote! {
+                    let current_calls = self.#field_name.calls();
+                    let current_count = self.#field_name.sample_count();
+                    let current_sum = self.#field_name.sample_sum_nanos();
+                    let delta_calls = if current_calls >= state.#calls_state_field {
+                        current_calls - state.#calls_state_field
+                    } else {
+                        current_calls
+                    };
+                    let delta_count = if current_count >= state.#count_state_field {
+                        current_count - state.#count_state_field
+                    } else {
+                        current_count
+                    };
+                    let delta_sum = if current_sum >= state.#sum_state_field {
+                        current_sum - state.#sum_state_field
+                    } else {
+                        current_sum
+                    };
+                    state.#calls_state_field = current_calls;
+                    state.#count_state_field = current_count;
+                    state.#sum_state_field = current_sum;
+                    fast_telemetry::__macro_support::__write_dogstatsd(output, #calls_metric_name, delta_calls, "c", tags);
+                    fast_telemetry::__macro_support::__write_dogstatsd(output, #count_metric_name, delta_count, "c", tags);
+                    fast_telemetry::__macro_support::__write_dogstatsd(output, #sum_metric_name, delta_sum, "c", tags);
+                });
+            }
             MetricKind::LabeledCounter(label_ty) => {
                 state_label_count_exprs.push(quote! { 0usize });
                 state_fields.push(quote! { #field_name: Vec<isize>, });
@@ -699,7 +774,7 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                             delta,
                             "c",
                             <#label_ty as fast_telemetry::LabelEnum>::LABEL_NAME,
-                            label.variant_name(),
+                            <#label_ty as fast_telemetry::LabelEnum>::variant_name(label),
                             tags,
                         );
                     }
@@ -748,7 +823,7 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                             delta_count,
                             "c",
                             <#label_ty as fast_telemetry::LabelEnum>::LABEL_NAME,
-                            label.variant_name(),
+                            <#label_ty as fast_telemetry::LabelEnum>::variant_name(label),
                             tags,
                         );
                         fast_telemetry::__macro_support::__write_dogstatsd_with_label(
@@ -757,7 +832,81 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                             delta_sum,
                             "c",
                             <#label_ty as fast_telemetry::LabelEnum>::LABEL_NAME,
-                            label.variant_name(),
+                            <#label_ty as fast_telemetry::LabelEnum>::variant_name(label),
+                            tags,
+                        );
+                    }
+                });
+            }
+            MetricKind::LabeledSampledTimer(label_ty) => {
+                let calls_state_field = format_ident!("{}_calls", field_name);
+                let count_state_field = format_ident!("{}_sample_count", field_name);
+                let sum_state_field = format_ident!("{}_sample_sum", field_name);
+                let calls_metric_name = format!("{}.calls", statsd_metric_name);
+                let count_metric_name = format!("{}.samples.count", statsd_metric_name);
+                let sum_metric_name = format!("{}.samples.sum", statsd_metric_name);
+                state_label_count_exprs.push(quote! { 0usize });
+                state_fields.push(quote! { #calls_state_field: Vec<u64>, });
+                state_fields.push(quote! { #count_state_field: Vec<u64>, });
+                state_fields.push(quote! { #sum_state_field: Vec<u64>, });
+                state_inits.push(quote! {
+                    #calls_state_field: vec![0; <#label_ty as fast_telemetry::LabelEnum>::CARDINALITY],
+                });
+                state_inits.push(quote! {
+                    #count_state_field: vec![0; <#label_ty as fast_telemetry::LabelEnum>::CARDINALITY],
+                });
+                state_inits.push(quote! {
+                    #sum_state_field: vec![0; <#label_ty as fast_telemetry::LabelEnum>::CARDINALITY],
+                });
+                delta_exports.push(quote! {
+                    for idx in 0..<#label_ty as fast_telemetry::LabelEnum>::CARDINALITY {
+                        let label = <#label_ty as fast_telemetry::LabelEnum>::from_index(idx);
+                        let current_calls = self.#field_name.calls(label);
+                        let current_count = self.#field_name.sample_count(label);
+                        let current_sum = self.#field_name.sample_sum_nanos(label);
+                        let delta_calls = if current_calls >= state.#calls_state_field[idx] {
+                            current_calls - state.#calls_state_field[idx]
+                        } else {
+                            current_calls
+                        };
+                        let delta_count = if current_count >= state.#count_state_field[idx] {
+                            current_count - state.#count_state_field[idx]
+                        } else {
+                            current_count
+                        };
+                        let delta_sum = if current_sum >= state.#sum_state_field[idx] {
+                            current_sum - state.#sum_state_field[idx]
+                        } else {
+                            current_sum
+                        };
+                        state.#calls_state_field[idx] = current_calls;
+                        state.#count_state_field[idx] = current_count;
+                        state.#sum_state_field[idx] = current_sum;
+                        fast_telemetry::__macro_support::__write_dogstatsd_with_label(
+                            output,
+                            #calls_metric_name,
+                            delta_calls,
+                            "c",
+                            <#label_ty as fast_telemetry::LabelEnum>::LABEL_NAME,
+                            <#label_ty as fast_telemetry::LabelEnum>::variant_name(label),
+                            tags,
+                        );
+                        fast_telemetry::__macro_support::__write_dogstatsd_with_label(
+                            output,
+                            #count_metric_name,
+                            delta_count,
+                            "c",
+                            <#label_ty as fast_telemetry::LabelEnum>::LABEL_NAME,
+                            <#label_ty as fast_telemetry::LabelEnum>::variant_name(label),
+                            tags,
+                        );
+                        fast_telemetry::__macro_support::__write_dogstatsd_with_label(
+                            output,
+                            #sum_metric_name,
+                            delta_sum,
+                            "c",
+                            <#label_ty as fast_telemetry::LabelEnum>::LABEL_NAME,
+                            <#label_ty as fast_telemetry::LabelEnum>::variant_name(label),
                             tags,
                         );
                     }

--- a/crates/fast-telemetry/examples/basic.rs
+++ b/crates/fast-telemetry/examples/basic.rs
@@ -2,7 +2,9 @@
 //!
 //! Run with: cargo run --example basic
 
-use fast_telemetry::{Counter, ExportMetrics, Gauge, Histogram};
+use std::time::Duration;
+
+use fast_telemetry::{Counter, ExportMetrics, Gauge, Histogram, SampledTimer};
 
 #[derive(ExportMetrics)]
 #[metric_prefix = "myapp"]
@@ -12,6 +14,9 @@ struct AppMetrics {
 
     #[help = "Request latency in microseconds"]
     latency: Histogram,
+
+    #[help = "Hot path latency"]
+    hot_path_latency: SampledTimer,
 
     #[help = "Current queue depth"]
     queue_depth: Gauge,
@@ -23,6 +28,7 @@ impl AppMetrics {
             // Use number of CPUs for shard count in production
             requests: Counter::new(4),
             latency: Histogram::with_latency_buckets(4),
+            hot_path_latency: SampledTimer::with_latency_buckets(4, 64),
             queue_depth: Gauge::new(),
         }
     }
@@ -35,6 +41,9 @@ fn main() {
     for i in 0..100 {
         metrics.requests.inc();
         metrics.latency.record(50 + (i % 200)); // 50-250µs
+        metrics
+            .hot_path_latency
+            .record_elapsed(Duration::from_nanos(80_000 + ((i % 200) as u64 * 1_000)));
     }
     metrics.queue_depth.set(42);
 

--- a/crates/fast-telemetry/examples/labeled.rs
+++ b/crates/fast-telemetry/examples/labeled.rs
@@ -2,8 +2,10 @@
 //!
 //! Run with: cargo run --example labeled
 
+use std::time::Duration;
+
 use fast_telemetry::{
-    DeriveLabel, ExportMetrics, LabelEnum, LabeledCounter, LabeledGauge, LabeledHistogram,
+    DeriveLabel, ExportMetrics, LabeledCounter, LabeledGauge, LabeledHistogram, LabeledSampledTimer,
 };
 
 // Define label enums with the derive macro.
@@ -39,6 +41,9 @@ struct HttpMetrics {
     #[help = "Request latency by method (microseconds)"]
     latency: LabeledHistogram<HttpMethod>,
 
+    #[help = "Handler phase latency"]
+    phase_latency: LabeledSampledTimer<HttpMethod>,
+
     #[help = "Active connections by method"]
     active: LabeledGauge<HttpMethod>,
 }
@@ -49,6 +54,7 @@ impl HttpMetrics {
             requests: LabeledCounter::new(4),
             responses: LabeledCounter::new(4),
             latency: LabeledHistogram::with_latency_buckets(4),
+            phase_latency: LabeledSampledTimer::with_latency_buckets(4, 32),
             active: LabeledGauge::new(),
         }
     }
@@ -61,12 +67,18 @@ fn main() {
     for _ in 0..100 {
         metrics.requests.inc(HttpMethod::Get);
         metrics.latency.record(HttpMethod::Get, 150);
+        metrics
+            .phase_latency
+            .record_elapsed(HttpMethod::Get, Duration::from_nanos(120_000));
         metrics.responses.inc(StatusClass::Success2xx);
     }
 
     for _ in 0..30 {
         metrics.requests.inc(HttpMethod::Post);
         metrics.latency.record(HttpMethod::Post, 500);
+        metrics
+            .phase_latency
+            .record_elapsed(HttpMethod::Post, Duration::from_nanos(240_000));
         metrics.responses.inc(StatusClass::Success2xx);
     }
 

--- a/crates/fast-telemetry/examples/service_metrics.rs
+++ b/crates/fast-telemetry/examples/service_metrics.rs
@@ -6,7 +6,7 @@
 //! Run with: cargo run --example service_metrics
 
 use fast_telemetry::{
-    Counter, DeriveLabel, ExportMetrics, Gauge, LabelEnum, LabeledCounter, LabeledHistogram,
+    Counter, DeriveLabel, ExportMetrics, Gauge, LabeledCounter, LabeledHistogram,
 };
 use std::sync::Arc;
 use std::thread;

--- a/crates/fast-telemetry/src/export/otlp.rs
+++ b/crates/fast-telemetry/src/export/otlp.rs
@@ -10,7 +10,8 @@ use crate::exp_buckets::ExpBucketsSnapshot;
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    SampledTimer,
 };
 
 /// Re-export proto types so downstream crates (and the derive macro) can reference them.
@@ -347,6 +348,25 @@ impl OtlpExport for Histogram {
     }
 }
 
+impl OtlpExport for SampledTimer {
+    fn export_otlp(
+        &self,
+        metrics: &mut Vec<pb::Metric>,
+        name: &str,
+        description: &str,
+        time_unix_nano: u64,
+    ) {
+        let calls_name = format!("{name}.calls");
+        let samples_name = format!("{name}.samples");
+        let calls_description = format!("{description} total calls");
+        let samples_description = format!("{description} sampled latency in nanoseconds");
+        self.calls_metric()
+            .export_otlp(metrics, &calls_name, &calls_description, time_unix_nano);
+        self.histogram()
+            .export_otlp(metrics, &samples_name, &samples_description, time_unix_nano);
+    }
+}
+
 /// Build an OTLP ExponentialHistogramDataPoint from an ExpBucketsSnapshot.
 fn exp_histogram_data_point(
     snap: &ExpBucketsSnapshot,
@@ -507,6 +527,65 @@ impl<L: LabelEnum> OtlpExport for LabeledHistogram<L> {
             description: description.to_string(),
             data: Some(pb::metric::Data::Histogram(pb::OtlpHistogram {
                 data_points,
+                aggregation_temporality: pb::AggregationTemporality::Cumulative as i32,
+            })),
+            ..Default::default()
+        });
+    }
+}
+
+impl<L: LabelEnum> OtlpExport for LabeledSampledTimer<L> {
+    fn export_otlp(
+        &self,
+        metrics: &mut Vec<pb::Metric>,
+        name: &str,
+        description: &str,
+        time_unix_nano: u64,
+    ) {
+        let calls_name = format!("{name}.calls");
+        let samples_name = format!("{name}.samples");
+        let calls_description = format!("{description} total calls");
+        let samples_description = format!("{description} sampled latency in nanoseconds");
+
+        let mut call_points = Vec::new();
+        let mut sample_points = Vec::new();
+
+        for (label, calls, histogram) in self.iter() {
+            call_points.push(int_data_point(
+                calls.sum() as i64,
+                vec![label_to_attribute(label)],
+                time_unix_nano,
+            ));
+
+            let (bucket_counts, explicit_bounds) =
+                cumulative_to_otlp_buckets(&histogram.buckets_cumulative());
+            sample_points.push(pb::HistogramDataPoint {
+                attributes: vec![label_to_attribute(label)],
+                time_unix_nano,
+                count: histogram.count(),
+                sum: Some(histogram.sum() as f64),
+                bucket_counts,
+                explicit_bounds,
+                ..Default::default()
+            });
+        }
+
+        metrics.push(pb::Metric {
+            name: calls_name,
+            description: calls_description,
+            data: Some(pb::metric::Data::Sum(pb::Sum {
+                data_points: call_points,
+                aggregation_temporality: pb::AggregationTemporality::Cumulative as i32,
+                is_monotonic: false,
+            })),
+            ..Default::default()
+        });
+
+        metrics.push(pb::Metric {
+            name: samples_name,
+            description: samples_description,
+            data: Some(pb::metric::Data::Histogram(pb::OtlpHistogram {
+                data_points: sample_points,
                 aggregation_temporality: pb::AggregationTemporality::Cumulative as i32,
             })),
             ..Default::default()

--- a/crates/fast-telemetry/src/export/text/dogstatsd.rs
+++ b/crates/fast-telemetry/src/export/text/dogstatsd.rs
@@ -1,8 +1,8 @@
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, DynamicLabelSet, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter,
-    LabeledGauge, LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
-    exp_buckets::ExpBucketsSnapshot,
+    LabeledGauge, LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MinGauge,
+    MinGaugeF64, SampledTimer, exp_buckets::ExpBucketsSnapshot,
 };
 use std::fmt::{Display, Write as _};
 
@@ -441,6 +441,17 @@ impl DogStatsDExport for Histogram {
     }
 }
 
+impl DogStatsDExport for SampledTimer {
+    fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
+        let calls_name = format!("{name}.calls");
+        let samples_name = format!("{name}.samples");
+        self.calls_metric()
+            .export_dogstatsd(output, &calls_name, tags);
+        self.histogram()
+            .export_dogstatsd(output, &samples_name, tags);
+    }
+}
+
 impl DogStatsDExport for Distribution {
     /// Export distribution as `|d` samples for Datadog percentile computation.
     fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
@@ -493,6 +504,47 @@ impl<L: LabelEnum> DogStatsDExport for LabeledHistogram<L> {
             output.push_str("|c");
             append_tags_with_label(output, L::LABEL_NAME, variant, tags);
             output.push('\n');
+        }
+    }
+}
+
+impl<L: LabelEnum> DogStatsDExport for LabeledSampledTimer<L> {
+    fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]) {
+        let calls_name = format!("{name}.calls");
+        let samples_name = format!("{name}.samples");
+
+        for (label, calls, histogram) in self.iter() {
+            let variant = label.variant_name();
+
+            __write_dogstatsd_with_label(
+                output,
+                &calls_name,
+                calls.sum(),
+                "c",
+                L::LABEL_NAME,
+                variant,
+                tags,
+            );
+
+            __write_dogstatsd_with_label(
+                output,
+                &format!("{}.count", samples_name),
+                histogram.count(),
+                "c",
+                L::LABEL_NAME,
+                variant,
+                tags,
+            );
+
+            __write_dogstatsd_with_label(
+                output,
+                &format!("{}.sum", samples_name),
+                histogram.sum(),
+                "c",
+                L::LABEL_NAME,
+                variant,
+                tags,
+            );
         }
     }
 }

--- a/crates/fast-telemetry/src/export/text/prometheus.rs
+++ b/crates/fast-telemetry/src/export/text/prometheus.rs
@@ -1,7 +1,8 @@
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    SampledTimer,
 };
 use std::fmt::Write as _;
 
@@ -28,6 +29,84 @@ fn write_dynamic_labels(output: &mut String, labels: &[(String, String)]) {
         output.push_str("=\"");
         output.push_str(v);
         output.push('"');
+    }
+}
+
+fn write_labeled_counter_series<L, I>(output: &mut String, name: &str, help: &str, series: I)
+where
+    L: LabelEnum,
+    I: IntoIterator<Item = (L, u64)>,
+{
+    output.push_str("# HELP ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(help);
+    output.push_str("\n# TYPE ");
+    output.push_str(name);
+    output.push_str(" counter\n");
+
+    for (label, count) in series {
+        output.push_str(name);
+        output.push('{');
+        output.push_str(L::LABEL_NAME);
+        output.push_str("=\"");
+        output.push_str(label.variant_name());
+        output.push_str("\"} ");
+        push_display(output, count);
+        output.push('\n');
+    }
+}
+
+fn write_labeled_histogram_series<L, I>(output: &mut String, name: &str, help: &str, series: I)
+where
+    L: LabelEnum,
+    I: IntoIterator<Item = (L, Vec<(u64, u64)>, u64, u64)>,
+{
+    output.push_str("# HELP ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(help);
+    output.push_str("\n# TYPE ");
+    output.push_str(name);
+    output.push_str(" histogram\n");
+
+    for (label, buckets, sum, count) in series {
+        let variant = label.variant_name();
+
+        for (bound, bucket_count) in buckets {
+            output.push_str(name);
+            output.push_str("_bucket{");
+            output.push_str(L::LABEL_NAME);
+            output.push_str("=\"");
+            output.push_str(variant);
+            output.push_str("\",le=\"");
+            if bound == u64::MAX {
+                output.push_str("+Inf");
+            } else {
+                push_display(output, bound);
+            }
+            output.push_str("\"} ");
+            push_display(output, bucket_count);
+            output.push('\n');
+        }
+
+        output.push_str(name);
+        output.push_str("_sum{");
+        output.push_str(L::LABEL_NAME);
+        output.push_str("=\"");
+        output.push_str(variant);
+        output.push_str("\"} ");
+        push_display(output, sum);
+        output.push('\n');
+
+        output.push_str(name);
+        output.push_str("_count{");
+        output.push_str(L::LABEL_NAME);
+        output.push_str("=\"");
+        output.push_str(variant);
+        output.push_str("\"} ");
+        push_display(output, count);
+        output.push('\n');
     }
 }
 
@@ -178,6 +257,19 @@ impl PrometheusExport for Histogram {
     }
 }
 
+impl PrometheusExport for SampledTimer {
+    fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
+        let calls_name = format!("{name}_calls");
+        let samples_name = format!("{name}_samples");
+        let calls_help = format!("{help} total calls");
+        let samples_help = format!("{help} sampled latency in nanoseconds");
+        self.calls_metric()
+            .export_prometheus(output, &calls_name, &calls_help);
+        self.histogram()
+            .export_prometheus(output, &samples_name, &samples_help);
+    }
+}
+
 impl PrometheusExport for Distribution {
     /// Export distribution as summary (count + sum only, no quantiles).
     fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
@@ -203,24 +295,12 @@ impl PrometheusExport for Distribution {
 
 impl<L: LabelEnum> PrometheusExport for LabeledCounter<L> {
     fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
-        output.push_str("# HELP ");
-        output.push_str(name);
-        output.push(' ');
-        output.push_str(help);
-        output.push_str("\n# TYPE ");
-        output.push_str(name);
-        output.push_str(" counter\n");
-
-        for (label, count) in self.iter() {
-            output.push_str(name);
-            output.push('{');
-            output.push_str(L::LABEL_NAME);
-            output.push_str("=\"");
-            output.push_str(label.variant_name());
-            output.push_str("\"} ");
-            push_display(output, count);
-            output.push('\n');
-        }
+        write_labeled_counter_series::<L, _>(
+            output,
+            name,
+            help,
+            self.iter().map(|(label, count)| (label, count as u64)),
+        );
     }
 }
 
@@ -249,52 +329,37 @@ impl<L: LabelEnum> PrometheusExport for LabeledGauge<L> {
 
 impl<L: LabelEnum> PrometheusExport for LabeledHistogram<L> {
     fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
-        output.push_str("# HELP ");
-        output.push_str(name);
-        output.push(' ');
-        output.push_str(help);
-        output.push_str("\n# TYPE ");
-        output.push_str(name);
-        output.push_str(" histogram\n");
+        write_labeled_histogram_series::<L, _>(output, name, help, self.iter());
+    }
+}
 
-        for (label, buckets, sum, count) in self.iter() {
-            let variant = label.variant_name();
+impl<L: LabelEnum> PrometheusExport for LabeledSampledTimer<L> {
+    fn export_prometheus(&self, output: &mut String, name: &str, help: &str) {
+        let calls_name = format!("{name}_calls");
+        let samples_name = format!("{name}_samples");
+        let calls_help = format!("{help} total calls");
+        let samples_help = format!("{help} sampled latency in nanoseconds");
 
-            for (bound, bucket_count) in buckets {
-                output.push_str(name);
-                output.push_str("_bucket{");
-                output.push_str(L::LABEL_NAME);
-                output.push_str("=\"");
-                output.push_str(variant);
-                output.push_str("\",le=\"");
-                if bound == u64::MAX {
-                    output.push_str("+Inf");
-                } else {
-                    push_display(output, bound);
-                }
-                output.push_str("\"} ");
-                push_display(output, bucket_count);
-                output.push('\n');
-            }
-
-            output.push_str(name);
-            output.push_str("_sum{");
-            output.push_str(L::LABEL_NAME);
-            output.push_str("=\"");
-            output.push_str(variant);
-            output.push_str("\"} ");
-            push_display(output, sum);
-            output.push('\n');
-
-            output.push_str(name);
-            output.push_str("_count{");
-            output.push_str(L::LABEL_NAME);
-            output.push_str("=\"");
-            output.push_str(variant);
-            output.push_str("\"} ");
-            push_display(output, count);
-            output.push('\n');
-        }
+        write_labeled_counter_series::<L, _>(
+            output,
+            &calls_name,
+            &calls_help,
+            self.iter()
+                .map(|(label, calls, _)| (label, calls.sum() as u64)),
+        );
+        write_labeled_histogram_series::<L, _>(
+            output,
+            &samples_name,
+            &samples_help,
+            self.iter().map(|(label, _, histogram)| {
+                (
+                    label,
+                    histogram.buckets_cumulative(),
+                    histogram.sum(),
+                    histogram.count(),
+                )
+            }),
+        );
     }
 }
 

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -51,7 +51,8 @@ pub use metric::{
     DynamicDistributionSeries, DynamicGauge, DynamicGaugeI64, DynamicGaugeI64Series,
     DynamicGaugeSeries, DynamicHistogram, DynamicHistogramSeries, DynamicHistogramSeriesView,
     DynamicLabelSet, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
+    SampledTimer, SampledTimerGuard,
 };
 #[cfg(feature = "eviction")]
 pub use metric::{advance_cycle, current_cycle};

--- a/crates/fast-telemetry/src/metric/mod.rs
+++ b/crates/fast-telemetry/src/metric/mod.rs
@@ -12,6 +12,7 @@ mod max_gauge;
 mod max_gauge_f64;
 mod min_gauge;
 mod min_gauge_f64;
+mod sampled_timer;
 
 pub use counter::Counter;
 pub use distribution::Distribution;
@@ -33,3 +34,4 @@ pub use max_gauge::MaxGauge;
 pub use max_gauge_f64::MaxGaugeF64;
 pub use min_gauge::MinGauge;
 pub use min_gauge_f64::MinGaugeF64;
+pub use sampled_timer::{LabeledSampledTimer, SampledTimer, SampledTimerGuard};

--- a/crates/fast-telemetry/src/metric/sampled_timer.rs
+++ b/crates/fast-telemetry/src/metric/sampled_timer.rs
@@ -1,0 +1,412 @@
+//! Sampled elapsed-time recording for hot paths.
+//!
+//! `SampledTimer` counts every call but only records elapsed time for one call
+//! per configured stride. This keeps hot-path instrumentation cheap while still
+//! giving useful phase latency samples.
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::time::{Duration, Instant};
+
+use crate::{Counter, Histogram, LabelEnum};
+
+thread_local! {
+    static SAMPLE_SEQ: Cell<u64> = const { Cell::new(0) };
+}
+
+/// Counts every timed operation and samples elapsed latency into a histogram.
+///
+/// Durations are recorded in nanoseconds.
+pub struct SampledTimer {
+    inner: SampledTimerInner,
+}
+
+/// Label-indexed sampled timer with O(1) lookup.
+pub struct LabeledSampledTimer<L: LabelEnum> {
+    timers: Vec<SampledTimerInner>,
+    _phantom: PhantomData<L>,
+}
+
+/// RAII guard returned by [`SampledTimer::start`] and [`LabeledSampledTimer::start`].
+///
+/// Dropping the guard records elapsed time when the operation was selected for
+/// sampling. Call [`finish`](Self::finish) when an explicit endpoint is clearer.
+pub struct SampledTimerGuard<'a> {
+    timer: &'a SampledTimerInner,
+    start: Option<Instant>,
+    finished: bool,
+}
+
+struct SampledTimerInner {
+    calls: Counter,
+    samples: Histogram,
+    stride_mask: u64,
+}
+
+impl SampledTimer {
+    /// Create a sampled timer with custom histogram bounds in nanoseconds.
+    ///
+    /// `sample_stride` is rounded up to a power of two. A stride of `1` records
+    /// every call.
+    pub fn new(bounds_nanos: &[u64], shard_count: usize, sample_stride: u64) -> Self {
+        Self {
+            inner: SampledTimerInner::new(bounds_nanos, shard_count, sample_stride),
+        }
+    }
+
+    /// Create a sampled timer with default latency buckets in nanoseconds.
+    pub fn with_latency_buckets(shard_count: usize, sample_stride: u64) -> Self {
+        Self {
+            inner: SampledTimerInner::with_latency_buckets(shard_count, sample_stride),
+        }
+    }
+
+    /// Start timing one operation.
+    #[inline]
+    pub fn start(&self) -> SampledTimerGuard<'_> {
+        self.inner.start()
+    }
+
+    /// Record an already-measured duration if this call should be sampled.
+    #[inline]
+    pub fn record_elapsed(&self, elapsed: Duration) {
+        self.inner.record_elapsed(elapsed);
+    }
+
+    /// Total operation calls, sampled or not.
+    #[inline]
+    pub fn calls(&self) -> u64 {
+        self.inner.calls()
+    }
+
+    /// Number of latency samples recorded.
+    #[inline]
+    pub fn sample_count(&self) -> u64 {
+        self.inner.sample_count()
+    }
+
+    /// Sum of sampled latency values in nanoseconds.
+    #[inline]
+    pub fn sample_sum_nanos(&self) -> u64 {
+        self.inner.sample_sum_nanos()
+    }
+
+    /// Average sampled latency in nanoseconds.
+    pub fn avg_sample_nanos(&self) -> Option<f64> {
+        self.inner.avg_sample_nanos()
+    }
+
+    /// Access the underlying call counter for export.
+    #[inline]
+    pub fn calls_metric(&self) -> &Counter {
+        &self.inner.calls
+    }
+
+    /// Access the underlying sampled histogram for export.
+    #[inline]
+    pub fn histogram(&self) -> &Histogram {
+        &self.inner.samples
+    }
+}
+
+impl<L: LabelEnum> LabeledSampledTimer<L> {
+    /// Create a labeled sampled timer with custom histogram bounds in nanoseconds.
+    pub fn new(bounds_nanos: &[u64], shard_count: usize, sample_stride: u64) -> Self {
+        let timers = (0..L::CARDINALITY)
+            .map(|_| SampledTimerInner::new(bounds_nanos, shard_count, sample_stride))
+            .collect();
+        Self {
+            timers,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Create a labeled sampled timer with default latency buckets in nanoseconds.
+    pub fn with_latency_buckets(shard_count: usize, sample_stride: u64) -> Self {
+        let timers = (0..L::CARDINALITY)
+            .map(|_| SampledTimerInner::with_latency_buckets(shard_count, sample_stride))
+            .collect();
+        Self {
+            timers,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Start timing one labeled operation.
+    #[inline]
+    pub fn start(&self, label: L) -> SampledTimerGuard<'_> {
+        self.timer(label).start()
+    }
+
+    /// Record an already-measured duration for the given label if it should be sampled.
+    #[inline]
+    pub fn record_elapsed(&self, label: L, elapsed: Duration) {
+        self.timer(label).record_elapsed(elapsed);
+    }
+
+    /// Total calls for a label, sampled or not.
+    #[inline]
+    pub fn calls(&self, label: L) -> u64 {
+        self.timer(label).calls()
+    }
+
+    /// Number of latency samples recorded for a label.
+    #[inline]
+    pub fn sample_count(&self, label: L) -> u64 {
+        self.timer(label).sample_count()
+    }
+
+    /// Sum of sampled latency values in nanoseconds for a label.
+    #[inline]
+    pub fn sample_sum_nanos(&self, label: L) -> u64 {
+        self.timer(label).sample_sum_nanos()
+    }
+
+    /// Average sampled latency in nanoseconds for a label.
+    pub fn avg_sample_nanos(&self, label: L) -> Option<f64> {
+        self.timer(label).avg_sample_nanos()
+    }
+
+    /// Access the underlying call counter for a label.
+    #[inline]
+    pub fn calls_metric(&self, label: L) -> &Counter {
+        &self.timer(label).calls
+    }
+
+    /// Access the underlying sampled histogram for a label.
+    #[inline]
+    pub fn histogram(&self, label: L) -> &Histogram {
+        &self.timer(label).samples
+    }
+
+    /// Iterate over all label/timer pairs for export.
+    pub fn iter(&self) -> impl Iterator<Item = (L, &Counter, &Histogram)> + '_ {
+        self.timers
+            .iter()
+            .enumerate()
+            .map(|(idx, timer)| (L::from_index(idx), &timer.calls, &timer.samples))
+    }
+
+    #[inline]
+    fn timer(&self, label: L) -> &SampledTimerInner {
+        let idx = label.as_index();
+        debug_assert!(idx < self.timers.len(), "label index out of bounds");
+        if cfg!(debug_assertions) {
+            &self.timers[idx]
+        } else {
+            unsafe { self.timers.get_unchecked(idx) }
+        }
+    }
+}
+
+impl SampledTimerGuard<'_> {
+    /// Finish timing now.
+    #[inline]
+    pub fn finish(mut self) {
+        self.record();
+        self.finished = true;
+    }
+
+    #[inline]
+    fn record(&mut self) {
+        let Some(start) = self.start.take() else {
+            return;
+        };
+        self.timer.samples.record(duration_nanos(start.elapsed()));
+    }
+}
+
+impl Drop for SampledTimerGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        if !self.finished {
+            self.record();
+        }
+    }
+}
+
+impl SampledTimerInner {
+    fn new(bounds_nanos: &[u64], shard_count: usize, sample_stride: u64) -> Self {
+        Self {
+            calls: Counter::new(shard_count),
+            samples: Histogram::new(bounds_nanos, shard_count),
+            stride_mask: stride_mask(sample_stride),
+        }
+    }
+
+    fn with_latency_buckets(shard_count: usize, sample_stride: u64) -> Self {
+        Self::new(
+            &[
+                10_000,         // 10µs
+                50_000,         // 50µs
+                100_000,        // 100µs
+                500_000,        // 500µs
+                1_000_000,      // 1ms
+                5_000_000,      // 5ms
+                10_000_000,     // 10ms
+                50_000_000,     // 50ms
+                100_000_000,    // 100ms
+                500_000_000,    // 500ms
+                1_000_000_000,  // 1s
+                5_000_000_000,  // 5s
+                10_000_000_000, // 10s
+            ],
+            shard_count,
+            sample_stride,
+        )
+    }
+
+    #[inline]
+    fn start(&self) -> SampledTimerGuard<'_> {
+        self.calls.inc();
+        let sampled = should_sample(self.stride_mask);
+        SampledTimerGuard {
+            timer: self,
+            start: sampled.then(Instant::now),
+            finished: false,
+        }
+    }
+
+    #[inline]
+    fn record_elapsed(&self, elapsed: Duration) {
+        self.calls.inc();
+        if should_sample(self.stride_mask) {
+            self.samples.record(duration_nanos(elapsed));
+        }
+    }
+
+    #[inline]
+    fn calls(&self) -> u64 {
+        self.calls.sum() as u64
+    }
+
+    #[inline]
+    fn sample_count(&self) -> u64 {
+        self.samples.count()
+    }
+
+    #[inline]
+    fn sample_sum_nanos(&self) -> u64 {
+        self.samples.sum()
+    }
+
+    fn avg_sample_nanos(&self) -> Option<f64> {
+        let count = self.sample_count();
+        if count == 0 {
+            return None;
+        }
+        Some(self.sample_sum_nanos() as f64 / count as f64)
+    }
+}
+
+fn should_sample(stride_mask: u64) -> bool {
+    SAMPLE_SEQ.with(|seq| {
+        let next = seq.get().wrapping_add(1);
+        seq.set(next);
+        next & stride_mask == 0
+    })
+}
+
+fn stride_mask(sample_stride: u64) -> u64 {
+    sample_stride.max(1).next_power_of_two() - 1
+}
+
+fn duration_nanos(elapsed: Duration) -> u64 {
+    elapsed.as_nanos().min(u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    enum TestLabel {
+        A,
+        B,
+    }
+
+    impl LabelEnum for TestLabel {
+        const CARDINALITY: usize = 2;
+        const LABEL_NAME: &'static str = "label";
+
+        fn as_index(self) -> usize {
+            self as usize
+        }
+
+        fn from_index(index: usize) -> Self {
+            match index {
+                0 => Self::A,
+                _ => Self::B,
+            }
+        }
+
+        fn variant_name(self) -> &'static str {
+            match self {
+                Self::A => "a",
+                Self::B => "b",
+            }
+        }
+    }
+
+    #[test]
+    fn stride_one_records_every_call() {
+        let timer = SampledTimer::with_latency_buckets(4, 1);
+
+        timer.record_elapsed(Duration::from_nanos(10));
+        timer.record_elapsed(Duration::from_nanos(20));
+
+        assert_eq!(timer.calls(), 2);
+        assert_eq!(timer.sample_count(), 2);
+        assert_eq!(timer.sample_sum_nanos(), 30);
+        assert_eq!(timer.avg_sample_nanos(), Some(15.0));
+    }
+
+    #[test]
+    fn stride_samples_subset() {
+        let timer = SampledTimer::with_latency_buckets(4, 4);
+
+        for _ in 0..8 {
+            timer.record_elapsed(Duration::from_nanos(10));
+        }
+
+        assert_eq!(timer.calls(), 8);
+        assert_eq!(timer.sample_count(), 2);
+    }
+
+    #[test]
+    fn guard_records_on_drop() {
+        let timer = SampledTimer::with_latency_buckets(4, 1);
+
+        {
+            let _guard = timer.start();
+        }
+
+        assert_eq!(timer.calls(), 1);
+        assert_eq!(timer.sample_count(), 1);
+    }
+
+    #[test]
+    fn explicit_finish_records_once() {
+        let timer = SampledTimer::with_latency_buckets(4, 1);
+
+        timer.start().finish();
+
+        assert_eq!(timer.calls(), 1);
+        assert_eq!(timer.sample_count(), 1);
+    }
+
+    #[test]
+    fn labeled_timer_tracks_labels_independently() {
+        let timer: LabeledSampledTimer<TestLabel> = LabeledSampledTimer::with_latency_buckets(4, 1);
+
+        timer.record_elapsed(TestLabel::A, Duration::from_nanos(15));
+        timer.record_elapsed(TestLabel::B, Duration::from_nanos(25));
+        timer.record_elapsed(TestLabel::A, Duration::from_nanos(35));
+
+        assert_eq!(timer.calls(TestLabel::A), 2);
+        assert_eq!(timer.calls(TestLabel::B), 1);
+        assert_eq!(timer.sample_count(TestLabel::A), 2);
+        assert_eq!(timer.sample_sum_nanos(TestLabel::A), 50);
+        assert_eq!(timer.sample_sum_nanos(TestLabel::B), 25);
+    }
+}

--- a/crates/fast-telemetry/tests/sampled_timer_export_test.rs
+++ b/crates/fast-telemetry/tests/sampled_timer_export_test.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+use fast_telemetry::{DeriveLabel, ExportMetrics, LabeledSampledTimer, SampledTimer, Temporality};
+
+#[derive(Copy, Clone, Debug, DeriveLabel)]
+#[label_name = "phase"]
+enum Phase {
+    Parse,
+    Execute,
+}
+
+#[derive(ExportMetrics)]
+#[metric_prefix = "test"]
+#[cfg_attr(feature = "otlp", otlp)]
+struct SampledMetrics {
+    #[help = "Request latency"]
+    latency: SampledTimer,
+
+    #[help = "Phase latency"]
+    phase_latency: LabeledSampledTimer<Phase>,
+}
+
+impl SampledMetrics {
+    fn new() -> Self {
+        Self {
+            latency: SampledTimer::with_latency_buckets(4, 1),
+            phase_latency: LabeledSampledTimer::with_latency_buckets(4, 1),
+        }
+    }
+}
+
+#[test]
+fn test_sampled_timer_prometheus_export() {
+    let metrics = SampledMetrics::new();
+    metrics.latency.record_elapsed(Duration::from_nanos(50_000));
+
+    let mut output = String::new();
+    metrics.export_prometheus(&mut output);
+
+    assert!(output.contains("# HELP test_latency_calls Request latency total calls"));
+    assert!(output.contains("test_latency_calls 1"));
+    assert!(output.contains("# TYPE test_latency_samples histogram"));
+    assert!(output.contains("test_latency_samples_count 1"));
+}
+
+#[test]
+fn test_labeled_sampled_timer_prometheus_export() {
+    let metrics = SampledMetrics::new();
+    metrics
+        .phase_latency
+        .record_elapsed(Phase::Parse, Duration::from_nanos(100_000));
+
+    let mut output = String::new();
+    metrics.export_prometheus(&mut output);
+
+    assert!(output.contains("test_phase_latency_calls{phase=\"parse\"} 1"));
+    assert!(output.contains("test_phase_latency_samples_count{phase=\"parse\"} 1"));
+    assert!(output.contains("test_phase_latency_calls{phase=\"execute\"} 0"));
+}
+
+#[test]
+fn test_sampled_timer_dogstatsd_export() {
+    let metrics = SampledMetrics::new();
+    metrics.latency.record_elapsed(Duration::from_nanos(50_000));
+
+    let mut output = String::new();
+    metrics.export_dogstatsd(&mut output, &[]);
+
+    assert!(output.contains("test.latency.calls:1|c\n"));
+    assert!(output.contains("test.latency.samples.count:1|c\n"));
+    assert!(output.contains("test.latency.samples.sum:50000|c\n"));
+}
+
+#[test]
+fn test_sampled_timer_dogstatsd_delta_export() {
+    let metrics = SampledMetrics::new();
+    let mut state = SampledMetricsDogStatsDState::new();
+
+    metrics.latency.record_elapsed(Duration::from_nanos(50_000));
+
+    let mut output = String::new();
+    metrics.export_dogstatsd_with_temporality(&mut output, &[], Temporality::Delta, &mut state);
+    assert!(output.contains("test.latency.calls:1|c\n"));
+    assert!(output.contains("test.latency.samples.count:1|c\n"));
+    assert!(output.contains("test.latency.samples.sum:50000|c\n"));
+
+    metrics.latency.record_elapsed(Duration::from_nanos(70_000));
+
+    let mut output = String::new();
+    metrics.export_dogstatsd_with_temporality(&mut output, &[], Temporality::Delta, &mut state);
+    assert!(output.contains("test.latency.calls:1|c\n"));
+    assert!(output.contains("test.latency.samples.count:1|c\n"));
+    assert!(output.contains("test.latency.samples.sum:70000|c\n"));
+}
+
+#[cfg(feature = "otlp")]
+#[test]
+fn test_sampled_timer_otlp_export() {
+    let metrics = SampledMetrics::new();
+    metrics.latency.record_elapsed(Duration::from_nanos(50_000));
+
+    let mut exported = Vec::new();
+    metrics.export_otlp(&mut exported, 123);
+
+    assert_eq!(exported.len(), 4);
+    assert_eq!(exported[0].name, "test_latency.calls");
+    assert_eq!(exported[1].name, "test_latency.samples");
+    assert_eq!(exported[2].name, "test_phase_latency.calls");
+    assert_eq!(exported[3].name, "test_phase_latency.samples");
+}

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use fast_telemetry::{
-    Counter, DeriveLabel, Distribution, DynamicCounter, ExportMetrics, Gauge, Histogram, LabelEnum,
+    Counter, DeriveLabel, Distribution, DynamicCounter, ExportMetrics, Gauge, Histogram,
     LabeledCounter, LabeledHistogram, MaxGauge, MinGauge, SpanCollector, SpanKind, SpanStatus,
 };
 use tokio_util::sync::CancellationToken;


### PR DESCRIPTION
`SampledTimer` is for measuring elapsed time around an operation. Can start timing with an RAII guard and let it record on drop, or record a pre-measured `Duration` directly.

Designed for hot paths where timing instrumentation should stay cheap. Every use increments a total call counter, while elapsed-time measurements are sampled at the configured stride before being recorded into the latency histogram.