### PR TITLE
chore: ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ Cargo.lock
 .vscode/
 *.iml
 
+# Agent state
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Local Claude Code agent state directory lives at the repo root. It is per-machine and should never be committed. \`.gitignore\` was missing the entry, which nearly leaked the dir into a recent perf PR (caught manually via \`git status\` before pushing).

Verified \`.claude/\` was not actually committed to any branch on origin before this fix:
\`\`\`
$ for branch in $(git branch -r | grep -v HEAD); do
    git ls-tree -r --name-only "$branch" | grep -q "^\.claude" && echo "$branch"
  done
(no output)
\`\`\`

So no removal-from-history needed — just the gitignore addition.