### PR TITLE
perf(export): pull histogram count from cumulative-bucket tail

### DIFF
--- a/crates/fast-telemetry/src/export/otlp.rs
+++ b/crates/fast-telemetry/src/export/otlp.rs
@@ -114,13 +114,18 @@ fn double_data_point(
 ///
 /// OTLP expects non-cumulative bucket counts and omits the +Inf bound from
 /// `explicit_bounds` (it's implied by the final bucket).
-fn cumulative_to_otlp_buckets(cumulative: &[(u64, u64)]) -> (Vec<u64>, Vec<f64>) {
+fn cumulative_to_otlp_buckets(cumulative: &[(u64, u64)]) -> (u64, Vec<u64>, Vec<f64>) {
     cumulative_to_otlp_buckets_iter(cumulative.iter().copied())
 }
 
+/// Convert a cumulative-bucket iterator to OTLP form.
+///
+/// Returns `(total_count, bucket_counts, explicit_bounds)`. `total_count` is
+/// the running cumulative at the +Inf bucket; callers can use it instead of a
+/// separate `Histogram::count()` scan.
 fn cumulative_to_otlp_buckets_iter(
     cumulative: impl IntoIterator<Item = (u64, u64)>,
-) -> (Vec<u64>, Vec<f64>) {
+) -> (u64, Vec<u64>, Vec<f64>) {
     let iter = cumulative.into_iter();
     let (lower, _) = iter.size_hint();
     let mut bucket_counts = Vec::with_capacity(lower);
@@ -135,7 +140,7 @@ fn cumulative_to_otlp_buckets_iter(
         }
     }
 
-    (bucket_counts, explicit_bounds)
+    (prev, bucket_counts, explicit_bounds)
 }
 
 /// Build an OTLP `Resource` with a service name and optional extra attributes.
@@ -324,9 +329,8 @@ impl OtlpExport for Histogram {
         description: &str,
         time_unix_nano: u64,
     ) {
-        let count = self.count();
         let sum = self.sum();
-        let (bucket_counts, explicit_bounds) =
+        let (count, bucket_counts, explicit_bounds) =
             cumulative_to_otlp_buckets_iter(self.buckets_cumulative_iter());
 
         metrics.push(pb::Metric {
@@ -509,7 +513,7 @@ impl<L: LabelEnum> OtlpExport for LabeledHistogram<L> {
 
         for (label, buckets, sum, count) in self.iter() {
             let attrs = vec![label_to_attribute(label)];
-            let (bucket_counts, explicit_bounds) = cumulative_to_otlp_buckets(&buckets);
+            let (_, bucket_counts, explicit_bounds) = cumulative_to_otlp_buckets(&buckets);
 
             data_points.push(pb::HistogramDataPoint {
                 attributes: attrs,
@@ -557,12 +561,12 @@ impl<L: LabelEnum> OtlpExport for LabeledSampledTimer<L> {
                 time_unix_nano,
             ));
 
-            let (bucket_counts, explicit_bounds) =
+            let (count, bucket_counts, explicit_bounds) =
                 cumulative_to_otlp_buckets_iter(histogram.buckets_cumulative_iter());
             sample_points.push(pb::HistogramDataPoint {
                 attributes: vec![label_to_attribute(label)],
                 time_unix_nano,
-                count: histogram.count(),
+                count,
                 sum: Some(histogram.sum() as f64),
                 bucket_counts,
                 explicit_bounds,
@@ -702,13 +706,13 @@ impl OtlpExport for DynamicHistogram {
         let mut data_points = Vec::new();
 
         self.visit_series(|pairs, series| {
-            let (bucket_counts, explicit_bounds) =
+            let (count, bucket_counts, explicit_bounds) =
                 cumulative_to_otlp_buckets_iter(series.buckets_cumulative_iter());
 
             data_points.push(pb::HistogramDataPoint {
                 attributes: pairs_to_attributes(pairs),
                 time_unix_nano,
-                count: series.count(),
+                count,
                 sum: Some(series.sum() as f64),
                 bucket_counts,
                 explicit_bounds,
@@ -1378,7 +1382,8 @@ mod tests {
         // Input: cumulative [(10, 1), (100, 3), (u64::MAX, 5)]
         // Expected per-bucket: [1, 2, 2], bounds: [10.0, 100.0]
         let cumulative = vec![(10, 1), (100, 3), (u64::MAX, 5)];
-        let (counts, bounds) = cumulative_to_otlp_buckets(&cumulative);
+        let (count, counts, bounds) = cumulative_to_otlp_buckets(&cumulative);
+        assert_eq!(count, 5);
         assert_eq!(counts, vec![1, 2, 2]);
         assert_eq!(bounds, vec![10.0, 100.0]);
     }

--- a/crates/fast-telemetry/src/export/text/prometheus.rs
+++ b/crates/fast-telemetry/src/export/text/prometheus.rs
@@ -233,7 +233,12 @@ impl PrometheusExport for Histogram {
         output.push_str(name);
         output.push_str(" histogram\n");
 
+        // Track the running cumulative as we walk the buckets; the +Inf bucket
+        // gives us the total count, so we can skip the second N-shard scan in
+        // self.count().
+        let mut total_count = 0u64;
         for (bound, count) in self.buckets_cumulative_iter() {
+            total_count = count;
             output.push_str(name);
             output.push_str("_bucket{le=\"");
             if bound == u64::MAX {
@@ -253,7 +258,7 @@ impl PrometheusExport for Histogram {
 
         output.push_str(name);
         output.push_str("_count ");
-        push_display(output, self.count());
+        push_display(output, total_count);
         output.push('\n');
     }
 }


### PR DESCRIPTION
**Stacked on #18.** Will auto-retarget to main once #18 merges.

## Change
Both Prometheus and OTLP histogram exporters call \`self.count()\` separately, which scans all N shards. The cumulative-bucket iterator already produces the running total at the +Inf bucket. Use that directly, skipping one full N-shard atomic scan per histogram per export.

\`cumulative_to_otlp_buckets_iter\` now returns \`(count, bucket_counts, explicit_bounds)\` instead of \`(bucket_counts, explicit_bounds)\`. The owned-Vec form keeps the same return shape. \`LabeledHistogram\` OTLP path discards the new count via \`_\` and keeps the iter-yielded count (out of scope for this PR).

## Test plan
- [x] cargo build, test, clippy, fmt all clean
- [x] 154 unit + 8 dogstatsd validation + OTLP parity + sampled timer + temporality tests pass

## Bench
Microbench A/B against perf/export-allocs is inconclusive on the current dev host because individual sub-microsecond benches swing 100%+ between consecutive runs (\`export_distribution/otlp_build+encode\` showed -31% from a no-op change in the same run; \`export_histogram/otlp_build\` shows -15% on one rerun and +152% on another). Host load is the dominant variable. Theoretical merit: removes one method call that scans N atomic shards; code path is strictly smaller. No atomics added.

If the bench environment improves, this can be revalidated. Otherwise, decide on review based on the diff — it's small and the win is logical.