### PR TITLE
Add monoio exporter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.3.0" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.3.0" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.3.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.4.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.4.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.4.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 # --- Export: fast-telemetry-export runtime dependencies ---
 log = "0.4"
 memchr = "2"                                                              # dogstatsd feature
+monoio = "0.2.4"
 tokio = { version = "1", features = ["net", "rt", "rt-multi-thread", "time", "macros"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ dynamic metric types. Without it, these APIs are not available.
 
 ```toml
 [dependencies]
-fast-telemetry = "0.2"
+fast-telemetry = "0.4"
 ```
 
 ### Define Metrics
@@ -370,7 +370,7 @@ batching, compression, backoff, and graceful shutdown.
 
 ```toml
 [dependencies]
-fast-telemetry-export = "0.2"
+fast-telemetry-export = "0.4"
 ```
 
 ### DogStatsD
@@ -575,7 +575,7 @@ sweep and then sum each dynamic metric's `evict_stale(...)` result.
 enable the export crate's `monoio` feature for monoio-native loops:
 
 ```toml
-fast-telemetry-export = { version = "0.3", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.4", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 Use `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, and

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ High-performance, cache-friendly telemetry for Rust.
 ## Why
 
 fast-telemetry grew out of [Eden](https://eden.dev)'s observability stack. Eden was a
-heavy user of the OpenTelemetry ecosystem — we relied on the `opentelemetry`
+heavy user of the OpenTelemetry ecosystem. At Eden, we relied on the `opentelemetry`
 crate and its SDK for metrics across our services. That worked fine until we
 started benchmarking our high-performance Redis proxy under realistic production
 load.
 
 The proxy handles millions of operations per second across many cores, and we
-care about per-request, per-endpoint, and per-organization telemetry -- a lot of
+care about telemetry per-request, per-endpoint, per-organization, and used lot of
 counters, which led to a lot of contention. Under benchmark loads, the metrics layer
 itself became a clear bottleneck.
 
@@ -568,6 +568,22 @@ tokio::spawn(run(SweepConfig::default (), cancel, move | threshold| {
 
 If you wrap your metrics in a helper method, call `advance_cycle()` once per
 sweep and then sum each dynamic metric's `evict_stale(...)` result.
+
+### Monoio Exporters
+
+`fast-telemetry` recording is runtime-agnostic. If your service runs monoio,
+enable the export crate's `monoio` feature for monoio-native loops:
+
+```toml
+fast-telemetry-export = { version = "0.3", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+```
+
+Use `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, and
+`sweeper::run_monoio(...)` inside a monoio runtime with timers enabled.
+`otlp::run_monoio(...)` currently supports plaintext `http://` collector
+endpoints. For spans, run `spans::run_local_flusher_monoio(...)` on each monoio
+worker that records spans so thread-local span buffers are published for the
+exporter to drain.
 
 ## OTLP Protobuf (Manual)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 # Release Notes
 
+## 0.4.0 - 2026-05-16
+
+Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.
+
+Why this is a 0.4.0 bump:
+
+- this release adds a new optional `monoio` exporter feature and new public exporter entry points in `fast-telemetry-export`.
+- because these crates are still pre-1.0, new public API should advance the minor version so downstream users have a clear compatibility boundary.
+- all workspace crates are aligned at `0.4.0` to keep the runtime, derive macros, and exporter adapters on the same API contract and avoid dependency skew.
+
+Highlights:
+
+- monoio export support: added `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, `sweeper::run_monoio(...)`, and `spans::run_local_flusher_monoio(...)` behind the optional `monoio` feature.
+- OTLP monoio transport: `otlp::run_monoio(...)` sends plaintext `http://` OTLP HTTP/protobuf over monoio TCP for monoio-native services. Keep using the default Tokio exporter for `https://` endpoints.
+- span flushing: added a per-worker monoio flusher helper so low-volume spans buffered in thread-local collectors are published for the exporter to drain.
+- benchmark validation: compared the branch against `main` with Criterion and the quick telemetry harness; no serious hot-path regressions were observed.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.4"
+fast-telemetry-export = "0.4"
+```
+
 ## 0.3.0 - 2026-05-07
 
 Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -20,10 +20,12 @@ default = ["dogstatsd", "otlp"]
 dogstatsd = ["dep:memchr"]
 otlp = ["dep:flate2", "dep:prost", "dep:reqwest", "fast-telemetry/otlp"]
 clickhouse = ["dep:klickhouse", "dep:indexmap", "fast-telemetry/otlp", "fast-telemetry/clickhouse"]
+monoio = ["dep:monoio"]
 
 [dependencies]
 log = { workspace = true }
 memchr = { workspace = true, optional = true }
+monoio = { workspace = true, optional = true }
 fast-telemetry = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -45,7 +45,7 @@ columns with defaults. Summary metrics are ignored.
 Enable the `monoio` feature to run exporter loops on a monoio runtime:
 
 ```toml
-fast-telemetry-export = { version = "0.3", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.4", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 The monoio entry points mirror the Tokio ones:

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -18,6 +18,7 @@ This crate provides:
 | `dogstatsd`  | ✓       | DogStatsD UDP exporter                                                               |
 | `otlp`       | ✓       | OTLP HTTP/protobuf metrics + span exporters                                          |
 | `clickhouse` |         | Native-TCP ClickHouse exporter — first-party rows, generic primitive, and OTel schema |
+| `monoio`     |         | Monoio-native DogStatsD, OTLP HTTP/protobuf, sweeper, and span-flush helper          |
 
 The ClickHouse exporter ships two layers:
 
@@ -38,6 +39,28 @@ The OTel-standard exporter currently writes sum, gauge, histogram, and
 exponential histogram metrics. It creates the Collector's compatibility columns
 for scope/schema/exemplar data, but flat `export_otlp()` metrics populate those
 columns with defaults. Summary metrics are ignored.
+
+## Monoio
+
+Enable the `monoio` feature to run exporter loops on a monoio runtime:
+
+```toml
+fast-telemetry-export = { version = "0.3", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+```
+
+The monoio entry points mirror the Tokio ones:
+
+- `dogstatsd::run_monoio(...)`
+- `otlp::run_monoio(...)`
+- `sweeper::run_monoio(...)`
+- `spans::run_local_flusher_monoio(...)`
+
+`otlp::run_monoio(...)` sends OTLP HTTP/protobuf over monoio TCP and currently
+supports plaintext `http://` collector endpoints. Keep using the default Tokio
+exporter for `https://` endpoints. Monoio timer APIs require a runtime with
+timers enabled, and span-heavy applications should run one local flusher task on
+each monoio worker that records spans so low-volume thread-local span buffers
+are published for the exporter to drain.
 
 Integration tests covering both layers run against a real ClickHouse via
 `testcontainers`:

--- a/crates/fast-telemetry-export/src/dogstatsd.rs
+++ b/crates/fast-telemetry-export/src/dogstatsd.rs
@@ -205,3 +205,173 @@ pub async fn run<F>(
         );
     }
 }
+
+/// Run the DogStatsD export loop on a monoio runtime.
+///
+/// This is the monoio-native counterpart to [`run`]. It uses
+/// [`monoio::net::udp::UdpSocket`] and [`monoio::time::interval`], so the
+/// caller must run it inside a monoio runtime with timers enabled.
+#[cfg(feature = "monoio")]
+pub async fn run_monoio<F>(
+    config: DogStatsDConfig,
+    cancel: tokio_util::sync::CancellationToken,
+    mut export_fn: F,
+) where
+    F: FnMut(&mut String),
+{
+    use std::net::{SocketAddr, ToSocketAddrs};
+
+    use monoio::net::udp::UdpSocket;
+    use monoio::time::MissedTickBehavior;
+
+    log::info!(
+        "Starting monoio DogStatsD exporter, endpoint={}",
+        config.endpoint
+    );
+
+    let endpoint = match config.endpoint.to_socket_addrs() {
+        Ok(mut addrs) => match addrs.next() {
+            Some(addr) => addr,
+            None => {
+                log::error!("DogStatsD endpoint resolved to no addresses");
+                return;
+            }
+        },
+        Err(e) => {
+            log::error!(
+                "Failed to resolve DogStatsD endpoint {}: {e}",
+                config.endpoint
+            );
+            return;
+        }
+    };
+
+    let bind_addr: SocketAddr = if endpoint.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    }
+    .parse()
+    .expect("valid UDP bind address");
+
+    let socket = match UdpSocket::bind(bind_addr) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Failed to bind monoio UDP socket for DogStatsD export: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = socket.connect(endpoint).await {
+        log::error!("Failed to connect monoio UDP socket to {endpoint}: {e}");
+        return;
+    }
+
+    let max_packet_size = config.max_packet_size;
+    let mut output = String::with_capacity(16384);
+    let mut batch = Vec::<u8>::with_capacity(max_packet_size);
+
+    let mut interval = monoio::time::interval(config.interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval.tick().await;
+
+    loop {
+        monoio::select! {
+            _ = interval.tick() => {}
+            _ = cancel.cancelled() => {
+                log::info!("monoio DogStatsD exporter shutting down");
+                return;
+            }
+        }
+
+        output.clear();
+        export_fn(&mut output);
+
+        if output.is_empty() {
+            continue;
+        }
+
+        let output_bytes = output.as_bytes();
+        batch.clear();
+
+        let mut total_sent = 0usize;
+        let mut batch_count = 0usize;
+        let mut metric_count = 0usize;
+        let mut start = 0usize;
+
+        for nl in memchr::memchr_iter(b'\n', output_bytes) {
+            let end = nl + 1;
+            let line = &output_bytes[start..end];
+            let line_len = line.len();
+            metric_count += 1;
+
+            if line_len > max_packet_size {
+                log::warn!(
+                    "Dropping oversized metric line ({line_len} bytes, max {max_packet_size})"
+                );
+                start = end;
+                continue;
+            }
+
+            if !batch.is_empty() && batch.len() + line_len > max_packet_size {
+                if let Some(n) = send_monoio_batch(&socket, &mut batch, "DogStatsD batch").await {
+                    total_sent += n;
+                    batch_count += 1;
+                }
+            }
+
+            batch.extend_from_slice(line);
+            start = end;
+        }
+
+        if start < output_bytes.len() {
+            let line = &output_bytes[start..];
+            let line_len = line.len();
+            metric_count += 1;
+
+            if line_len <= max_packet_size {
+                if !batch.is_empty() && batch.len() + line_len > max_packet_size {
+                    if let Some(n) = send_monoio_batch(&socket, &mut batch, "DogStatsD batch").await
+                    {
+                        total_sent += n;
+                        batch_count += 1;
+                    }
+                }
+                batch.extend_from_slice(line);
+            } else {
+                log::warn!("Dropping oversized trailing metric ({line_len} bytes)");
+            }
+        }
+
+        if !batch.is_empty()
+            && let Some(n) = send_monoio_batch(&socket, &mut batch, "final DogStatsD batch").await
+        {
+            total_sent += n;
+            batch_count += 1;
+        }
+
+        log::debug!(
+            "monoio DogStatsD export: {metric_count} metrics, {batch_count} batches, {total_sent} bytes"
+        );
+    }
+}
+
+#[cfg(feature = "monoio")]
+async fn send_monoio_batch(
+    socket: &monoio::net::udp::UdpSocket,
+    batch: &mut Vec<u8>,
+    context: &str,
+) -> Option<usize> {
+    let send_buf = std::mem::take(batch);
+    let (result, mut send_buf) = socket.send(send_buf).await;
+    send_buf.clear();
+    *batch = send_buf;
+
+    match result {
+        Ok(n) => Some(n),
+        Err(e) => {
+            log::warn!("Failed to send monoio {context}: {e}");
+            None
+        }
+    }
+}

--- a/crates/fast-telemetry-export/src/lib.rs
+++ b/crates/fast-telemetry-export/src/lib.rs
@@ -18,6 +18,8 @@
 //! - The stale-series sweeper expects the caller to invoke
 //!   `fast_telemetry::advance_cycle()` once per sweep and then call each dynamic
 //!   metric's `evict_stale(...)` method.
+//! - The `monoio` feature adds monoio-native DogStatsD, OTLP HTTP/protobuf, and
+//!   stale-series sweep loops, plus a per-worker span flusher.
 //!
 //! # Features
 //!
@@ -25,6 +27,7 @@
 //! - `otlp` (default) — OTLP HTTP/protobuf metrics and span exporters
 //! - `clickhouse` — ClickHouse native-protocol metrics exporter, including
 //!   first-party rows and OTel-standard table support (via [`klickhouse`])
+//! - `monoio` — monoio-native exporter loops for monoio applications
 
 #[cfg(feature = "clickhouse")]
 pub mod clickhouse;

--- a/crates/fast-telemetry-export/src/otlp.rs
+++ b/crates/fast-telemetry-export/src/otlp.rs
@@ -284,6 +284,129 @@ where
     }
 }
 
+/// Run the OTLP metrics export loop on a monoio runtime.
+///
+/// This is a monoio-native alternative to [`run`] for applications that do not
+/// want their metrics exporter to run on Tokio. It sends OTLP HTTP/protobuf over
+/// a fresh monoio TCP connection per export attempt.
+///
+/// Currently this supports plaintext `http://` collector endpoints only. Keep
+/// using [`run`] for `https://` endpoints until a monoio TLS transport is added.
+/// The caller must run this inside a monoio runtime with timers enabled.
+#[cfg(feature = "monoio")]
+pub async fn run_monoio<F>(config: OtlpConfig, cancel: CancellationToken, mut collect_fn: F)
+where
+    F: FnMut(&mut Vec<pb::Metric>),
+{
+    use monoio::time::MissedTickBehavior;
+
+    let url = format!("{}/v1/metrics", config.endpoint.trim_end_matches('/'));
+    let target = match MonoioHttpTarget::parse(&url) {
+        Ok(target) => target,
+        Err(e) => {
+            log::error!("Invalid monoio OTLP endpoint {url}: {e}");
+            return;
+        }
+    };
+
+    log::info!(
+        "Starting monoio OTLP metrics exporter, endpoint={url}, interval={}s",
+        config.interval.as_secs()
+    );
+
+    let attr_refs: Vec<(&str, &str)> = config
+        .resource_attributes
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let resource = build_resource(&config.service_name, &attr_refs);
+
+    let mut interval = monoio::time::interval(config.interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval.tick().await;
+
+    let mut consecutive_failures: u32 = 0;
+    let mut bufs = ExportBufs::default();
+
+    let ctx = MonoioExportContext {
+        target: &target,
+        resource: &resource,
+        scope_name: &config.scope_name,
+        extra_headers: &config.headers,
+        timeout: config.timeout,
+    };
+
+    loop {
+        monoio::select! {
+            _ = interval.tick() => {}
+            _ = cancel.cancelled() => {
+                log::info!("monoio OTLP metrics exporter shutting down, performing final export");
+                export_once_monoio(&ctx, &mut collect_fn, &mut bufs).await;
+                return;
+            }
+        }
+
+        if consecutive_failures > 0 {
+            let backoff = backoff_with_jitter(consecutive_failures);
+            log::debug!(
+                "monoio OTLP export backing off {}ms (failures={consecutive_failures})",
+                backoff.as_millis()
+            );
+            monoio::select! {
+                _ = monoio::time::sleep(backoff) => {}
+                _ = cancel.cancelled() => {
+                    export_once_monoio(&ctx, &mut collect_fn, &mut bufs).await;
+                    return;
+                }
+            }
+        }
+
+        let mut metric_messages = Vec::new();
+        collect_fn(&mut metric_messages);
+
+        if metric_messages.is_empty() {
+            continue;
+        }
+
+        let metric_count = metric_messages.len();
+        let request = build_export_request(&resource, &config.scope_name, metric_messages);
+
+        bufs.encode.clear();
+        if let Err(e) = request.encode(&mut bufs.encode) {
+            log::warn!("monoio OTLP protobuf encode failed: {e}");
+            continue;
+        }
+        let body_len = bufs.encode.len();
+
+        match send_otlp_monoio(
+            &target,
+            &bufs.encode,
+            &mut bufs.gzip,
+            &config.headers,
+            config.timeout,
+        )
+        .await
+        {
+            Ok(resp) if resp.is_success() => {
+                consecutive_failures = 0;
+                log::debug!("Exported {metric_count} monoio OTLP metrics ({body_len} bytes)");
+            }
+            Ok(resp) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                log::warn!(
+                    "monoio OTLP export failed: status={}, body={}",
+                    resp.status,
+                    resp.body_text_lossy()
+                );
+            }
+            Err(e) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                log::warn!("monoio OTLP export request failed: {e}");
+            }
+        }
+    }
+}
+
 struct ExportContext<'a> {
     client: &'a reqwest::Client,
     url: &'a str,
@@ -336,6 +459,312 @@ where
     }
 }
 
+#[cfg(feature = "monoio")]
+struct MonoioExportContext<'a> {
+    target: &'a MonoioHttpTarget,
+    resource: &'a pb::Resource,
+    scope_name: &'a str,
+    extra_headers: &'a [(String, String)],
+    timeout: Duration,
+}
+
+#[cfg(feature = "monoio")]
+async fn export_once_monoio<F>(
+    ctx: &MonoioExportContext<'_>,
+    collect_fn: &mut F,
+    bufs: &mut ExportBufs,
+) where
+    F: FnMut(&mut Vec<pb::Metric>),
+{
+    let mut metric_messages = Vec::new();
+    collect_fn(&mut metric_messages);
+
+    if metric_messages.is_empty() {
+        return;
+    }
+
+    let request = build_export_request(ctx.resource, ctx.scope_name, metric_messages);
+
+    bufs.encode.clear();
+    if let Err(e) = request.encode(&mut bufs.encode) {
+        log::warn!("Final monoio OTLP protobuf encode failed: {e}");
+        return;
+    }
+
+    match send_otlp_monoio(
+        ctx.target,
+        &bufs.encode,
+        &mut bufs.gzip,
+        ctx.extra_headers,
+        ctx.timeout,
+    )
+    .await
+    {
+        Ok(resp) if !resp.is_success() => {
+            log::warn!(
+                "Final monoio OTLP export returned {}: {}",
+                resp.status,
+                resp.body_text_lossy()
+            );
+        }
+        Err(e) => log::warn!("Final monoio OTLP export failed: {e}"),
+        _ => {}
+    }
+}
+
+#[cfg(feature = "monoio")]
+#[derive(Debug)]
+struct MonoioHttpTarget {
+    connect_addr: String,
+    host_header: String,
+    path: String,
+}
+
+#[cfg(feature = "monoio")]
+impl MonoioHttpTarget {
+    fn parse(url: &str) -> Result<Self, MonoioHttpError> {
+        let rest = url
+            .strip_prefix("http://")
+            .ok_or_else(|| MonoioHttpError::InvalidEndpoint("only http:// is supported".into()))?;
+        let (authority, path) = match rest.find('/') {
+            Some(idx) => (&rest[..idx], &rest[idx..]),
+            None => (rest, "/"),
+        };
+
+        if authority.is_empty() {
+            return Err(MonoioHttpError::InvalidEndpoint(
+                "missing host in endpoint".into(),
+            ));
+        }
+
+        let connect_addr = connect_addr_for_authority(authority)?;
+
+        Ok(Self {
+            connect_addr,
+            host_header: authority.to_string(),
+            path: path.to_string(),
+        })
+    }
+}
+
+#[cfg(feature = "monoio")]
+fn connect_addr_for_authority(authority: &str) -> Result<String, MonoioHttpError> {
+    if let Some(rest) = authority.strip_prefix('[') {
+        let end = rest.find(']').ok_or_else(|| {
+            MonoioHttpError::InvalidEndpoint("IPv6 hosts must use [addr] syntax".into())
+        })?;
+        let suffix = &rest[end + 1..];
+        return if suffix.is_empty() {
+            Ok(format!("{authority}:80"))
+        } else if let Some(port) = suffix.strip_prefix(':') {
+            validate_port(port)?;
+            Ok(authority.to_string())
+        } else {
+            Err(MonoioHttpError::InvalidEndpoint(
+                "unexpected characters after IPv6 host".into(),
+            ))
+        };
+    }
+
+    match authority.rsplit_once(':') {
+        Some((_host, port)) => {
+            validate_port(port)?;
+            Ok(authority.to_string())
+        }
+        None => Ok(format!("{authority}:80")),
+    }
+}
+
+#[cfg(feature = "monoio")]
+fn validate_port(port: &str) -> Result<(), MonoioHttpError> {
+    if port.parse::<u16>().is_ok() {
+        Ok(())
+    } else {
+        Err(MonoioHttpError::InvalidEndpoint(
+            "invalid port in endpoint".into(),
+        ))
+    }
+}
+
+#[cfg(feature = "monoio")]
+#[derive(Debug)]
+struct MonoioHttpResponse {
+    status: u16,
+    body: Vec<u8>,
+}
+
+#[cfg(feature = "monoio")]
+impl MonoioHttpResponse {
+    fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    fn body_text_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.body).into_owned()
+    }
+}
+
+#[cfg(feature = "monoio")]
+#[derive(Debug)]
+enum MonoioHttpError {
+    InvalidEndpoint(String),
+    InvalidHeader(String),
+    Io(std::io::Error),
+    Timeout,
+    InvalidResponse,
+}
+
+#[cfg(feature = "monoio")]
+impl std::fmt::Display for MonoioHttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidEndpoint(msg) => write!(f, "{msg}"),
+            Self::InvalidHeader(name) => write!(f, "invalid HTTP header {name:?}"),
+            Self::Io(e) => write!(f, "{e}"),
+            Self::Timeout => f.write_str("request timed out"),
+            Self::InvalidResponse => f.write_str("invalid HTTP response"),
+        }
+    }
+}
+
+#[cfg(feature = "monoio")]
+impl From<std::io::Error> for MonoioHttpError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[cfg(feature = "monoio")]
+async fn send_otlp_monoio(
+    target: &MonoioHttpTarget,
+    body: &[u8],
+    gzip_buf: &mut Vec<u8>,
+    extra_headers: &[(String, String)],
+    timeout: Duration,
+) -> Result<MonoioHttpResponse, MonoioHttpError> {
+    let compressed = gzip_compress(body, gzip_buf);
+    let request_body = if compressed {
+        gzip_buf.as_slice()
+    } else {
+        body
+    };
+    let request = build_monoio_http_request(target, request_body, compressed, extra_headers)?;
+
+    match monoio::time::timeout(timeout, send_monoio_http_request(target, request)).await {
+        Ok(result) => result,
+        Err(_) => Err(MonoioHttpError::Timeout),
+    }
+}
+
+#[cfg(feature = "monoio")]
+fn build_monoio_http_request(
+    target: &MonoioHttpTarget,
+    body: &[u8],
+    compressed: bool,
+    extra_headers: &[(String, String)],
+) -> Result<Vec<u8>, MonoioHttpError> {
+    use std::fmt::Write as _;
+
+    let mut head = String::with_capacity(512 + extra_headers.len() * 64);
+    write!(
+        &mut head,
+        "POST {} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/x-protobuf\r\nContent-Length: {}\r\nConnection: close\r\n",
+        target.path,
+        target.host_header,
+        body.len()
+    )
+    .expect("writing to String cannot fail");
+
+    if compressed {
+        head.push_str("Content-Encoding: gzip\r\n");
+    }
+
+    for (name, value) in extra_headers {
+        validate_header(name, value)?;
+        write!(&mut head, "{name}: {value}\r\n").expect("writing to String cannot fail");
+    }
+
+    head.push_str("\r\n");
+    let mut request = head.into_bytes();
+    request.extend_from_slice(body);
+    Ok(request)
+}
+
+#[cfg(feature = "monoio")]
+fn validate_header(name: &str, value: &str) -> Result<(), MonoioHttpError> {
+    let invalid_name = name.is_empty()
+        || name
+            .bytes()
+            .any(|b| b <= b' ' || b == b':' || b == b'\r' || b == b'\n');
+    let invalid_value = value.bytes().any(|b| b == b'\r' || b == b'\n');
+
+    if invalid_name || invalid_value {
+        Err(MonoioHttpError::InvalidHeader(name.to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "monoio")]
+async fn send_monoio_http_request(
+    target: &MonoioHttpTarget,
+    request: Vec<u8>,
+) -> Result<MonoioHttpResponse, MonoioHttpError> {
+    use monoio::io::{AsyncReadRent, AsyncWriteRentExt};
+    use monoio::net::TcpStream;
+
+    let mut stream = TcpStream::connect(target.connect_addr.as_str()).await?;
+    let (write_result, _request) = stream.write_all(request).await;
+    write_result?;
+
+    let mut response = Vec::with_capacity(8192);
+    loop {
+        let buf = Vec::with_capacity(8192);
+        let (read_result, buf) = stream.read(buf).await;
+        let n = read_result?;
+        if n == 0 {
+            break;
+        }
+        let available = buf.len().min(n);
+        response.extend_from_slice(&buf[..available]);
+        if response.len() >= 64 * 1024 {
+            break;
+        }
+    }
+
+    parse_monoio_http_response(response)
+}
+
+#[cfg(feature = "monoio")]
+fn parse_monoio_http_response(response: Vec<u8>) -> Result<MonoioHttpResponse, MonoioHttpError> {
+    let header_end = response
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .map(|idx| idx + 4)
+        .ok_or(MonoioHttpError::InvalidResponse)?;
+
+    let status_line_end = response[..header_end]
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .ok_or(MonoioHttpError::InvalidResponse)?;
+    let status_line = std::str::from_utf8(&response[..status_line_end])
+        .map_err(|_| MonoioHttpError::InvalidResponse)?;
+    let status = parse_status_code(status_line).ok_or(MonoioHttpError::InvalidResponse)?;
+    let body = response[header_end..].to_vec();
+
+    Ok(MonoioHttpResponse { status, body })
+}
+
+#[cfg(feature = "monoio")]
+fn parse_status_code(status_line: &str) -> Option<u16> {
+    let mut parts = status_line.split_whitespace();
+    let version = parts.next()?;
+    if !version.starts_with("HTTP/") {
+        return None;
+    }
+    parts.next()?.parse().ok()
+}
+
 /// Compute backoff with jitter: min(MAX_BACKOFF, BASE_BACKOFF * 2^failures) +/- 25% jitter.
 fn backoff_with_jitter(consecutive_failures: u32) -> Duration {
     let exp = consecutive_failures.min(10);
@@ -353,4 +782,65 @@ fn backoff_with_jitter(consecutive_failures: u32) -> Duration {
     let final_ms = backoff_ms.saturating_add(jitter);
 
     Duration::from_millis(final_ms)
+}
+
+#[cfg(all(test, feature = "monoio"))]
+mod monoio_tests {
+    use super::*;
+
+    #[test]
+    fn parses_http_target_with_port() {
+        let target = MonoioHttpTarget::parse("http://localhost:4318/v1/metrics").unwrap();
+        assert_eq!(target.connect_addr, "localhost:4318");
+        assert_eq!(target.host_header, "localhost:4318");
+        assert_eq!(target.path, "/v1/metrics");
+    }
+
+    #[test]
+    fn parses_http_target_without_port() {
+        let target = MonoioHttpTarget::parse("http://collector/v1/metrics").unwrap();
+        assert_eq!(target.connect_addr, "collector:80");
+        assert_eq!(target.host_header, "collector");
+        assert_eq!(target.path, "/v1/metrics");
+    }
+
+    #[test]
+    fn rejects_https_target() {
+        let err = MonoioHttpTarget::parse("https://collector:4318/v1/metrics").unwrap_err();
+        assert!(matches!(err, MonoioHttpError::InvalidEndpoint(_)));
+    }
+
+    #[test]
+    fn rejects_invalid_port() {
+        let err = MonoioHttpTarget::parse("http://collector:nope/v1/metrics").unwrap_err();
+        assert!(matches!(err, MonoioHttpError::InvalidEndpoint(_)));
+    }
+
+    #[test]
+    fn builds_http_request() {
+        let target = MonoioHttpTarget::parse("http://localhost:4318/v1/metrics").unwrap();
+        let request = build_monoio_http_request(
+            &target,
+            b"abc",
+            true,
+            &[("Authorization".to_string(), "Bearer token".to_string())],
+        )
+        .unwrap();
+        let request = String::from_utf8(request).unwrap();
+        assert!(request.starts_with("POST /v1/metrics HTTP/1.1\r\n"));
+        assert!(request.contains("Host: localhost:4318\r\n"));
+        assert!(request.contains("Content-Length: 3\r\n"));
+        assert!(request.contains("Content-Encoding: gzip\r\n"));
+        assert!(request.ends_with("\r\n\r\nabc"));
+    }
+
+    #[test]
+    fn parses_http_status() {
+        let response = parse_monoio_http_response(
+            b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n".to_vec(),
+        )
+        .unwrap();
+        assert_eq!(response.status, 204);
+        assert!(response.body.is_empty());
+    }
 }

--- a/crates/fast-telemetry-export/src/spans.rs
+++ b/crates/fast-telemetry-export/src/spans.rs
@@ -164,6 +164,41 @@ pub fn spawn(
         .ok()
 }
 
+/// Periodically flush this monoio worker's thread-local span buffer.
+///
+/// [`SpanCollector::drain_into`] can only drain spans that have already moved
+/// from a worker's thread-local buffer into the shared outbox. On long-lived
+/// monoio workers, low-volume spans may sit below the collector's automatic
+/// flush threshold for a long time, so run one of these tasks on each monoio
+/// worker that records spans.
+///
+/// The actual OTLP span exporter can remain [`spawn`], which runs on its own
+/// private Tokio runtime and drains the shared outboxes.
+#[cfg(feature = "monoio")]
+pub async fn run_local_flusher_monoio(
+    collector: Arc<SpanCollector>,
+    interval: Duration,
+    cancel: CancellationToken,
+) {
+    use monoio::time::MissedTickBehavior;
+
+    let mut interval = monoio::time::interval(interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval.tick().await;
+
+    loop {
+        monoio::select! {
+            _ = interval.tick() => {
+                collector.flush_local();
+            }
+            _ = cancel.cancelled() => {
+                collector.flush_local();
+                return;
+            }
+        }
+    }
+}
+
 /// Run the OTLP span export loop.
 ///
 /// Drains completed spans from the collector in batches and sends them to

--- a/crates/fast-telemetry-export/src/sweeper.rs
+++ b/crates/fast-telemetry-export/src/sweeper.rs
@@ -111,3 +111,42 @@ where
         }
     }
 }
+
+/// Run the stale-series sweep loop on a monoio runtime.
+///
+/// This is the monoio-native counterpart to [`run`]. It uses
+/// [`monoio::time::interval`], so the caller must run it inside a monoio
+/// runtime with timers enabled.
+#[cfg(feature = "monoio")]
+pub async fn run_monoio<F>(config: SweepConfig, cancel: CancellationToken, mut sweep_fn: F)
+where
+    F: FnMut(u32) -> usize,
+{
+    use monoio::time::MissedTickBehavior;
+
+    log::info!(
+        "Starting monoio stale-series sweeper, interval={}s, eviction_threshold={}",
+        config.interval.as_secs(),
+        config.eviction_threshold
+    );
+
+    let mut interval = monoio::time::interval(config.interval);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    interval.tick().await;
+
+    loop {
+        monoio::select! {
+            _ = interval.tick() => {}
+            _ = cancel.cancelled() => {
+                log::info!("monoio stale-series sweeper shutting down");
+                return;
+            }
+        }
+
+        let evicted = sweep_fn(config.eviction_threshold);
+
+        if evicted > 0 {
+            log::debug!("Evicted {evicted} stale metric series");
+        }
+    }
+}

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Adds optional monoio support to `fast-telemetry-export` behind a `monoio` feature, with monoio-native DogStatsD, plaintext HTTP OTLP, stale-series sweeper, and span local flusher entrypoints. ClickHouse remains on the existing Tokio path.

Also bumps the workspace crates and docs to `0.4.0` for crates.io publishing.