### PR TITLE
chore: prepare 0.2.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.2.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.2.1" }
 fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.2.0" }
 fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.2.0" }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## 0.2.1 - 2026-04-29
+
+Published crates: `fast-telemetry`. (`fast-telemetry-macros` and `fast-telemetry-export` are unchanged since 0.2.0.)
+
+Highlights:
+
+- distribution export performance: Prometheus summary export now uses `Distribution::sum_and_count()` to read each shard once instead of separately walking shards for sum and count.
+- public API: added `Distribution::sum_and_count()` for callers that need both aggregate values without two shard scans.
+- span performance: replaced the thread-local span submit-path `RefCell` borrow check with an `UnsafeCell`-backed implementation, preserving the zero-atomic hot path while avoiding per-submit runtime borrow overhead.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.2.1"
+fast-telemetry-export = "0.2"
+```
+
 ## 0.2.0 - 2026-04-29
 
 Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary
- bump fast-telemetry to 0.2.1
- update the workspace fast-telemetry pin
- add 0.2.1 release notes for the distribution export and span hot-path performance changes

## Verification
- cargo fmt --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo package -p fast-telemetry --allow-dirty

## Publish plan
- publish fast-telemetry 0.2.1 after merge
- fast-telemetry-macros and fast-telemetry-export remain at 0.2.0