### PR TITLE
chore: release 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.1.0" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.1.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.1.1" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.1.1" }
 fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.1.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## 0.1.1 - 2026-04-27
+
+Republished crates: `fast-telemetry`, `fast-telemetry-macros`. (`fast-telemetry-export` is unchanged since 0.1.0 and stays at that version; it picks up `fast-telemetry` 0.1.1 via semver.)
+
+Highlights:
+
+- new metric types: `MaxGauge`, `MinGauge`, `MaxGaugeF64`, `MinGaugeF64` for tracking running extrema (peaks/troughs) without a single contended atomic on the hot path
+- new metric types: `SampledTimer` and `LabeledSampledTimer` for low-cost elapsed-time measurement, composing a call counter with a stride-sampled latency histogram and an RAII timing guard
+- dynamic-metric label lookup now uses a multi-entry per-thread cache, fixing a single-entry cache thrash under rotating label sets
+- bug fix: `MinGauge::new()` and `MinGaugeF64::new()` now initialize to `i64::MAX` / `f64::INFINITY`, so any first observation displaces the initial value (previously the 0/0.0 default silently no-oped against positive observations). See #9.
+- bench harness: added a CPU workload, a `metrics` + `metrics-util` comparison mode, and a refreshed suite report renderer
+- macros: `MetricKind` now covers all extrema gauge types and `SampledTimer`
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.1.1"
+fast-telemetry-export = "0.1.0"
+```
+
 ## 0.1.0 - 2026-04-06
 
 Initial public release of the fast-telemetry workspace on crates.io.

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Bumps `fast-telemetry` and `fast-telemetry-macros` to 0.1.1.

`fast-telemetry-export` has no source changes since 0.1.0 and stays at that version (it picks up `fast-telemetry` 0.1.1 transitively via semver).

## Highlights since 0.1.0
- new metric types: `MaxGauge` / `MinGauge` / `MaxGaugeF64` / `MinGaugeF64`
- new metric types: `SampledTimer` / `LabeledSampledTimer`
- multi-entry per-thread cache for dynamic-metric label lookup (was single-entry)
- `MinGauge::new()` / `MinGaugeF64::new()` no longer silently no-op against positive observations (#9)
- bench harness updates: CPU workload, `metrics` crate comparison mode, refreshed report renderer

Full notes in `RELEASE_NOTES.md`.

## Release plan after merge
1. `cargo publish -p fast-telemetry-macros`
2. `cargo publish -p fast-telemetry`
3. `git tag v0.1.1 && git push origin v0.1.1`