### PR TITLE
perf(export): use itoa/ryu for numeric formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.1.
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"
+itoa = "1"
 parking_lot = "0.12"
+ryu = "1"
 uuid = { version = "1", features = ["v4"] }
 
 # --- Macros: fast-telemetry-macros proc-macro dependencies ---

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -26,6 +26,7 @@ eviction = []
 [dependencies]
 crossbeam-utils = { workspace = true }
 fast-telemetry-macros = { workspace = true, optional = true }
+itoa = { workspace = true }
 libc = { version = "0.2", optional = true }
 metrics = { workspace = true, optional = true }
 metrics-util = { workspace = true, optional = true }
@@ -34,6 +35,7 @@ opentelemetry-proto = { version = "0.30", default-features = false, features = [
 opentelemetry_sdk = { workspace = true, optional = true, features = ["testing"] }
 parking_lot = { workspace = true }
 prost = { version = "0.13", optional = true }
+ryu = { workspace = true }
 shuttle = { workspace = true, optional = true }
 uuid = { workspace = true }
 

--- a/crates/fast-telemetry/src/export/text/dogstatsd.rs
+++ b/crates/fast-telemetry/src/export/text/dogstatsd.rs
@@ -4,7 +4,8 @@ use crate::{
     LabeledGauge, LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MinGauge,
     MinGaugeF64, SampledTimer, exp_buckets::ExpBucketsSnapshot,
 };
-use std::fmt::{Display, Write as _};
+
+use super::fast_format::{FastFormat, push_f64_compact};
 
 /// Trait for exporting a metric in DogStatsD format.
 ///
@@ -23,27 +24,14 @@ pub trait DogStatsDExport {
     fn export_dogstatsd(&self, output: &mut String, name: &str, tags: &[(&str, &str)]);
 }
 
-fn push_display(output: &mut String, value: impl Display) {
-    let _ = write!(output, "{}", value);
+#[inline]
+fn push_display<T: FastFormat>(output: &mut String, value: T) {
+    value.fast_push(output);
 }
 
+#[inline]
 fn write_gauge_f64_value(output: &mut String, value: f64) {
-    if value.fract() == 0.0 {
-        push_display(output, value as i64);
-        return;
-    }
-
-    let start_len = output.len();
-    let _ = write!(output, "{:.6}", value);
-    while output.ends_with('0') {
-        output.pop();
-    }
-    if output.ends_with('.') {
-        output.pop();
-    }
-    if output.len() == start_len {
-        output.push('0');
-    }
+    push_f64_compact(output, value);
 }
 
 /// Helper to append tags in DogStatsD format: `|#tag1:value1,tag2:value2`
@@ -119,7 +107,7 @@ fn append_tags_with_dynamic_labels(
 pub fn __write_dogstatsd(
     output: &mut String,
     name: &str,
-    value: impl Display,
+    value: impl FastFormat,
     metric_type: &str,
     tags: &[(&str, &str)],
 ) {
@@ -136,7 +124,7 @@ pub fn __write_dogstatsd(
 pub fn __write_dogstatsd_with_label(
     output: &mut String,
     name: &str,
-    value: impl Display,
+    value: impl FastFormat,
     metric_type: &str,
     label_name: &str,
     label_value: &str,
@@ -155,7 +143,7 @@ pub fn __write_dogstatsd_with_label(
 pub fn __write_dogstatsd_dynamic(
     output: &mut String,
     name: &str,
-    value: impl Display,
+    value: impl FastFormat,
     metric_type: &str,
     labels: &DynamicLabelSet,
     tags: &[(&str, &str)],
@@ -173,7 +161,7 @@ pub fn __write_dogstatsd_dynamic(
 pub fn __write_dogstatsd_dynamic_pairs(
     output: &mut String,
     name: &str,
-    value: impl Display,
+    value: impl FastFormat,
     metric_type: &str,
     labels: &[(String, String)],
     tags: &[(&str, &str)],
@@ -198,7 +186,7 @@ fn write_distribution_sample(output: &mut String, name: &str, value: u64, count:
     if count > 1 {
         // sample_rate = 1/count tells the agent to multiply this sample by count
         output.push_str("|@");
-        let _ = write!(output, "{}", 1.0 / count as f64);
+        (1.0_f64 / count as f64).fast_push(output);
     }
 }
 

--- a/crates/fast-telemetry/src/export/text/fast_format.rs
+++ b/crates/fast-telemetry/src/export/text/fast_format.rs
@@ -1,0 +1,63 @@
+//! Fast numeric-to-string formatting for the text exporters.
+//!
+//! `core::fmt::Display` goes through the `Formatter` machinery (padding, alignment,
+//! locale checks, dynamic dispatch). For metric exports that emit thousands of
+//! integers and floats per scrape, `itoa` and `ryu` are 3-8x faster because they
+//! write directly to a stack buffer. This trait centralizes that dispatch.
+//!
+//! `FastFormat` is impl'd for the primitive numeric types this crate emits.
+//! Floats use `ryu`'s shortest-roundtrip form, which is canonical for both
+//! Prometheus exposition and DogStatsD.
+
+/// Internal trait for fast numeric serialization. Exposed only because the
+/// `__write_dogstatsd*` macro-support functions reference it in their public
+/// signatures; not part of the stable API.
+#[doc(hidden)]
+pub trait FastFormat {
+    fn fast_push(self, output: &mut String);
+}
+
+macro_rules! impl_int {
+    ($($t:ty),*) => {
+        $(
+            impl FastFormat for $t {
+                #[inline]
+                fn fast_push(self, output: &mut String) {
+                    let mut buf = itoa::Buffer::new();
+                    output.push_str(buf.format(self));
+                }
+            }
+        )*
+    };
+}
+
+impl_int!(
+    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize
+);
+
+impl FastFormat for f32 {
+    #[inline]
+    fn fast_push(self, output: &mut String) {
+        let mut buf = ryu::Buffer::new();
+        output.push_str(buf.format(self));
+    }
+}
+
+impl FastFormat for f64 {
+    #[inline]
+    fn fast_push(self, output: &mut String) {
+        let mut buf = ryu::Buffer::new();
+        output.push_str(buf.format(self));
+    }
+}
+
+/// DogStatsD's compact form: whole numbers as integers ("1" not "1.0"),
+/// fractions as canonical f64.
+#[inline]
+pub(crate) fn push_f64_compact(output: &mut String, value: f64) {
+    if value.is_finite() && value.fract() == 0.0 && value.abs() < 9_007_199_254_740_992.0 {
+        (value as i64).fast_push(output);
+    } else {
+        value.fast_push(output);
+    }
+}

--- a/crates/fast-telemetry/src/export/text/mod.rs
+++ b/crates/fast-telemetry/src/export/text/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides Prometheus and DogStatsD export traits/implementations.
 
 mod dogstatsd;
+mod fast_format;
 mod prometheus;
 
 pub use dogstatsd::{
@@ -12,4 +13,5 @@ pub use dogstatsd::{
     __write_dogstatsd_dynamic, __write_dogstatsd_dynamic_pairs, __write_dogstatsd_with_label,
     DogStatsDExport,
 };
+pub use fast_format::FastFormat;
 pub use prometheus::PrometheusExport;

--- a/crates/fast-telemetry/src/export/text/prometheus.rs
+++ b/crates/fast-telemetry/src/export/text/prometheus.rs
@@ -1,10 +1,10 @@
+use super::fast_format::FastFormat;
 use crate::{
     Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
     DynamicHistogram, Gauge, GaugeF64, Histogram, LabelEnum, LabeledCounter, LabeledGauge,
     LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MinGauge, MinGaugeF64,
     SampledTimer,
 };
-use std::fmt::Write as _;
 
 /// Trait for exporting a metric in Prometheus text exposition format.
 pub trait PrometheusExport {
@@ -16,8 +16,9 @@ pub trait PrometheusExport {
     fn export_prometheus(&self, output: &mut String, name: &str, help: &str);
 }
 
-fn push_display(output: &mut String, value: impl std::fmt::Display) {
-    let _ = write!(output, "{}", value);
+#[inline]
+fn push_display<T: FastFormat>(output: &mut String, value: T) {
+    value.fast_push(output);
 }
 
 fn write_dynamic_labels(output: &mut String, labels: &[(String, String)]) {

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -44,6 +44,7 @@ pub mod __macro_support {
         __write_dogstatsd_distribution_delta_dynamic,
         __write_dogstatsd_distribution_delta_dynamic_pairs, __write_dogstatsd_distribution_dynamic,
         __write_dogstatsd_dynamic, __write_dogstatsd_dynamic_pairs, __write_dogstatsd_with_label,
+        FastFormat,
     };
 }
 pub use metric::{


### PR DESCRIPTION
**Phase 1** of the optimization roadmap. Independent, low-risk, easy to validate.

## Change
Both text exporters (Prometheus, DogStatsD) formatted every integer and float through \`core::fmt::Display\`, which goes through the Formatter machinery (padding, alignment, locale checks, dynamic dispatch). Replace with a sealed \`FastFormat\` trait backed by \`itoa\` (integers) and \`ryu\` (floats). Both crates use stack buffers, no allocation.

DogStatsD's whole-number shortcut (\`1.0\` -> \`"1"\` not \`"1.0"\`) is preserved via \`push_f64_compact\`.

## Behavior
ryu produces shortest-roundtrip canonical form, valid for both exposition formats. May emit scientific notation for extreme values where \`{:.6}\` produced fixed-point — both parse correctly.

## Files
- \`Cargo.toml\` + \`crates/fast-telemetry/Cargo.toml\`: add itoa, ryu deps
- \`src/export/text/fast_format.rs\` (new): trait + impls for u8..u128, i8..i128, usize, isize, f32, f64, plus \`push_f64_compact\`
- \`src/export/text/{prometheus,dogstatsd}.rs\`: \`push_display\` now bounds on \`FastFormat\` instead of \`Display\`. \`__write_dogstatsd*\` helpers updated to match.
- \`src/lib.rs\`: re-export \`FastFormat\` through \`__macro_support\`

## Test plan
- [x] \`cargo build -p fast-telemetry\`
- [x] \`cargo test -p fast-telemetry\` — 133 unit + 8 DogStatsD + 3 OTLP + 4 sampled-timer + 3 temporality tests pass
- [x] \`cargo test -p fast-telemetry --features bench-tools\` — same
- [x] \`cargo clippy -p fast-telemetry --all-targets\` — only pre-existing example warning
- [x] \`cargo fmt --check\` — clean
- [ ] Bench A/B against main using \`cpu_ns_per_op\` (pending — will run after all perf phases land, per user)

## Expected impact
Per the optimization review: 3-8× faster format path on large exports. Most visible on dynamic_histogram_* cases where bucket/sum/count formatting dominates. May not move the per-record hot path needle (record path doesn't format).