### PR TITLE
bench: noisy-neighbor preflight check

### DIFF
--- a/crates/fast-telemetry/bench/preflight.sh
+++ b/crates/fast-telemetry/bench/preflight.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Preflight check: refuses to run benches when the box is too noisy to produce
+# decision-quality numbers. Captures host metadata so retroactive comparisons
+# can flag dirty runs.
+#
+# Usage:
+#   preflight.sh <host_json_out_path>
+#
+# Env:
+#   BENCH_SKIP_PREFLIGHT=1   bypass the load-avg block (warning still printed)
+#   BENCH_LOAD_THRESHOLD=N   override load-avg threshold (default cores/8)
+#   BENCH_TOP_PROC_PCT=N     override per-proc warn threshold (default 5)
+
+HOST_JSON_OUT="${1:?usage: preflight.sh <host_json_out>}"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  CORES="$(sysctl -n hw.ncpu)"
+  CPU_BRAND="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)"
+  MEM_BYTES="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
+else
+  CORES="$(nproc)"
+  CPU_BRAND="$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed -E 's/^ +//' || echo unknown)"
+  MEM_BYTES="$(awk '/MemTotal/ {print $2 * 1024}' /proc/meminfo 2>/dev/null || echo 0)"
+fi
+
+LOAD_THRESHOLD="${BENCH_LOAD_THRESHOLD:-$(awk -v c="$CORES" 'BEGIN { printf "%.2f", c / 8.0 }')}"
+TOP_PROC_PCT="${BENCH_TOP_PROC_PCT:-5}"
+
+LOAD_LINE="$(uptime | sed -E 's/.*load averages?: //' | tr -d ',')"
+LOAD_1="$(awk '{print $1}' <<<"$LOAD_LINE")"
+LOAD_5="$(awk '{print $2}' <<<"$LOAD_LINE")"
+LOAD_15="$(awk '{print $3}' <<<"$LOAD_LINE")"
+
+# Top non-bench CPU consumers (pcpu, comm). Trim full paths to basename.
+TOP_RAW="$(ps -A -o pcpu,comm | sort -k1 -nr | awk 'NR>0 && $1+0 > 0 { sub(".*/", "", $2); print }' | head -10)"
+
+GIT_REV="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+  GIT_DIRTY="true"
+else
+  GIT_DIRTY="false"
+fi
+RUSTC_VERSION="$(rustc --version 2>/dev/null || echo unknown)"
+KERNEL="$(uname -sr)"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+echo "=== bench preflight ==="
+echo "host:    $CPU_BRAND ($CORES cores)"
+echo "load:    $LOAD_1 / $LOAD_5 / $LOAD_15 (1m / 5m / 15m), threshold $LOAD_THRESHOLD"
+echo "git:     $GIT_REV (dirty=$GIT_DIRTY)"
+echo "rustc:   $RUSTC_VERSION"
+
+OVER_THRESHOLD="$(awk -v l="$LOAD_1" -v t="$LOAD_THRESHOLD" 'BEGIN { print (l > t) ? 1 : 0 }')"
+
+NOISY_PROCS=""
+while IFS= read -r line; do
+  pcpu="$(awk '{print $1}' <<<"$line")"
+  comm="$(awk '{$1=""; sub(/^ +/, ""); print}' <<<"$line")"
+  over="$(awk -v p="$pcpu" -v t="$TOP_PROC_PCT" 'BEGIN { print (p+0 >= t+0) ? 1 : 0 }')"
+  if [[ "$over" == "1" ]]; then
+    NOISY_PROCS+="    $line"$'\n'
+  fi
+done <<< "$TOP_RAW"
+
+if [[ -n "$NOISY_PROCS" ]]; then
+  echo ""
+  echo "noisy neighbors (>=${TOP_PROC_PCT}% CPU):"
+  printf "%s" "$NOISY_PROCS"
+fi
+
+# Build host.json.
+TOP_JSON_LINES=""
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  pcpu="$(awk '{print $1}' <<<"$line")"
+  comm="$(awk '{$1=""; sub(/^ +/, ""); gsub(/"/, "\\\""); print}' <<<"$line")"
+  TOP_JSON_LINES+="    {\"pcpu\": $pcpu, \"comm\": \"$comm\"},"$'\n'
+done <<< "$TOP_RAW"
+TOP_JSON_LINES="${TOP_JSON_LINES%,$'\n'}"
+
+mkdir -p "$(dirname "$HOST_JSON_OUT")"
+cat > "$HOST_JSON_OUT" <<EOF
+{
+  "timestamp_utc": "$TIMESTAMP",
+  "kernel": "$KERNEL",
+  "cpu_brand": "$CPU_BRAND",
+  "cores": $CORES,
+  "mem_bytes": $MEM_BYTES,
+  "load_avg": { "1min": $LOAD_1, "5min": $LOAD_5, "15min": $LOAD_15 },
+  "load_threshold": $LOAD_THRESHOLD,
+  "git_rev": "$GIT_REV",
+  "git_dirty": $GIT_DIRTY,
+  "rustc": "$RUSTC_VERSION",
+  "top_consumers": [
+$TOP_JSON_LINES
+  ]
+}
+EOF
+
+echo ""
+echo "host.json: $HOST_JSON_OUT"
+
+if [[ "$OVER_THRESHOLD" == "1" ]]; then
+  if [[ "${BENCH_SKIP_PREFLIGHT:-0}" == "1" ]]; then
+    echo ""
+    echo "WARNING: 1-min load avg $LOAD_1 exceeds $LOAD_THRESHOLD; running anyway (BENCH_SKIP_PREFLIGHT=1)."
+    exit 0
+  else
+    echo ""
+    echo "ERROR: 1-min load avg $LOAD_1 exceeds threshold $LOAD_THRESHOLD."
+    echo "       The bench will measure noise, not signal. Quit the listed apps and rerun,"
+    echo "       or set BENCH_SKIP_PREFLIGHT=1 to bypass."
+    exit 1
+  fi
+fi
+
+exit 0

--- a/crates/fast-telemetry/bench/run-bench-suite.sh
+++ b/crates/fast-telemetry/bench/run-bench-suite.sh
@@ -13,6 +13,7 @@ ITERS_SPAN="300000"
 EXPORT_INTERVAL_MS="10"
 ITERS_CACHE_SET=0
 ITERS_SPAN_SET=0
+SKIP_PREFLIGHT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -23,13 +24,18 @@ while [[ $# -gt 0 ]]; do
     --iters-cache) ITERS_CACHE="$2"; ITERS_CACHE_SET=1; shift 2 ;;
     --iters-span) ITERS_SPAN="$2"; ITERS_SPAN_SET=1; shift 2 ;;
     --export-interval-ms) EXPORT_INTERVAL_MS="$2"; shift 2 ;;
+    --skip-preflight) SKIP_PREFLIGHT=1; shift ;;
     --help)
-      echo "Usage: $0 [--threads N] [--runs N] [--preset quick|full] [--modes list] [--iters-cache N] [--iters-span N] [--export-interval-ms N]"
+      echo "Usage: $0 [--threads N] [--runs N] [--preset quick|full] [--modes list] [--iters-cache N] [--iters-span N] [--export-interval-ms N] [--skip-preflight]"
       echo ""
       echo "Runs matrix workloads and generates an HTML report with SVG charts."
       echo "Default modes: fast,otel,atomic (atomic applies only to cache counter cases; metrics can be added via --modes)"
       echo "Preset quick defaults: iters-cache=10000000, iters-span=300000"
       echo "Preset full defaults:  iters-cache=50000000, iters-span=1000000"
+      echo ""
+      echo "Refuses to run if 1-min load avg exceeds cores/8 (host is too noisy"
+      echo "to produce decision-quality numbers). Override with --skip-preflight"
+      echo "or BENCH_SKIP_PREFLIGHT=1."
       exit 0
       ;;
     *)
@@ -58,6 +64,15 @@ echo "=== fast-telemetry bench suite ==="
 echo "threads=$THREADS runs=$RUNS preset=$PRESET modes=$MODES_CSV"
 echo "iters_cache=$ITERS_CACHE iters_span=$ITERS_SPAN export_interval_ms=$EXPORT_INTERVAL_MS"
 echo "suite_dir=$SUITE_DIR"
+echo ""
+
+if [[ "$SKIP_PREFLIGHT" == "1" ]]; then
+  BENCH_SKIP_PREFLIGHT=1 "$SCRIPT_DIR/preflight.sh" "$SUITE_DIR/host.json"
+else
+  "$SCRIPT_DIR/preflight.sh" "$SUITE_DIR/host.json"
+fi
+
+echo ""
 
 "$SCRIPT_DIR/run-bench-matrix.sh" \
   --threads "$THREADS" \


### PR DESCRIPTION
## Summary
The recent harness run on macOS showed 3.6× run-to-run variance (counter_uniform fast: 1.04B – 3.77B ops/s across 3 runs). Cause was ambient host load (Arc browser ~30%, WindowServer ~30%, multiple VS Code procs ~20%, etc.) totaling ~1 core of contention on a 10-core box.

This adds a preflight that refuses to run the suite when the host is too noisy and captures host metadata so retroactive comparisons can flag dirty historical runs.

## Behavior
- Blocks if 1-min load avg > cores/8 (1.25 on a 10-core box)
- Lists top non-system CPU consumers >=5%
- Writes `host.json` to the suite dir with: timestamp, kernel, CPU brand, cores, mem, load avg (1/5/15), git rev (+ dirty bit), rustc version, top consumers
- Override: `--skip-preflight` flag or `BENCH_SKIP_PREFLIGHT=1` env var
- Tunable: `BENCH_LOAD_THRESHOLD`, `BENCH_TOP_PROC_PCT`

## Why threshold = cores/8
On a 10-core box that's load avg 1.25, ~12.5% sustained utilization. Lower than that and the bench should see ≤10% noise floor. The user can tune up if their workflow allows a busier host.

## Test plan
- [x] Tested standalone: `preflight.sh /tmp/host.json` correctly blocks (exit 1) under current dirty state (load 4.71)
- [x] `BENCH_SKIP_PREFLIGHT=1 preflight.sh ...` warns and exits 0
- [x] `host.json` parses as valid JSON
- [ ] After merge: real bench run with neighbors quit, see if variance actually collapses

If preflight alone makes the bench legible, no further harness fundamentals (warmup, ≥2s iters, trimmed mean, CV reporting) are needed.