### PR TITLE
perf(labeled): skip Vec<(u64,u64)> alloc per LabeledHistogram variant

### DIFF
--- a/crates/fast-telemetry/examples/basic.rs
+++ b/crates/fast-telemetry/examples/basic.rs
@@ -43,7 +43,7 @@ fn main() {
         metrics.latency.record(50 + (i % 200)); // 50-250µs
         metrics
             .hot_path_latency
-            .record_elapsed(Duration::from_nanos(80_000 + ((i % 200) as u64 * 1_000)));
+            .record_elapsed(Duration::from_nanos(80_000 + (i % 200) * 1_000));
     }
     metrics.queue_depth.set(42);
 

--- a/crates/fast-telemetry/src/export/otlp.rs
+++ b/crates/fast-telemetry/src/export/otlp.rs
@@ -109,16 +109,6 @@ fn double_data_point(
     }
 }
 
-/// Convert cumulative bucket counts (as returned by `buckets_cumulative()`) to
-/// OTLP's per-bucket counts and explicit bounds.
-///
-/// OTLP expects non-cumulative bucket counts and omits the +Inf bound from
-/// `explicit_bounds` (it's implied by the final bucket).
-#[cfg(test)]
-fn cumulative_to_otlp_buckets(cumulative: &[(u64, u64)]) -> (Vec<u64>, Vec<f64>) {
-    cumulative_to_otlp_buckets_iter(cumulative.iter().copied())
-}
-
 fn cumulative_to_otlp_buckets_iter(
     cumulative: impl IntoIterator<Item = (u64, u64)>,
 ) -> (Vec<u64>, Vec<f64>) {
@@ -1380,7 +1370,7 @@ mod tests {
         // Input: cumulative [(10, 1), (100, 3), (u64::MAX, 5)]
         // Expected per-bucket: [1, 2, 2], bounds: [10.0, 100.0]
         let cumulative = vec![(10, 1), (100, 3), (u64::MAX, 5)];
-        let (counts, bounds) = cumulative_to_otlp_buckets(&cumulative);
+        let (counts, bounds) = cumulative_to_otlp_buckets_iter(cumulative);
         assert_eq!(counts, vec![1, 2, 2]);
         assert_eq!(bounds, vec![10.0, 100.0]);
     }

--- a/crates/fast-telemetry/src/metric/labeled_histogram.rs
+++ b/crates/fast-telemetry/src/metric/labeled_histogram.rs
@@ -38,8 +38,8 @@ use std::marker::PhantomData;
 /// histogram.record(Endpoint::Auth, 2000);  // 2ms
 ///
 /// // Iteration for export
-/// for (label, buckets, sum, count) in histogram.iter() {
-///     println!("{}={}: count={}", Endpoint::LABEL_NAME, label.variant_name(), count);
+/// for (label, histogram) in histogram.iter() {
+///     println!("{}={}: count={}", Endpoint::LABEL_NAME, label.variant_name(), histogram.count());
 /// }
 /// ```
 pub struct LabeledHistogram<L: LabelEnum> {


### PR DESCRIPTION
**Stacked on #18.** Will auto-retarget to main once #18 merges.

## Change
\`LabeledHistogram::iter()\` yielded \`(L, Vec<(u64, u64)>, u64, u64)\` — one Vec allocation per variant per export call to hold cumulative buckets. The DogStatsD exporter only used sum/count and discarded the Vec, paying the alloc cost for nothing.

Change \`iter()\` to yield \`(L, &Histogram)\`. Each caller grabs only what it needs:
- **Prometheus**: walks \`histogram.buckets_cumulative_iter()\` with no Vec alloc, and pulls per-variant total count from the cumulative tail (saves one self.count() N-shard scan per variant).
- **OTLP**: \`cumulative_to_otlp_buckets_iter(buckets_cumulative_iter())\` instead of \`cumulative_to_otlp_buckets(&buckets_cumulative())\` — no intermediate Vec.
- **DogStatsD**: drops the Vec alloc entirely; only reads sum + count.

Per N-variant LabeledHistogram per export: saves 3*N Vec allocations (one per exporter format).

## Test plan
- [x] cargo build, test, clippy, fmt all clean
- [x] 154 unit + 8 dogstatsd validation + OTLP parity + sampled timer + temporality tests pass
- [x] Existing \`test_iteration\` in labeled_histogram.rs updated for new tuple shape

## Bench A/B (criterion, this branch vs perf/export-allocs)
The criterion suite has no LabeledHistogram-specific export bench. The numbers below are on adjacent single-Histogram paths I didn't touch — consistent with the host-noise pattern (-3% to +22%) that's been dominating sub-µs comparisons in this session:
| Bench | Δ | Note |
|---|---:|---|
| \`export_histogram/prometheus\` | -3.2% | unchanged code, noise |
| \`export_full_otlp_cycle/build_all\` | -1.1% | unchanged code, noise |
| \`export_histogram/dogstatsd\` | +2.3% | unchanged code, noise |
| \`export_histogram/otlp_build\` | +4.4% | unchanged code, noise |
| \`export_histogram/otlp_build+encode\` | +15.9% | unchanged code, noise |
| \`export_full_otlp_cycle/build_all+encode\` | +22.5% | unchanged code, noise |

For a clean number, a follow-up could add \`bench_export_labeled_histogram\`. Out of scope.