### PR TITLE
fix: initialize MinGauge/MinGaugeF64 to MAX/INFINITY

### DIFF
--- a/crates/fast-telemetry/src/metric/min_gauge.rs
+++ b/crates/fast-telemetry/src/metric/min_gauge.rs
@@ -16,9 +16,13 @@ pub struct MinGauge {
 }
 
 impl MinGauge {
-    /// Create a new min gauge with all shards initialized to zero.
+    /// Create a new min gauge with all shards initialized to [`i64::MAX`],
+    /// so any observation displaces the initial value.
+    ///
+    /// `get()` on a gauge that has never been observed returns [`i64::MAX`];
+    /// callers that need a different sentinel should use [`Self::with_value`].
     pub fn new(shard_count: usize) -> Self {
-        Self::with_value(shard_count, 0)
+        Self::with_value(shard_count, i64::MAX)
     }
 
     /// Create a new min gauge with all shards initialized to `initial`.
@@ -104,6 +108,16 @@ mod tests {
         let gauge = MinGauge::with_value(4, 10);
         assert_eq!(gauge.get(), 10);
         gauge.observe(3);
+        assert_eq!(gauge.get(), 3);
+    }
+
+    #[test]
+    fn new_tracks_minimum_of_positive_observations() {
+        let gauge = MinGauge::new(4);
+        assert_eq!(gauge.get(), i64::MAX);
+        gauge.observe(8);
+        gauge.observe(3);
+        gauge.observe(5);
         assert_eq!(gauge.get(), 3);
     }
 }

--- a/crates/fast-telemetry/src/metric/min_gauge_f64.rs
+++ b/crates/fast-telemetry/src/metric/min_gauge_f64.rs
@@ -36,9 +36,13 @@ pub struct MinGaugeF64 {
 }
 
 impl MinGaugeF64 {
-    /// Create a new min gauge with all shards initialized to zero.
+    /// Create a new min gauge with all shards initialized to [`f64::INFINITY`],
+    /// so any (non-NaN) observation displaces the initial value.
+    ///
+    /// `get()` on a gauge that has never been observed returns [`f64::INFINITY`];
+    /// callers that need a different sentinel should use [`Self::with_value`].
     pub fn new(shard_count: usize) -> Self {
-        Self::with_value(shard_count, 0.0)
+        Self::with_value(shard_count, f64::INFINITY)
     }
 
     /// Create a new min gauge with all shards initialized to `initial`.
@@ -134,5 +138,15 @@ mod tests {
         let gauge = MinGaugeF64::with_value(4, 1.0);
         gauge.observe(f64::NAN);
         assert!((gauge.get() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn new_tracks_minimum_of_positive_observations() {
+        let gauge = MinGaugeF64::new(4);
+        assert!(gauge.get().is_infinite() && gauge.get().is_sign_positive());
+        gauge.observe(8.0);
+        gauge.observe(3.25);
+        gauge.observe(5.5);
+        assert!((gauge.get() - 3.25).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## Summary
Closes #9.

`MinGauge::new()` initialized all shards to `0`, and `MinGaugeF64::new()` to `0.0`. Since both types track a running minimum via `fetch_min`, any positive observation silently no-ops. The README workaround is `MinGauge::with_value(_, i64::MAX)` / `MinGaugeF64::with_value(_, f64::INFINITY)` but `new()` (and `Default::default()`, which delegates to `new(4)`) leave the user with a metric that ignores positive values.

This change makes the `new()` defaults [`i64::MAX`] / [`f64::INFINITY`] so the first observation always displaces the initial value. `with_value()` is unchanged. `Default::default()` inherits the fix.

`get()` on a never-observed gauge now returns `MAX` / `INFINITY`, which truthfully encodes "no observations yet."

## Test plan
- [x] New regression tests `new_tracks_minimum_of_positive_observations` for both types — observe only positive values, assert smallest is returned.
- [x] `cargo test -p fast-telemetry` (all tests pass)
- [x] `cargo clippy -p fast-telemetry --all-targets` (no new warnings)
- [x] `cargo fmt -p fast-telemetry --check` (clean)