### PR TITLE
bench: variance-fighting harness changes

### DIFF
--- a/crates/fast-telemetry/bench/render_suite_report.py
+++ b/crates/fast-telemetry/bench/render_suite_report.py
@@ -18,6 +18,14 @@ def parse_kv(path: pathlib.Path) -> Dict[str, str]:
     return out
 
 
+def _f(row: Dict[str, str], *keys: str) -> float:
+    """Read the first present column; tolerates renames between summary versions."""
+    for k in keys:
+        if k in row and row[k] not in (None, ""):
+            return float(row[k])
+    return 0.0
+
+
 def read_summary(path: pathlib.Path) -> Dict[str, Dict[str, float]]:
     out: Dict[str, Dict[str, float]] = {}
     with path.open(newline="") as f:
@@ -25,15 +33,16 @@ def read_summary(path: pathlib.Path) -> Dict[str, Dict[str, float]]:
             mode = row["mode"]
             out[mode] = {
                 "runs": float(row["runs"]),
-                "record_med": float(row["median_record_ops_per_sec"]),
-                "total_med": float(row["median_total_ops_per_sec"]),
-                "total_min": float(row["min_total_ops_per_sec"]),
-                "total_max": float(row["max_total_ops_per_sec"]),
-                "export_med_ms": float(row["median_export_avg_ms"]),
-                "cpu_total_med_s": float(row.get("median_cpu_total_seconds", 0.0) or 0.0),
-                "cpu_avg_cores": float(row.get("median_cpu_avg_cores", 0.0) or 0.0),
-                "cpu_util_pct": float(row.get("median_cpu_utilization_pct", 0.0) or 0.0),
-                "cpu_ns_per_op": float(row.get("median_cpu_ns_per_op", 0.0) or 0.0),
+                "record_med": _f(row, "trimmed_record_ops_per_sec", "median_record_ops_per_sec"),
+                "total_med": _f(row, "trimmed_total_ops_per_sec", "median_total_ops_per_sec"),
+                "total_min": _f(row, "min_total_ops_per_sec"),
+                "total_max": _f(row, "max_total_ops_per_sec"),
+                "total_cv_pct": _f(row, "total_cv_pct"),
+                "export_med_ms": _f(row, "trimmed_export_avg_ms", "median_export_avg_ms"),
+                "cpu_total_med_s": _f(row, "trimmed_cpu_total_seconds", "median_cpu_total_seconds"),
+                "cpu_avg_cores": _f(row, "trimmed_cpu_avg_cores", "median_cpu_avg_cores"),
+                "cpu_util_pct": _f(row, "trimmed_cpu_utilization_pct", "median_cpu_utilization_pct"),
+                "cpu_ns_per_op": _f(row, "trimmed_cpu_ns_per_op", "median_cpu_ns_per_op"),
             }
     return out
 

--- a/crates/fast-telemetry/bench/run-bench-matrix.sh
+++ b/crates/fast-telemetry/bench/run-bench-matrix.sh
@@ -5,9 +5,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results"
 
 THREADS="$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)"
-ITERS_CACHE="10000000"
-ITERS_SPAN="300000"
-RUNS="3"
+ITERS_CACHE="50000000"
+ITERS_SPAN="1000000"
+RUNS="9"
 PRESET="quick"
 EXPORT_INTERVAL_MS="10"
 MODES_CSV="fast,otel"
@@ -30,12 +30,12 @@ while [[ $# -gt 0 ]]; do
       echo "  cache entities: counter,dynamic_counter,labeled_counter,dynamic_histogram"
       echo "  cache profiles: uniform,hotspot"
       echo "  span scenarios: root,lifecycle,pipeline"
-      echo "  default iters: cache=10000000 span=300000"
+      echo "  default iters: cache=50000000 span=1000000"
       echo "Preset full:"
       echo "  cache entities: all cache benchmark entities"
       echo "  cache profiles: uniform,hotspot,churn"
       echo "  span scenarios: root,lifecycle,pipeline"
-      echo "  default iters: cache=50000000 span=1000000"
+      echo "  default iters: cache=200000000 span=5000000"
       echo "Modes may include metrics for cache entities with direct metrics-rs equivalents."
       exit 0
       ;;
@@ -56,10 +56,10 @@ esac
 
 if [[ "$PRESET" == "full" ]]; then
   if [[ "$ITERS_CACHE_SET" == "0" ]]; then
-    ITERS_CACHE="50000000"
+    ITERS_CACHE="200000000"
   fi
   if [[ "$ITERS_SPAN_SET" == "0" ]]; then
-    ITERS_SPAN="1000000"
+    ITERS_SPAN="5000000"
   fi
 fi
 

--- a/crates/fast-telemetry/bench/run-bench-suite.sh
+++ b/crates/fast-telemetry/bench/run-bench-suite.sh
@@ -5,15 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESULTS_DIR="$SCRIPT_DIR/results"
 
 THREADS="$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)"
-RUNS="5"
+RUNS="9"
 PRESET="quick"
 MODES_CSV="fast,otel,atomic"
-ITERS_CACHE="10000000"
-ITERS_SPAN="300000"
+ITERS_CACHE="50000000"
+ITERS_SPAN="1000000"
 EXPORT_INTERVAL_MS="10"
 ITERS_CACHE_SET=0
 ITERS_SPAN_SET=0
-SKIP_PREFLIGHT=0
+STRICT_PREFLIGHT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,18 +24,18 @@ while [[ $# -gt 0 ]]; do
     --iters-cache) ITERS_CACHE="$2"; ITERS_CACHE_SET=1; shift 2 ;;
     --iters-span) ITERS_SPAN="$2"; ITERS_SPAN_SET=1; shift 2 ;;
     --export-interval-ms) EXPORT_INTERVAL_MS="$2"; shift 2 ;;
-    --skip-preflight) SKIP_PREFLIGHT=1; shift ;;
+    --strict-preflight) STRICT_PREFLIGHT=1; shift ;;
+    --skip-preflight) STRICT_PREFLIGHT=0; shift ;;
     --help)
-      echo "Usage: $0 [--threads N] [--runs N] [--preset quick|full] [--modes list] [--iters-cache N] [--iters-span N] [--export-interval-ms N] [--skip-preflight]"
+      echo "Usage: $0 [--threads N] [--runs N] [--preset quick|full] [--modes list] [--iters-cache N] [--iters-span N] [--export-interval-ms N] [--strict-preflight]"
       echo ""
       echo "Runs matrix workloads and generates an HTML report with SVG charts."
       echo "Default modes: fast,otel,atomic (atomic applies only to cache counter cases; metrics can be added via --modes)"
-      echo "Preset quick defaults: iters-cache=10000000, iters-span=300000"
-      echo "Preset full defaults:  iters-cache=50000000, iters-span=1000000"
+      echo "Preset quick defaults: iters-cache=50000000, iters-span=1000000, runs=9"
+      echo "Preset full defaults:  iters-cache=200000000, iters-span=5000000, runs=9"
       echo ""
-      echo "Refuses to run if 1-min load avg exceeds cores/8 (host is too noisy"
-      echo "to produce decision-quality numbers). Override with --skip-preflight"
-      echo "or BENCH_SKIP_PREFLIGHT=1."
+      echo "By default, preflight only warns about a noisy host. Pass --strict-preflight"
+      echo "to refuse to run when 1-min load avg exceeds cores/8."
       exit 0
       ;;
     *)
@@ -47,10 +47,10 @@ done
 
 if [[ "$PRESET" == "full" ]]; then
   if [[ "$ITERS_CACHE_SET" == "0" ]]; then
-    ITERS_CACHE="50000000"
+    ITERS_CACHE="200000000"
   fi
   if [[ "$ITERS_SPAN_SET" == "0" ]]; then
-    ITERS_SPAN="1000000"
+    ITERS_SPAN="5000000"
   fi
 fi
 
@@ -66,10 +66,10 @@ echo "iters_cache=$ITERS_CACHE iters_span=$ITERS_SPAN export_interval_ms=$EXPORT
 echo "suite_dir=$SUITE_DIR"
 echo ""
 
-if [[ "$SKIP_PREFLIGHT" == "1" ]]; then
-  BENCH_SKIP_PREFLIGHT=1 "$SCRIPT_DIR/preflight.sh" "$SUITE_DIR/host.json"
-else
+if [[ "$STRICT_PREFLIGHT" == "1" ]]; then
   "$SCRIPT_DIR/preflight.sh" "$SUITE_DIR/host.json"
+else
+  BENCH_SKIP_PREFLIGHT=1 "$SCRIPT_DIR/preflight.sh" "$SUITE_DIR/host.json"
 fi
 
 echo ""

--- a/crates/fast-telemetry/bench/summarize_bench.py
+++ b/crates/fast-telemetry/bench/summarize_bench.py
@@ -5,6 +5,32 @@ import statistics
 import sys
 
 
+def trimmed_mean(vals):
+    """Mean after dropping the highest and lowest values.
+
+    For >=5 runs, drops floor((n-1)/4) from each side. This makes a single
+    process spike during one run not poison the headline number. For <5 runs,
+    falls back to the median.
+    """
+    if not vals:
+        return 0.0
+    if len(vals) < 5:
+        return statistics.median(vals)
+    trim = (len(vals) - 1) // 4
+    sorted_vals = sorted(vals)
+    return statistics.fmean(sorted_vals[trim:len(sorted_vals) - trim])
+
+
+def cv_pct(vals):
+    """Coefficient of variation as a percentage. <10% is decision-quality."""
+    if len(vals) < 2:
+        return 0.0
+    mean = statistics.fmean(vals)
+    if mean == 0.0:
+        return 0.0
+    return (statistics.stdev(vals) / mean) * 100.0
+
+
 def parse_mode(run_dir: pathlib.Path, mode: str):
     record_vals = []
     total_vals = []
@@ -62,17 +88,17 @@ def parse_mode(run_dir: pathlib.Path, mode: str):
             cpu_util_vals.append(cpu_utilization)
         if cpu_ns_per_op is not None:
             cpu_ns_per_op_vals.append(cpu_ns_per_op)
-    return (
-        record_vals,
-        total_vals,
-        export_vals,
-        cpu_user_vals,
-        cpu_system_vals,
-        cpu_total_vals,
-        cpu_core_vals,
-        cpu_util_vals,
-        cpu_ns_per_op_vals,
-    )
+    return {
+        "record": record_vals,
+        "total": total_vals,
+        "export": export_vals,
+        "cpu_user": cpu_user_vals,
+        "cpu_system": cpu_system_vals,
+        "cpu_total": cpu_total_vals,
+        "cpu_cores": cpu_core_vals,
+        "cpu_util": cpu_util_vals,
+        "cpu_ns_per_op": cpu_ns_per_op_vals,
+    }
 
 
 def main() -> int:
@@ -81,120 +107,69 @@ def main() -> int:
 
     rows = []
     for mode in modes:
-        (
-            record_vals,
-            total_vals,
-            export_vals,
-            cpu_user_vals,
-            cpu_system_vals,
-            cpu_total_vals,
-            cpu_core_vals,
-            cpu_util_vals,
-            cpu_ns_per_op_vals,
-        ) = parse_mode(run_dir, mode)
-        if not total_vals:
+        vals = parse_mode(run_dir, mode)
+        if not vals["total"]:
             continue
-        rows.append(
-            (
-                mode,
-                record_vals,
-                total_vals,
-                export_vals,
-                cpu_user_vals,
-                cpu_system_vals,
-                cpu_total_vals,
-                cpu_core_vals,
-                cpu_util_vals,
-                cpu_ns_per_op_vals,
-                statistics.median(record_vals) if record_vals else 0.0,
-                statistics.median(total_vals),
-                min(total_vals),
-                max(total_vals),
-                statistics.median(export_vals) if export_vals else 0.0,
-                statistics.median(cpu_user_vals) if cpu_user_vals else 0.0,
-                statistics.median(cpu_system_vals) if cpu_system_vals else 0.0,
-                statistics.median(cpu_total_vals) if cpu_total_vals else 0.0,
-                statistics.median(cpu_core_vals) if cpu_core_vals else 0.0,
-                statistics.median(cpu_util_vals) if cpu_util_vals else 0.0,
-                statistics.median(cpu_ns_per_op_vals) if cpu_ns_per_op_vals else 0.0,
-            )
-        )
+        rows.append({
+            "mode": mode,
+            "n": len(vals["total"]),
+            "record_tm": trimmed_mean(vals["record"]),
+            "total_tm": trimmed_mean(vals["total"]),
+            "total_min": min(vals["total"]),
+            "total_max": max(vals["total"]),
+            "total_cv_pct": cv_pct(vals["total"]),
+            "export_tm": trimmed_mean(vals["export"]),
+            "cpu_user_tm": trimmed_mean(vals["cpu_user"]),
+            "cpu_system_tm": trimmed_mean(vals["cpu_system"]),
+            "cpu_total_tm": trimmed_mean(vals["cpu_total"]),
+            "cpu_cores_tm": trimmed_mean(vals["cpu_cores"]),
+            "cpu_util_tm": trimmed_mean(vals["cpu_util"]),
+            "cpu_ns_per_op_tm": trimmed_mean(vals["cpu_ns_per_op"]),
+        })
 
-    summary = [
-        "mode,runs,median_record_ops_per_sec,median_total_ops_per_sec,min_total_ops_per_sec,max_total_ops_per_sec,median_export_avg_ms,median_cpu_user_seconds,median_cpu_system_seconds,median_cpu_total_seconds,median_cpu_avg_cores,median_cpu_utilization_pct,median_cpu_ns_per_op"
+    csv_lines = [
+        "mode,runs,trimmed_record_ops_per_sec,trimmed_total_ops_per_sec,"
+        "min_total_ops_per_sec,max_total_ops_per_sec,total_cv_pct,"
+        "trimmed_export_avg_ms,trimmed_cpu_user_seconds,trimmed_cpu_system_seconds,"
+        "trimmed_cpu_total_seconds,trimmed_cpu_avg_cores,trimmed_cpu_utilization_pct,"
+        "trimmed_cpu_ns_per_op"
     ]
-    for (
-        mode,
-        _,
-        total_vals,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-        med_record,
-        med_total,
-        lo_total,
-        hi_total,
-        med_export,
-        med_cpu_user,
-        med_cpu_system,
-        med_cpu_total,
-        med_cpu_cores,
-        med_cpu_util,
-        med_cpu_ns_per_op,
-    ) in rows:
-        summary.append(
-            f"{mode},{len(total_vals)},{med_record:.2f},{med_total:.2f},{lo_total:.2f},{hi_total:.2f},{med_export:.6f},{med_cpu_user:.6f},{med_cpu_system:.6f},{med_cpu_total:.6f},{med_cpu_cores:.6f},{med_cpu_util:.2f},{med_cpu_ns_per_op:.2f}"
+    for r in rows:
+        csv_lines.append(
+            f"{r['mode']},{r['n']},{r['record_tm']:.2f},{r['total_tm']:.2f},"
+            f"{r['total_min']:.2f},{r['total_max']:.2f},{r['total_cv_pct']:.2f},"
+            f"{r['export_tm']:.6f},{r['cpu_user_tm']:.6f},{r['cpu_system_tm']:.6f},"
+            f"{r['cpu_total_tm']:.6f},{r['cpu_cores_tm']:.6f},{r['cpu_util_tm']:.2f},"
+            f"{r['cpu_ns_per_op_tm']:.2f}"
         )
-    (run_dir / "summary.csv").write_text("\n".join(summary) + "\n")
+    (run_dir / "summary.csv").write_text("\n".join(csv_lines) + "\n")
 
     print("")
-    print("Summary (median throughput and CPU cost, total min/max):")
-    for (
-        mode,
-        _,
-        total_vals,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-        med_record,
-        med_total,
-        lo_total,
-        hi_total,
-        med_export,
-        med_cpu_user,
-        med_cpu_system,
-        med_cpu_total,
-        med_cpu_cores,
-        med_cpu_util,
-        med_cpu_ns_per_op,
-    ) in rows:
+    print("Summary (trimmed mean throughput and CPU cost, total min/max, CV):")
+    for r in rows:
+        cv_marker = " [HIGH-CV]" if r["total_cv_pct"] > 10.0 else ""
         print(
-            f"  {mode:6s} runs={len(total_vals)} record_med={med_record:,.2f} total_med={med_total:,.2f} "
-            f"min={lo_total:,.2f} max={hi_total:,.2f} export_avg_ms={med_export:.6f} "
-            f"cpu_total_s={med_cpu_total:.6f} cpu_user_s={med_cpu_user:.6f} cpu_system_s={med_cpu_system:.6f} "
-            f"cpu_avg_cores={med_cpu_cores:.3f} cpu_util_pct={med_cpu_util:.2f} cpu_ns_per_op={med_cpu_ns_per_op:.2f}"
+            f"  {r['mode']:6s} runs={r['n']} record_tm={r['record_tm']:,.2f} "
+            f"total_tm={r['total_tm']:,.2f} min={r['total_min']:,.2f} max={r['total_max']:,.2f} "
+            f"cv={r['total_cv_pct']:.1f}%{cv_marker} "
+            f"export_avg_ms={r['export_tm']:.6f} "
+            f"cpu_total_s={r['cpu_total_tm']:.6f} cpu_user_s={r['cpu_user_tm']:.6f} "
+            f"cpu_system_s={r['cpu_system_tm']:.6f} cpu_avg_cores={r['cpu_cores_tm']:.3f} "
+            f"cpu_util_pct={r['cpu_util_tm']:.2f} cpu_ns_per_op={r['cpu_ns_per_op_tm']:.2f}"
         )
 
     if rows:
-        med = {row[0]: row[11] for row in rows}
-        if "fast" in med and "metrics" in med:
-            print(f"  fast/metrics total speedup: {med['fast'] / med['metrics']:.2f}x")
-        if "fast" in med and "atomic" in med:
-            print(f"  fast/atomic total speedup: {med['fast'] / med['atomic']:.2f}x")
-        if "fast" in med and "otel" in med:
-            print(f"  fast/otel total speedup:   {med['fast'] / med['otel']:.2f}x")
-        if "metrics" in med and "otel" in med:
-            print(f"  metrics/otel total speedup:{med['metrics'] / med['otel']:.2f}x")
-        if "atomic" in med and "otel" in med:
-            print(f"  atomic/otel total speedup: {med['atomic'] / med['otel']:.2f}x")
+        tm = {r["mode"]: r["total_tm"] for r in rows}
+        if "fast" in tm and "metrics" in tm:
+            print(f"  fast/metrics total speedup: {tm['fast'] / tm['metrics']:.2f}x")
+        if "fast" in tm and "atomic" in tm:
+            print(f"  fast/atomic total speedup: {tm['fast'] / tm['atomic']:.2f}x")
+        if "fast" in tm and "otel" in tm:
+            print(f"  fast/otel total speedup:   {tm['fast'] / tm['otel']:.2f}x")
+        if "metrics" in tm and "otel" in tm:
+            print(f"  metrics/otel total speedup:{tm['metrics'] / tm['otel']:.2f}x")
+        if "atomic" in tm and "otel" in tm:
+            print(f"  atomic/otel total speedup: {tm['atomic'] / tm['otel']:.2f}x")
 
     return 0
 

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -286,12 +286,17 @@ where
     });
 
     let worker = Arc::new(worker);
+    let warmup_iters = (iters / 10).max(1);
     let mut workers = Vec::with_capacity(threads);
     for t in 0..threads {
         let worker_fn = Arc::clone(&worker);
         let worker_barrier = Arc::clone(&barrier);
         workers.push(std::thread::spawn(move || {
             thread_affinity::pin_worker_thread(t, thread_affinity);
+            // Warmup pass: warms up the dynamic-metric cache, branch predictor,
+            // page tables, and JIT'd inline paths. Discarded from measurement
+            // because it runs before the barrier release.
+            worker_fn(t, warmup_iters);
             worker_barrier.wait();
             worker_fn(t, iters);
         }));

--- a/crates/fast-telemetry/bench/workloads/span_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/span_contention.rs
@@ -161,12 +161,16 @@ where
     });
 
     let worker = Arc::new(worker);
+    let warmup_iters = (iters / 10).max(1);
     let mut workers = Vec::with_capacity(threads);
     for t in 0..threads {
         let worker_fn = Arc::clone(&worker);
         let worker_barrier = Arc::clone(&barrier);
         workers.push(std::thread::spawn(move || {
             thread_affinity::pin_worker_thread(t, thread_affinity);
+            // Warmup pass: discarded from measurement because it runs before
+            // the barrier release.
+            worker_fn(t, warmup_iters);
             worker_barrier.wait();
             worker_fn(t, iters);
         }));


### PR DESCRIPTION
Follow-up to #12. Makes the harness produce decision-quality numbers when the host has ambient load (i.e. the realistic dev-box case).

## Changes
| Change | Why |
|---|---|
| Discarded warmup pass per worker thread | Cache lines, branch predictor, and dynamic-metric registries are warm before measurement starts. Runs `worker_fn(t, iters/10)` before the barrier release. |
| Default `--runs` 5→9 (suite), 3→9 (matrix) | Enough samples for trimmed mean to drop transient outliers. |
| Iters defaults bumped 5× | Quick: cache 10M→50M, span 300K→1M. Full: cache 50M→200M, span 1M→5M. Pushes runs past sub-scheduler-quantum so process spikes contribute proportionally less. |
| Trimmed mean replaces median in `summarize_bench.py` | Drops floor((n-1)/4) from each side. Single-run process spikes don't poison the headline number. |
| CV% column + `[HIGH-CV]` marker when >10% | Meta-signal: bench tells you "this run is trustworthy" or "rerun under quieter conditions". |
| Preflight defaults to warn-only | Blocking by default was unworkable when user can't quit noisy apps. `--strict-preflight` re-enables blocking. |

## Compat
- CSV column names changed (`median_*` → `trimmed_*`). `render_suite_report.py` reads either name, so old historical `summary.csv` files still render.
- Smoke-tested `summarize_bench.py` against an existing 3-run cache result (`cache_20260427_161419`): produces correct trimmed mean (= median when n<5) and CV.

## Test plan
- [x] `cargo build --release --bin bench_cache_contention --bin bench_span_contention --features bench-tools`
- [x] `cargo clippy -p fast-telemetry --features bench-tools --bins` (clean)
- [x] `cargo fmt -p fast-telemetry --check` (clean)
- [x] `cargo test -p fast-telemetry --lib` (133 passed)
- [x] `summarize_bench.py` smoke-tested against existing 3-run data; CV computed
- [ ] After merge: real bench run with apps still open. Variance should collapse from ~50% spread to <15% CV.

## What's NOT in this PR (deferred)
- CPU-time clock (`clock_gettime(CLOCK_THREAD_CPUTIME_ID)`) — requires libc shimming per platform. Useful for noisy-host tolerance but the warmup + longer iters + trimmed mean should already get us most of the way. Add later if CV is still >10% after this lands.
- `--min-seconds N` auto-calibration of iters — would refactor `run_with_threads` signature across ~15 call sites. Defer unless needed.

Closes the harness fundamentals so the actual perf-opt branches (Tier 1/2 from the optimization review) can produce defensible A/B numbers.