### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.1.2" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.1.1" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.1.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.2.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.2.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.2.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ dynamic metric types. Without it, these APIs are not available.
 
 ```toml
 [dependencies]
-fast-telemetry = "0.1"
+fast-telemetry = "0.2"
 ```
 
 ### Define Metrics
@@ -360,7 +360,7 @@ batching, compression, backoff, and graceful shutdown.
 
 ```toml
 [dependencies]
-fast-telemetry-export = "0.1"
+fast-telemetry-export = "0.2"
 ```
 
 ### DogStatsD

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## 0.2.0 - 2026-04-29
+
+Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.
+
+Highlights:
+
+- ClickHouse export: added optional first-party ClickHouse row export support in `fast-telemetry` behind the `clickhouse` feature, including `ClickHouseExport`, `ClickHouseMetricBatch`, and OTel-standard row structs.
+- ClickHouse export crate support: `fast-telemetry-export` now ships a native TCP ClickHouse exporter with three paths: custom `klickhouse::Row` schemas, OTel-standard OTLP-to-row translation, and first-party `export_clickhouse()` row batches via `otel_standard::run_first_party`.
+- derive macros: `#[derive(ExportMetrics)]` now accepts `#[clickhouse]` and generates `export_clickhouse(...)` methods when the runtime `clickhouse` feature is enabled.
+- export performance: histogram and sampled-timer export paths avoid several intermediate allocations. `Histogram::buckets_cumulative_iter()` is a new compatible public API for allocation-free bucket export.
+- labeled histograms: `LabeledHistogram::iter()` now yields `(label, &Histogram)`, allowing exporters that only need sum/count to skip building cumulative bucket vectors.
+- tooling and docs: added ClickHouse integration tests, a Docker-based ClickHouse smoke/benchmark harness, Criterion export-format comparisons, and updated ClickHouse documentation.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.2"
+fast-telemetry-export = "0.2"
+```
+
 ## 0.1.2 - 2026-04-28
 
 Republished crates: `fast-telemetry`. (`fast-telemetry-macros` is unchanged since 0.1.1 and stays at that version. `fast-telemetry-export` is unchanged since 0.1.0.)

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary
- bump fast-telemetry, fast-telemetry-macros, and fast-telemetry-export to 0.2.0
- update workspace dependency pins and README install snippets
- add 0.2.0 release notes for ClickHouse support, export API/performance changes, docs, tests, and benchmarks

## Verification
- cargo fmt --check
- cargo check --workspace --all-targets
- cargo package -p fast-telemetry-macros --allow-dirty

## Notes
- Full cargo package verification for fast-telemetry and fast-telemetry-export must happen during the staged publish because their new internal 0.2.0 dependencies are not on crates.io yet. Pre-publish attempts failed only at crates.io dependency resolution for those unpublished internal versions.