### PR TITLE
chore: release 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.1.1" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.1.2" }
 fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.1.1" }
 fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.1.0" }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## 0.1.2 - 2026-04-28
+
+Republished crates: `fast-telemetry`. (`fast-telemetry-macros` is unchanged since 0.1.1 and stays at that version. `fast-telemetry-export` is unchanged since 0.1.0.)
+
+Highlights:
+
+- export performance: the Prometheus and DogStatsD text exporters now format numeric values via `itoa` (integers) and `ryu` (floats) instead of going through the `core::fmt::Display` formatter machinery. Microbenchmarks show 18% to 45% reductions in format-path time across counter, histogram, and distribution exports. The largest wins are on distribution exports (44% on Prometheus, 42% on DogStatsD).
+- floating-point output: `f64` values now use `ryu`'s shortest-roundtrip canonical form. For typical values this matches the previous output. Very large or very small values may now use scientific notation (for example, `1e10` instead of `10000000000`); both forms parse correctly per the Prometheus and DogStatsD specs.
+- internal: a `FastFormat` trait is exposed under `__macro_support`. It is not part of the stable public API.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.1.2"
+fast-telemetry-export = "0.1.0"
+```
+
 ## 0.1.1 - 2026-04-27
 
 Republished crates: `fast-telemetry`, `fast-telemetry-macros`. (`fast-telemetry-export` is unchanged since 0.1.0 and stays at that version; it picks up `fast-telemetry` 0.1.1 via semver.)

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Bumps `fast-telemetry` to 0.1.2.

`fast-telemetry-macros` (0.1.1) and `fast-telemetry-export` (0.1.0) have no source changes since their last published versions and stay at those versions; they pick up `fast-telemetry` 0.1.2 transitively via semver.

## What's in this release
- itoa/ryu numeric formatting in the Prometheus and DogStatsD text exporters (#15). Microbench A/B vs the previous main showed:
  - `export_distribution/prometheus`: -44.6%
  - `export_distribution/dogstatsd`: -41.7%
  - `export_histogram/dogstatsd`: -30.6%
  - `export_counter/dogstatsd`: -25.0%
  - `export_histogram/prometheus`: -22.6%
  - `export_counter/prometheus`: -18.2%
  - dynamic-cardinality counterparts: -12% to -34%

## Release plan after merge
1. `cargo publish -p fast-telemetry`
2. `git tag v0.1.2 && git push origin v0.1.2`

Awaiting your go-ahead before publishing (waiting on this turn after the prior accidental-merge).