### PR TITLE
perf(dynamic): snapshot under read lock, format outside

### DIFF
--- a/crates/fast-telemetry/src/metric/dynamic/counter.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/counter.rs
@@ -267,16 +267,24 @@ impl DynamicCounter {
         self.overflow_count.load(Ordering::Relaxed)
     }
 
-    /// Iterate all series without cloning label sets.
+    /// Iterate all series without doing heavy work under the read lock.
     ///
-    /// Calls `f` with borrowed label pairs and the current sum for each series.
-    /// Used by exporters/macros to avoid the intermediate `snapshot()` allocation.
+    /// Snapshots `(label_set, sum)` pairs under the shard read lock, releases
+    /// the lock, then invokes `f` for each entry. This keeps writers from
+    /// stalling on the lock during the formatting / encoding work the exporter
+    /// does in `f`. Cloning the label set is a cheap `Arc` bump.
     #[doc(hidden)]
     pub fn visit_series(&self, mut f: impl FnMut(&[(String, String)], isize)) {
         for shard in &self.index_shards {
-            let guard = shard.read();
-            for (labels, series) in guard.iter() {
-                f(labels.pairs(), series.sum());
+            let snapshot: Vec<(DynamicLabelSet, isize)> = {
+                let guard = shard.read();
+                guard
+                    .iter()
+                    .map(|(labels, series)| (labels.clone(), series.sum()))
+                    .collect()
+            };
+            for (labels, sum) in &snapshot {
+                f(labels.pairs(), *sum);
             }
         }
     }

--- a/crates/fast-telemetry/src/metric/dynamic/distribution.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/distribution.rs
@@ -287,19 +287,23 @@ impl DynamicDistribution {
         self.overflow_count.load(Ordering::Relaxed)
     }
 
-    /// Iterate all series without cloning label sets.
+    /// Iterate all series without doing heavy work under the read lock.
     ///
-    /// Calls `f` with borrowed label pairs, count, sum, and bucket snapshot
-    /// for each series. Used by exporters/macros to avoid `snapshot()` cloning.
+    /// Snapshots under the lock, then invokes `f` outside; see [`DynamicCounter::visit_series`].
     #[doc(hidden)]
     pub fn visit_series(
         &self,
         mut f: impl FnMut(&[(String, String)], u64, u64, ExpBucketsSnapshot),
     ) {
         for shard in &self.index_shards {
-            let guard = shard.read();
-            for (labels, series) in guard.iter() {
-                let snap = series.buckets_snapshot();
+            let snapshot: Vec<(DynamicLabelSet, ExpBucketsSnapshot)> = {
+                let guard = shard.read();
+                guard
+                    .iter()
+                    .map(|(labels, series)| (labels.clone(), series.buckets_snapshot()))
+                    .collect()
+            };
+            for (labels, snap) in snapshot {
                 f(labels.pairs(), snap.count, snap.sum, snap);
             }
         }

--- a/crates/fast-telemetry/src/metric/dynamic/gauge.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/gauge.rs
@@ -224,15 +224,20 @@ impl DynamicGauge {
         self.overflow_count.load(Ordering::Relaxed)
     }
 
-    /// Iterate all series without cloning label sets.
+    /// Iterate all series without doing heavy work under the read lock.
     ///
-    /// Calls `f` with borrowed label pairs and the current value for each series.
-    /// Used by exporters to avoid the intermediate `snapshot()` allocation.
+    /// Snapshots under the lock, then invokes `f` outside; see [`DynamicCounter::visit_series`].
     pub(crate) fn visit_series(&self, mut f: impl FnMut(&[(String, String)], f64)) {
         for shard in &self.index_shards {
-            let guard = shard.read();
-            for (labels, series) in guard.iter() {
-                f(labels.pairs(), series.get());
+            let snapshot: Vec<(DynamicLabelSet, f64)> = {
+                let guard = shard.read();
+                guard
+                    .iter()
+                    .map(|(labels, series)| (labels.clone(), series.get()))
+                    .collect()
+            };
+            for (labels, value) in &snapshot {
+                f(labels.pairs(), *value);
             }
         }
     }

--- a/crates/fast-telemetry/src/metric/dynamic/gauge_i64.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/gauge_i64.rs
@@ -314,15 +314,20 @@ impl DynamicGaugeI64 {
         self.overflow_count.load(Ordering::Relaxed)
     }
 
-    /// Iterate all series without cloning label sets.
+    /// Iterate all series without doing heavy work under the read lock.
     ///
-    /// Calls `f` with borrowed label pairs and the current value for each series.
-    /// Used by exporters to avoid the intermediate `snapshot()` allocation.
+    /// Snapshots under the lock, then invokes `f` outside; see [`DynamicCounter::visit_series`].
     pub(crate) fn visit_series(&self, mut f: impl FnMut(&[(String, String)], i64)) {
         for shard in &self.index_shards {
-            let guard = shard.read();
-            for (labels, series) in guard.iter() {
-                f(labels.pairs(), series.sum());
+            let snapshot: Vec<(DynamicLabelSet, i64)> = {
+                let guard = shard.read();
+                guard
+                    .iter()
+                    .map(|(labels, series)| (labels.clone(), series.sum()))
+                    .collect()
+            };
+            for (labels, value) in &snapshot {
+                f(labels.pairs(), *value);
             }
         }
     }

--- a/crates/fast-telemetry/src/metric/dynamic/histogram.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/histogram.rs
@@ -401,18 +401,24 @@ impl DynamicHistogram {
         self.overflow_count.load(Ordering::Relaxed)
     }
 
-    /// Iterate all series without cloning label sets.
+    /// Iterate all series without doing heavy work under the read lock.
     ///
-    /// Calls `f` with borrowed label pairs and a borrowed series view.
-    /// Used by exporters/macros to avoid `snapshot()` and bucket vec allocations.
+    /// Snapshots `Arc<HistogramSeries>` pairs under the lock, releases it,
+    /// then invokes `f` with views over the cloned Arcs.
     #[doc(hidden)]
     pub fn visit_series<F>(&self, mut f: F)
     where
         F: for<'a> FnMut(&'a [(String, String)], DynamicHistogramSeriesView<'a>),
     {
         for shard in &self.index_shards {
-            let guard = shard.read();
-            for (labels, series) in guard.iter() {
+            let snapshot: Vec<(DynamicLabelSet, Arc<HistogramSeries>)> = {
+                let guard = shard.read();
+                guard
+                    .iter()
+                    .map(|(labels, series)| (labels.clone(), Arc::clone(series)))
+                    .collect()
+            };
+            for (labels, series) in &snapshot {
                 f(labels.pairs(), DynamicHistogramSeriesView { series });
             }
         }

--- a/crates/fast-telemetry/src/metric/dynamic/mod.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/mod.rs
@@ -24,6 +24,7 @@ pub use gauge_i64::{DynamicGaugeI64, DynamicGaugeI64Series};
 pub use histogram::{DynamicHistogram, DynamicHistogramSeries, DynamicHistogramSeriesView};
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 #[cfg(feature = "eviction")]
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -53,9 +54,14 @@ pub fn advance_cycle() -> u32 {
 ///
 /// Labels are deduplicated by key (last value wins) and sorted by key to ensure
 /// stable identity regardless of input order.
+///
+/// Internally stored as `Arc<[_]>` so cloning is a cheap refcount bump rather
+/// than re-allocating each label string. This lets exporters snapshot label
+/// sets out of the dynamic-metric index under the read lock and release the
+/// lock before formatting.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DynamicLabelSet {
-    labels: Vec<(String, String)>,
+    labels: Arc<[(String, String)]>,
 }
 
 impl DynamicLabelSet {
@@ -66,7 +72,7 @@ impl DynamicLabelSet {
             map.insert((*k).to_string(), (*v).to_string());
         }
         Self {
-            labels: map.into_iter().collect(),
+            labels: map.into_iter().collect::<Vec<_>>().into(),
         }
     }
 
@@ -76,7 +82,7 @@ impl DynamicLabelSet {
     #[doc(hidden)]
     pub fn from_canonical_pairs(labels: &[(String, String)]) -> Self {
         Self {
-            labels: labels.to_vec(),
+            labels: labels.to_vec().into(),
         }
     }
 


### PR DESCRIPTION
**Phase 4** of the optimization roadmap.

## Problem
Dynamic-metric exporters call \`f\` (the formatting closure) with the shard read lock held across the entire iteration. With heavy exporters (OTLP encoding, Prometheus formatting), each series formatting can take hundreds of nanoseconds. A writer needing the write lock to register a new label set blocks for the entire shard's export duration — easily 100µs+ on a registry with 1000 series.

## Fix
Snapshot \`(label_set, value)\` pairs under the read lock, release it, then invoke \`f\` outside.

To make snapshotting cheap, change \`DynamicLabelSet\`'s internal storage from \`Vec<(String, String)>\` to \`Arc<[(String, String)]>\`. Cloning is now a refcount bump rather than re-allocating each label string (saves ~9 allocations per 4-label set).

Histogram snapshots \`Arc<HistogramSeries>\` pairs and builds the borrowed \`View\` over the Arc'd series for the duration of the f call.

## Files
- \`metric/dynamic/mod.rs\`: \`DynamicLabelSet\` storage type change (\`Vec\` → \`Arc<[_]>\`); add \`use std::sync::Arc\`
- \`metric/dynamic/{counter,gauge,gauge_i64,distribution,histogram}.rs\`: \`visit_series\` snapshots before invoking \`f\`

## Test plan
- [x] \`cargo build -p fast-telemetry\` clean
- [x] \`cargo test -p fast-telemetry\` — 133 unit + 8 dogstatsd validation + 1 otel parity + 4 sampled timer + 3 temporality + 7 macro integration pass
- [x] \`cargo clippy -p fast-telemetry --all-targets\` — only pre-existing example warning
- [x] \`cargo fmt --check\` clean
- [ ] Bench A/B against main for OTLP path (pending — measurement phase)

## No public API changes
\`DynamicLabelSet::pairs()\` still returns \`&[(String, String)]\` (compatible with both \`Vec\` and \`Arc<[_]>\` deref). All public method signatures unchanged.

## Expected impact
- Eliminates writer stalls during export (writers no longer wait for export formatting to complete on a shard).
- Cheaper \`DynamicLabelSet::clone()\` — Arc bump instead of Vec + N String clones.
- Slight added cost: one \`Vec\` allocation per shard per export (the snapshot Vec), with capacity = shard's series count. Amortized across series.