### PR TITLE
feat(export): add compio exporter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ authors = [
 homepage = "https://github.com/eden-dev-inc/fast-telemetry"
 license = "Apache-2.0"
 repository = "https://github.com/eden-dev-inc/fast-telemetry"
-rust-version = "1.85"
+rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.4.0" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.4.0" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.4.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.5.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.5.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.5.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"
@@ -33,7 +33,7 @@ syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 
 # --- Export: fast-telemetry-export runtime dependencies ---
 log = "0.4"
-compio = { version = "0.19.0-rc.1", default-features = false }
+compio = { version = "0.18", default-features = false }
 futures-util = "0.3"
 memchr = "2"                                                              # dogstatsd feature
 monoio = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 
 # --- Export: fast-telemetry-export runtime dependencies ---
 log = "0.4"
+compio = { version = "0.19.0-rc.1", default-features = false }
+futures-util = "0.3"
 memchr = "2"                                                              # dogstatsd feature
 monoio = "0.2.4"
 tokio = { version = "1", features = ["net", "rt", "rt-multi-thread", "time", "macros"] }

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ sweep and then sum each dynamic metric's `evict_stale(...)` result.
 enable the export crate's `monoio` feature for monoio-native loops:
 
 ```toml
-fast-telemetry-export = { version = "0.4", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.5", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 Use `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, and

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -17,18 +17,22 @@ all-features = true
 
 [features]
 default = ["dogstatsd", "otlp"]
-dogstatsd = ["dep:memchr"]
-otlp = ["dep:flate2", "dep:prost", "dep:reqwest", "fast-telemetry/otlp"]
-clickhouse = ["dep:klickhouse", "dep:indexmap", "fast-telemetry/otlp", "fast-telemetry/clickhouse"]
-monoio = ["dep:monoio"]
+tokio-runtime = ["dep:tokio", "dep:tokio-util"]
+dogstatsd = ["dep:memchr", "tokio-runtime"]
+otlp = ["dep:flate2", "dep:prost", "dep:reqwest", "fast-telemetry/otlp", "tokio-runtime"]
+clickhouse = ["dep:klickhouse", "dep:indexmap", "fast-telemetry/otlp", "fast-telemetry/clickhouse", "tokio-runtime"]
+monoio = ["dep:monoio", "tokio-runtime"]
+compio = ["dep:compio", "dep:futures-util", "dep:memchr"]
 
 [dependencies]
+compio = { workspace = true, features = ["runtime", "io", "net", "time", "io-uring"], optional = true }
+futures-util = { workspace = true, optional = true }
 log = { workspace = true }
 memchr = { workspace = true, optional = true }
 monoio = { workspace = true, optional = true }
 fast-telemetry = { workspace = true }
-tokio = { workspace = true }
-tokio-util = { workspace = true }
+tokio = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
 
 # otlp
 flate2 = { workspace = true, optional = true }

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -46,7 +46,7 @@ columns with defaults. Summary metrics are ignored.
 Enable the `monoio` feature to run exporter loops on a monoio runtime:
 
 ```toml
-fast-telemetry-export = { version = "0.4", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.5", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 The monoio entry points mirror the Tokio ones:
@@ -69,7 +69,7 @@ Enable the `compio` feature to run the DogStatsD UDP exporter and sweeper on a
 compio runtime without pulling in Tokio:
 
 ```toml
-fast-telemetry-export = { version = "0.4", default-features = false, features = ["compio"] }
+fast-telemetry-export = { version = "0.5", default-features = false, features = ["compio"] }
 ```
 
 The compio entry points are:

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -19,6 +19,7 @@ This crate provides:
 | `otlp`       | ✓       | OTLP HTTP/protobuf metrics + span exporters                                          |
 | `clickhouse` |         | Native-TCP ClickHouse exporter — first-party rows, generic primitive, and OTel schema |
 | `monoio`     |         | Monoio-native DogStatsD, OTLP HTTP/protobuf, sweeper, and span-flush helper          |
+| `compio`     |         | Compio-native DogStatsD and sweeper; span-flush helper with `otlp`                   |
 
 The ClickHouse exporter ships two layers:
 
@@ -61,6 +62,30 @@ exporter for `https://` endpoints. Monoio timer APIs require a runtime with
 timers enabled, and span-heavy applications should run one local flusher task on
 each monoio worker that records spans so low-volume thread-local span buffers
 are published for the exporter to drain.
+
+## Compio
+
+Enable the `compio` feature to run the DogStatsD UDP exporter and sweeper on a
+compio runtime without pulling in Tokio:
+
+```toml
+fast-telemetry-export = { version = "0.4", default-features = false, features = ["compio"] }
+```
+
+The compio entry points are:
+
+- `dogstatsd::run_compio(...)`
+- `sweeper::run_compio(...)`
+- `spans::run_local_flusher_compio(...)`, when the `otlp` feature is also enabled
+
+`dogstatsd::run_compio(...)` mirrors `dogstatsd::run(...)`, including
+newline-delimited batching and `DogStatsDConfig::max_packet_size` enforcement.
+Compio entry points accept any cancellation future with `Output = ()`, so callers
+can bridge their own shutdown model without constructing a runtime-local compio
+cancel token.
+As with the monoio span flusher, run one local flusher task on each compio worker
+that records spans so low-volume thread-local span buffers are published for the
+OTLP span exporter to drain.
 
 Integration tests covering both layers run against a real ClickHouse via
 `testcontainers`:

--- a/crates/fast-telemetry-export/src/dogstatsd.rs
+++ b/crates/fast-telemetry-export/src/dogstatsd.rs
@@ -81,6 +81,7 @@ impl DogStatsDConfig {
 ///
 /// `MyMetricsExportState` is the derive-generated state type for delta
 /// DogStatsD export. Keep one state instance per export sink.
+#[cfg(feature = "tokio-runtime")]
 pub async fn run<F>(
     config: DogStatsDConfig,
     cancel: tokio_util::sync::CancellationToken,
@@ -356,6 +357,160 @@ pub async fn run_monoio<F>(
     }
 }
 
+/// Run the DogStatsD export loop on a compio runtime.
+///
+/// This is the compio-native counterpart to `run`. It uses
+/// [`compio::net::UdpSocket`] and [`compio::time`], so the caller must run it
+/// inside a compio runtime. `cancel` may be any future that completes when the
+/// exporter should shut down.
+#[cfg(feature = "compio")]
+pub async fn run_compio<F>(
+    config: DogStatsDConfig,
+    cancel: impl std::future::Future<Output = ()>,
+    mut export_fn: F,
+) where
+    F: FnMut(&mut String),
+{
+    use std::net::{SocketAddr, ToSocketAddrs};
+
+    use compio::net::UdpSocket;
+    use futures_util::{FutureExt as _, select};
+
+    log::info!(
+        "Starting compio DogStatsD exporter, endpoint={}",
+        config.endpoint
+    );
+
+    let endpoint = match config.endpoint.to_socket_addrs() {
+        Ok(mut addrs) => match addrs.next() {
+            Some(addr) => addr,
+            None => {
+                log::error!("DogStatsD endpoint resolved to no addresses");
+                return;
+            }
+        },
+        Err(e) => {
+            log::error!(
+                "Failed to resolve DogStatsD endpoint {}: {e}",
+                config.endpoint
+            );
+            return;
+        }
+    };
+
+    let bind_addr: SocketAddr = if endpoint.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    }
+    .parse()
+    .expect("valid UDP bind address");
+
+    let socket = match UdpSocket::bind(bind_addr).await {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("Failed to bind compio UDP socket for DogStatsD export: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = socket.connect(endpoint).await {
+        log::error!("Failed to connect compio UDP socket to {endpoint}: {e}");
+        return;
+    }
+
+    let max_packet_size = config.max_packet_size;
+    let mut output = String::with_capacity(16384);
+    let mut batch = Vec::<u8>::with_capacity(max_packet_size);
+    let mut interval = compio::time::interval(config.interval);
+    interval.tick().await;
+    let cancel = cancel.fuse();
+    let mut cancel = std::pin::pin!(cancel);
+
+    loop {
+        let tick = interval.tick();
+        let tick = std::pin::pin!(tick);
+
+        select! {
+            _ = tick.fuse() => {},
+            _ = cancel.as_mut() => {
+                log::info!("compio DogStatsD exporter shutting down");
+                return;
+            }
+        }
+
+        output.clear();
+        export_fn(&mut output);
+
+        if output.is_empty() {
+            continue;
+        }
+
+        let output_bytes = output.as_bytes();
+        batch.clear();
+
+        let mut total_sent = 0usize;
+        let mut batch_count = 0usize;
+        let mut metric_count = 0usize;
+        let mut start = 0usize;
+
+        for nl in memchr::memchr_iter(b'\n', output_bytes) {
+            let end = nl + 1;
+            let line = &output_bytes[start..end];
+            let line_len = line.len();
+            metric_count += 1;
+
+            if line_len > max_packet_size {
+                log::warn!(
+                    "Dropping oversized metric line ({line_len} bytes, max {max_packet_size})"
+                );
+                start = end;
+                continue;
+            }
+
+            if !batch.is_empty() && batch.len() + line_len > max_packet_size {
+                if let Some(n) = send_compio_batch(&socket, &mut batch, "DogStatsD batch").await {
+                    total_sent += n;
+                    batch_count += 1;
+                }
+            }
+
+            batch.extend_from_slice(line);
+            start = end;
+        }
+
+        if start < output_bytes.len() {
+            let line = &output_bytes[start..];
+            let line_len = line.len();
+            metric_count += 1;
+
+            if line_len <= max_packet_size {
+                if !batch.is_empty() && batch.len() + line_len > max_packet_size {
+                    if let Some(n) = send_compio_batch(&socket, &mut batch, "DogStatsD batch").await
+                    {
+                        total_sent += n;
+                        batch_count += 1;
+                    }
+                }
+                batch.extend_from_slice(line);
+            } else {
+                log::warn!("Dropping oversized trailing metric ({line_len} bytes)");
+            }
+        }
+
+        if !batch.is_empty()
+            && let Some(n) = send_compio_batch(&socket, &mut batch, "final DogStatsD batch").await
+        {
+            total_sent += n;
+            batch_count += 1;
+        }
+
+        log::debug!(
+            "compio DogStatsD export: {metric_count} metrics, {batch_count} batches, {total_sent} bytes"
+        );
+    }
+}
+
 #[cfg(feature = "monoio")]
 async fn send_monoio_batch(
     socket: &monoio::net::udp::UdpSocket,
@@ -371,6 +526,26 @@ async fn send_monoio_batch(
         Ok(n) => Some(n),
         Err(e) => {
             log::warn!("Failed to send monoio {context}: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(feature = "compio")]
+async fn send_compio_batch(
+    socket: &compio::net::UdpSocket,
+    batch: &mut Vec<u8>,
+    context: &str,
+) -> Option<usize> {
+    let send_buf = std::mem::take(batch);
+    let compio::BufResult(result, mut send_buf) = socket.send(send_buf).await;
+    send_buf.clear();
+    *batch = send_buf;
+
+    match result {
+        Ok(n) => Some(n),
+        Err(e) => {
+            log::warn!("Failed to send compio {context}: {e}");
             None
         }
     }

--- a/crates/fast-telemetry-export/src/lib.rs
+++ b/crates/fast-telemetry-export/src/lib.rs
@@ -20,6 +20,8 @@
 //!   metric's `evict_stale(...)` method.
 //! - The `monoio` feature adds monoio-native DogStatsD, OTLP HTTP/protobuf, and
 //!   stale-series sweep loops, plus a per-worker span flusher.
+//! - The `compio` feature adds compio-native DogStatsD and stale-series sweep
+//!   loops, plus a per-worker span flusher when `otlp` is also enabled.
 //!
 //! # Features
 //!
@@ -28,11 +30,12 @@
 //! - `clickhouse` — ClickHouse native-protocol metrics exporter, including
 //!   first-party rows and OTel-standard table support (via [`klickhouse`])
 //! - `monoio` — monoio-native exporter loops for monoio applications
+//! - `compio` — compio-native exporter loops for compio applications
 
 #[cfg(feature = "clickhouse")]
 pub mod clickhouse;
 
-#[cfg(feature = "dogstatsd")]
+#[cfg(any(feature = "dogstatsd", feature = "compio"))]
 pub mod dogstatsd;
 
 #[cfg(feature = "otlp")]

--- a/crates/fast-telemetry-export/src/lib.rs
+++ b/crates/fast-telemetry-export/src/lib.rs
@@ -28,7 +28,7 @@
 //! - `dogstatsd` (default) — DogStatsD UDP exporter
 //! - `otlp` (default) — OTLP HTTP/protobuf metrics and span exporters
 //! - `clickhouse` — ClickHouse native-protocol metrics exporter, including
-//!   first-party rows and OTel-standard table support (via [`klickhouse`])
+//!   first-party rows and OTel-standard table support (via `klickhouse`)
 //! - `monoio` — monoio-native exporter loops for monoio applications
 //! - `compio` — compio-native exporter loops for compio applications
 

--- a/crates/fast-telemetry-export/src/spans.rs
+++ b/crates/fast-telemetry-export/src/spans.rs
@@ -199,6 +199,41 @@ pub async fn run_local_flusher_monoio(
     }
 }
 
+/// Periodically flush this compio worker's thread-local span buffer.
+///
+/// This is the compio-native counterpart to [`run_local_flusher_monoio`]. Run
+/// one task on each compio worker that records spans; the OTLP span exporter can
+/// remain [`spawn`]. `cancel` may be any future that completes when the flusher
+/// should shut down.
+#[cfg(feature = "compio")]
+pub async fn run_local_flusher_compio(
+    collector: Arc<SpanCollector>,
+    interval: Duration,
+    cancel: impl std::future::Future<Output = ()>,
+) {
+    use futures_util::{FutureExt as _, select};
+
+    let mut interval = compio::time::interval(interval);
+    interval.tick().await;
+    let cancel = cancel.fuse();
+    let mut cancel = std::pin::pin!(cancel);
+
+    loop {
+        let tick = interval.tick();
+        let tick = std::pin::pin!(tick);
+
+        select! {
+            _ = tick.fuse() => {
+                collector.flush_local();
+            },
+            _ = cancel.as_mut() => {
+                collector.flush_local();
+                return;
+            }
+        }
+    }
+}
+
 /// Run the OTLP span export loop.
 ///
 /// Drains completed spans from the collector in batches and sends them to

--- a/crates/fast-telemetry-export/src/spans.rs
+++ b/crates/fast-telemetry-export/src/spans.rs
@@ -201,7 +201,7 @@ pub async fn run_local_flusher_monoio(
 
 /// Periodically flush this compio worker's thread-local span buffer.
 ///
-/// This is the compio-native counterpart to [`run_local_flusher_monoio`]. Run
+/// This is the compio-native counterpart to `run_local_flusher_monoio`. Run
 /// one task on each compio worker that records spans; the OTLP span exporter can
 /// remain [`spawn`]. `cancel` may be any future that completes when the flusher
 /// should shut down.

--- a/crates/fast-telemetry-export/src/sweeper.rs
+++ b/crates/fast-telemetry-export/src/sweeper.rs
@@ -9,6 +9,7 @@
 
 use std::time::Duration;
 
+#[cfg(feature = "tokio-runtime")]
 use tokio_util::sync::CancellationToken;
 
 /// Default sweep interval.
@@ -79,6 +80,7 @@ impl SweepConfig {
 ///         + m.latency_by_endpoint.evict_stale(threshold)
 /// }));
 /// ```
+#[cfg(feature = "tokio-runtime")]
 pub async fn run<F>(config: SweepConfig, cancel: CancellationToken, mut sweep_fn: F)
 where
     F: FnMut(u32) -> usize,
@@ -139,6 +141,52 @@ where
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
                 log::info!("monoio stale-series sweeper shutting down");
+                return;
+            }
+        }
+
+        let evicted = sweep_fn(config.eviction_threshold);
+
+        if evicted > 0 {
+            log::debug!("Evicted {evicted} stale metric series");
+        }
+    }
+}
+
+/// Run the stale-series sweep loop on a compio runtime.
+///
+/// This is the compio-native counterpart to `run`. It uses
+/// [`compio::time`], so the caller must run it inside a compio runtime. `cancel`
+/// may be any future that completes when the sweeper should shut down.
+#[cfg(feature = "compio")]
+pub async fn run_compio<F>(
+    config: SweepConfig,
+    cancel: impl std::future::Future<Output = ()>,
+    mut sweep_fn: F,
+) where
+    F: FnMut(u32) -> usize,
+{
+    use futures_util::{FutureExt as _, select};
+
+    log::info!(
+        "Starting compio stale-series sweeper, interval={}s, eviction_threshold={}",
+        config.interval.as_secs(),
+        config.eviction_threshold
+    );
+
+    let mut interval = compio::time::interval(config.interval);
+    interval.tick().await;
+    let cancel = cancel.fuse();
+    let mut cancel = std::pin::pin!(cancel);
+
+    loop {
+        let tick = interval.tick();
+        let tick = std::pin::pin!(tick);
+
+        select! {
+            _ = tick.fuse() => {},
+            _ = cancel.as_mut() => {
+                log::info!("compio stale-series sweeper shutting down");
                 return;
             }
         }

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Add compio-native DogStatsD export, stale-series sweeping, and span local flushing support. The compio loops use runtime intervals so export and sweep cadence remains schedule-based under slow work.

Follow roughly the pattern set for the monio export.

Wire the optional compio feature through the export crate, including the futures-util dependency needed for cancellation selection, and document that the compio span flusher is available when both compio and otlp are enabled.