### PR TITLE
Add shared telemetry runtime API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.5.1" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.5.0" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.5.1" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.6.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.6.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.6.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For detailed benchmark results and methodology, see
 | Feature      | Default | Description                                      |
 | ------------ | ------- | ------------------------------------------------ |
 | `macros`     | ✓       | `ExportMetrics` and `LabelEnum` derive macros    |
-| `runtime`    |         | Shared metric runtime/registry API               |
+| `runtime`    |         | Shared telemetry runtime for metrics and spans   |
 | `otlp`       |         | OTLP protobuf export support                     |
 | `clickhouse` |         | First-party ClickHouse row export support        |
 | `eviction`   |         | Enable stale-series eviction for dynamic metrics |
@@ -232,6 +232,11 @@ Enable the `runtime` feature when a parent service should own telemetry and pass
 the same concrete runtime type into child crates. The runtime owns metric
 registration and a shared span collector so export setup happens once.
 
+```toml
+[dependencies]
+fast-telemetry = { version = "0.5", features = ["runtime"] }
+```
+
 ```rust
 use fast_telemetry::{MetricScope, Runtime, RuntimeConfig, SpanKind};
 use std::sync::Arc;
@@ -240,7 +245,6 @@ pub type TelemetryRuntime = fast_telemetry::Runtime;
 
 let runtime: Arc<TelemetryRuntime> = Runtime::new(RuntimeConfig::default());
 let metrics = runtime.register_metrics(MetricScope::new("myapp"), AppMetrics::new());
-let span_collector = Arc::clone(runtime.span_collector());
 
 metrics.requests.inc();
 
@@ -248,11 +252,96 @@ let span = runtime.start_span("handle_request", SpanKind::Server);
 drop(span);
 ```
 
-Registration is construction-time work. Keep hot paths on direct metric handles
-from the returned `RegisteredMetrics<M>` value, or on handles pre-resolved inside
-your telemetry struct; do not perform registry lookup per operation. Clone the
-runtime's span collector once when wiring exporters, and start spans through the
-shared runtime or collector.
+#### Parent Service
+
+The top-level service should create one runtime and pass `Arc` clones to child
+crates that accept telemetry. Exporters should also be wired from this runtime,
+so metrics and spans are collected from one shared telemetry service.
+Metric exporters that consume structured observations should call
+`runtime.visit_metrics(&mut visitor)`. Span exporters should clone the runtime's
+span collector once.
+
+```rust
+use fast_telemetry::{Runtime, RuntimeConfig};
+use fast_telemetry_export::spans::{self, SpanExportConfig};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+pub type TelemetryRuntime = fast_telemetry::Runtime;
+
+let runtime: Arc<TelemetryRuntime> = Runtime::new(RuntimeConfig::default());
+
+let span_cancel = CancellationToken::new();
+let _span_exporter = spans::spawn(
+    Arc::clone(runtime.span_collector()),
+    SpanExportConfig::new("http://otel-collector:4318").with_service_name("myapp"),
+    span_cancel.clone(),
+);
+
+let cache = shardmap::ShardMap::with_parent_telemetry(Some(Arc::clone(&runtime)));
+```
+
+#### Child Crates
+
+Child crates should re-export the exact runtime type they accept, register their
+metrics once during construction, and store the returned `RegisteredMetrics<M>`
+or direct handles inside their own telemetry state.
+
+```rust
+use fast_telemetry::{
+    Counter, ExportMetrics, MetricScope, RegisteredMetrics, Runtime, RuntimeConfig, SpanKind,
+};
+use std::sync::Arc;
+
+pub type TelemetryRuntime = fast_telemetry::Runtime;
+
+#[derive(ExportMetrics)]
+#[metric_prefix = "shardmap"]
+pub struct CacheMetrics {
+    #[help = "Cache lookups"]
+    lookups: Counter,
+}
+
+impl CacheMetrics {
+    fn new() -> Self {
+        Self {
+            lookups: Counter::new(4),
+        }
+    }
+}
+
+pub struct CacheTelemetry {
+    runtime: Arc<TelemetryRuntime>,
+    metrics: RegisteredMetrics<CacheMetrics>,
+}
+
+impl CacheTelemetry {
+    pub fn with_parent_telemetry(runtime: Option<Arc<TelemetryRuntime>>) -> Self {
+        let runtime = runtime.unwrap_or_else(|| Runtime::new(RuntimeConfig::default()));
+        let metrics =
+            runtime.register_metrics(MetricScope::new("shardmap.cache"), CacheMetrics::new());
+        Self { runtime, metrics }
+    }
+
+    pub fn record_lookup(&self) {
+        self.metrics.lookups.inc();
+
+        let _span = self.runtime.start_span("shardmap.cache.lookup", SpanKind::Internal);
+        // lookup work
+    }
+}
+```
+
+#### Performance Rules
+
+- Create one `Runtime` per service and share it across crate boundaries.
+- Register metric groups once during construction, not during operations.
+- Keep hot paths on `RegisteredMetrics<M>` or direct metric handles.
+- Clone `runtime.span_collector()` once when wiring span exporters.
+- Start spans through the shared runtime or its shared `SpanCollector`.
+- Do not create a new `Runtime` or `SpanCollector` per child crate when a parent
+  runtime is available.
+- Do not look up metric groups in the registry per operation.
 
 ### Extrema Gauges
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ parsing Prometheus, DogStatsD, OTLP, or ClickHouse output.
 Enable the `runtime` feature when a parent service should own telemetry and pass
 the same concrete runtime type into child crates. The runtime owns metric
 registration and a shared span collector so export setup happens once.
+`RuntimeConfig` is currently reserved for future runtime tuning; use
+`RuntimeConfig::default()` when creating a runtime.
 
 ```toml
 [dependencies]
@@ -281,6 +283,17 @@ let _span_exporter = spans::spawn(
 let cache = shardmap::ShardMap::with_parent_telemetry(Some(Arc::clone(&runtime)));
 ```
 
+Metric export and span export use different surfaces from the same runtime:
+
+```rust
+let mut visitor = MyMetricVisitor::default();
+runtime.visit_metrics(&mut visitor);
+
+let mut completed_spans = Vec::new();
+runtime.flush_local_spans();
+runtime.drain_spans_into(&mut completed_spans);
+```
+
 #### Child Crates
 
 Child crates should re-export the exact runtime type they accept, register their
@@ -328,6 +341,15 @@ impl CacheTelemetry {
 
         let _span = self.runtime.start_span("shardmap.cache.lookup", SpanKind::Internal);
         // lookup work
+    }
+
+    pub fn record_inbound_lookup(&self, traceparent: Option<&str>) {
+        let _span = self.runtime.start_span_from_traceparent(
+            traceparent,
+            "shardmap.cache.inbound_lookup",
+            SpanKind::Server,
+        );
+        // inbound lookup work
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -226,26 +226,33 @@ metric names and borrowed `MetricLabels`, including borrowed canonical dynamic
 label pairs, so custom exporters can collect report frames or UI models without
 parsing Prometheus, DogStatsD, OTLP, or ClickHouse output.
 
-### Runtime Registry
+### Runtime
 
 Enable the `runtime` feature when a parent service should own telemetry and pass
-the same concrete runtime type into child crates.
+the same concrete runtime type into child crates. The runtime owns metric
+registration and a shared span collector so export setup happens once.
 
 ```rust
-use fast_telemetry::{MetricScope, Runtime, RuntimeConfig};
+use fast_telemetry::{MetricScope, Runtime, RuntimeConfig, SpanKind};
 use std::sync::Arc;
 
 pub type TelemetryRuntime = fast_telemetry::Runtime;
 
 let runtime: Arc<TelemetryRuntime> = Runtime::new(RuntimeConfig::default());
 let metrics = runtime.register_metrics(MetricScope::new("myapp"), AppMetrics::new());
+let span_collector = Arc::clone(runtime.span_collector());
 
 metrics.requests.inc();
+
+let span = runtime.start_span("handle_request", SpanKind::Server);
+drop(span);
 ```
 
 Registration is construction-time work. Keep hot paths on direct metric handles
 from the returned `RegisteredMetrics<M>` value, or on handles pre-resolved inside
-your telemetry struct; do not perform registry lookup per operation.
+your telemetry struct; do not perform registry lookup per operation. Clone the
+runtime's span collector once when wiring exporters, and start spans through the
+shared runtime or collector.
 
 ### Extrema Gauges
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For detailed benchmark results and methodology, see
 | Feature      | Default | Description                                      |
 | ------------ | ------- | ------------------------------------------------ |
 | `macros`     | ✓       | `ExportMetrics` and `LabelEnum` derive macros    |
+| `runtime`    |         | Shared metric runtime/registry API               |
 | `otlp`       |         | OTLP protobuf export support                     |
 | `clickhouse` |         | First-party ClickHouse row export support        |
 | `eviction`   |         | Enable stale-series eviction for dynamic metrics |
@@ -224,6 +225,27 @@ metrics.visit_metrics(&mut visitor);
 metric names and borrowed `MetricLabels`, including borrowed canonical dynamic
 label pairs, so custom exporters can collect report frames or UI models without
 parsing Prometheus, DogStatsD, OTLP, or ClickHouse output.
+
+### Runtime Registry
+
+Enable the `runtime` feature when a parent service should own telemetry and pass
+the same concrete runtime type into child crates.
+
+```rust
+use fast_telemetry::{MetricScope, Runtime, RuntimeConfig};
+use std::sync::Arc;
+
+pub type TelemetryRuntime = fast_telemetry::Runtime;
+
+let runtime: Arc<TelemetryRuntime> = Runtime::new(RuntimeConfig::default());
+let metrics = runtime.register_metrics(MetricScope::new("myapp"), AppMetrics::new());
+
+metrics.requests.inc();
+```
+
+Registration is construction-time work. Keep hot paths on direct metric handles
+from the returned `RegisteredMetrics<M>` value, or on handles pre-resolved inside
+your telemetry struct; do not perform registry lookup per operation.
 
 ### Extrema Gauges
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ dynamic metric types. Without it, these APIs are not available.
 
 ```toml
 [dependencies]
-fast-telemetry = "0.4"
+fast-telemetry = "0.6"
 ```
 
 ### Define Metrics
@@ -234,7 +234,7 @@ registration and a shared span collector so export setup happens once.
 
 ```toml
 [dependencies]
-fast-telemetry = { version = "0.5", features = ["runtime"] }
+fast-telemetry = { version = "0.6", features = ["runtime"] }
 ```
 
 ```rust
@@ -693,7 +693,7 @@ sweep and then sum each dynamic metric's `evict_stale(...)` result.
 enable the export crate's `monoio` feature for monoio-native loops:
 
 ```toml
-fast-telemetry-export = { version = "0.5", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.6", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 Use `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, and

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -46,7 +46,7 @@ columns with defaults. Summary metrics are ignored.
 Enable the `monoio` feature to run exporter loops on a monoio runtime:
 
 ```toml
-fast-telemetry-export = { version = "0.5", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.6", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 The monoio entry points mirror the Tokio ones:
@@ -69,7 +69,7 @@ Enable the `compio` feature to run the DogStatsD UDP exporter and sweeper on a
 compio runtime without pulling in Tokio:
 
 ```toml
-fast-telemetry-export = { version = "0.5", default-features = false, features = ["compio"] }
+fast-telemetry-export = { version = "0.6", default-features = false, features = ["compio"] }
 ```
 
 The compio entry points are:

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-macros/src/lib.rs
+++ b/crates/fast-telemetry-macros/src/lib.rs
@@ -1236,6 +1236,12 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
             }
         }
 
+        impl fast_telemetry::ExportMetrics for #name {
+            fn visit_metrics<V: fast_telemetry::MetricVisitor + ?Sized>(&self, visitor: &mut V) {
+                #(#visitor_exports)*
+            }
+        }
+
         impl #name {
             /// Export all metrics in Prometheus text exposition format.
             pub fn export_prometheus(&self, output: &mut String) {
@@ -1306,7 +1312,7 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
 
             /// Visit all metrics as structured cumulative observations.
             pub fn visit_metrics<V: fast_telemetry::MetricVisitor + ?Sized>(&self, visitor: &mut V) {
-                #(#visitor_exports)*
+                fast_telemetry::ExportMetrics::visit_metrics(self, visitor);
             }
 
             #otlp_method

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 [features]
 default = ["macros"]
 macros = ["dep:fast-telemetry-macros"]
+runtime = []
 otlp = ["dep:opentelemetry-proto", "dep:prost"]
 clickhouse = ["dep:indexmap", "dep:klickhouse"]
 shuttle-tests = ["dep:shuttle"]

--- a/crates/fast-telemetry/README.md
+++ b/crates/fast-telemetry/README.md
@@ -15,7 +15,7 @@ service for metric registration, span collection, and export setup while child
 crates keep hot paths on direct metric handles.
 
 See the [workspace README](../../README.md) for full documentation, examples,
-and API reference.
+runtime integration rules, and API reference.
 
 ## Companion Crates
 

--- a/crates/fast-telemetry/README.md
+++ b/crates/fast-telemetry/README.md
@@ -10,8 +10,9 @@ export.
 in-process export path for custom `MetricVisitor` implementations that need
 typed cumulative observations instead of a wire-format string or protobuf.
 
-Enable the `runtime` feature when a parent crate should own a shared telemetry
-registry and child crates should keep hot paths on direct metric handles.
+Enable the `runtime` feature when a parent crate should own one shared telemetry
+service for metric registration, span collection, and export setup while child
+crates keep hot paths on direct metric handles.
 
 See the [workspace README](../../README.md) for full documentation, examples,
 and API reference.

--- a/crates/fast-telemetry/README.md
+++ b/crates/fast-telemetry/README.md
@@ -10,6 +10,9 @@ export.
 in-process export path for custom `MetricVisitor` implementations that need
 typed cumulative observations instead of a wire-format string or protobuf.
 
+Enable the `runtime` feature when a parent crate should own a shared telemetry
+registry and child crates should keep hot paths on direct metric handles.
+
 See the [workspace README](../../README.md) for full documentation, examples,
 and API reference.
 

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -29,6 +29,8 @@
 mod export;
 pub(crate) mod internal;
 mod metric;
+#[cfg(feature = "runtime")]
+mod runtime;
 pub mod span;
 mod temporality;
 
@@ -47,6 +49,7 @@ pub mod __macro_support {
         FastFormat,
     };
 }
+pub use metric::ExportMetrics;
 pub use metric::{
     Counter, Distribution, DistributionSnapshot, DynamicCounter, DynamicCounterSeries,
     DynamicDistribution, DynamicDistributionSeries, DynamicGauge, DynamicGaugeI64,
@@ -58,6 +61,8 @@ pub use metric::{
 };
 #[cfg(feature = "eviction")]
 pub use metric::{advance_cycle, current_cycle};
+#[cfg(feature = "runtime")]
+pub use runtime::{MetricScope, RegisteredMetrics, Runtime, RuntimeConfig};
 pub use span::{
     CompletedSpan, Span, SpanAttribute, SpanCollector, SpanEvent, SpanId, SpanKind, SpanStatus,
     SpanValue, TraceId, current_span_id, current_trace_id,

--- a/crates/fast-telemetry/src/metric/mod.rs
+++ b/crates/fast-telemetry/src/metric/mod.rs
@@ -37,6 +37,6 @@ pub use min_gauge::MinGauge;
 pub use min_gauge_f64::MinGaugeF64;
 pub use sampled_timer::{LabeledSampledTimer, SampledTimer, SampledTimerGuard};
 pub use visitor::{
-    DistributionSnapshot, HistogramSnapshot, MetricKind, MetricLabel, MetricLabels,
+    DistributionSnapshot, ExportMetrics, HistogramSnapshot, MetricKind, MetricLabel, MetricLabels,
     MetricLabelsIter, MetricMeta, MetricVisitor,
 };

--- a/crates/fast-telemetry/src/metric/visitor.rs
+++ b/crates/fast-telemetry/src/metric/visitor.rs
@@ -176,6 +176,14 @@ pub trait MetricVisitor {
     }
 }
 
+/// Structured export surface implemented by metric groups.
+///
+/// `#[derive(ExportMetrics)]` implements this trait and also keeps generating
+/// the inherent `visit_metrics(...)` convenience method.
+pub trait ExportMetrics {
+    fn visit_metrics<V: MetricVisitor + ?Sized>(&self, visitor: &mut V);
+}
+
 impl HistogramSnapshot for Histogram {
     fn count(&self) -> u64 {
         self.count()

--- a/crates/fast-telemetry/src/runtime.rs
+++ b/crates/fast-telemetry/src/runtime.rs
@@ -1,10 +1,13 @@
-//! Runtime registry for sharing pre-built metric groups.
+//! Runtime service for sharing telemetry across crate boundaries.
 //!
-//! The runtime owns metric groups for export/snapshot traversal. Recording
-//! remains a direct call on metric handles owned by the registered metric type.
+//! The runtime owns metric groups for export/snapshot traversal and one shared
+//! span collector. Recording remains a direct call on metric handles owned by
+//! the registered metric type, and span recording forwards to the embedded
+//! collector without a registry lookup.
 
-use crate::{ExportMetrics, MetricVisitor};
+use crate::{CompletedSpan, ExportMetrics, MetricVisitor, Span, SpanCollector, SpanKind};
 use parking_lot::RwLock;
+use std::borrow::Cow;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -51,11 +54,14 @@ impl From<String> for MetricScope {
 
 /// Shared telemetry runtime.
 ///
-/// Register metric groups once during construction, then keep updating the
-/// returned metric handles directly on hot paths.
+/// Share one runtime across crate boundaries so metric registration, span
+/// collection, and export setup are owned once per service. Register metric
+/// groups during construction, then keep updating the returned metric handles
+/// directly on hot paths.
 pub struct Runtime {
     config: RuntimeConfig,
     registry: RwLock<Vec<RegisteredMetricGroup>>,
+    span_collector: Arc<SpanCollector>,
 }
 
 impl Runtime {
@@ -64,12 +70,53 @@ impl Runtime {
         Arc::new(Self {
             config,
             registry: RwLock::new(Vec::new()),
+            span_collector: Arc::new(SpanCollector::new(8, 4096)),
         })
     }
 
     /// Return this runtime's configuration.
     pub fn config(&self) -> &RuntimeConfig {
         &self.config
+    }
+
+    /// Return the shared span collector owned by this runtime.
+    ///
+    /// Clone this once when wiring exporters. Hot-path span creation should use
+    /// [`start_span`](Self::start_span) or keep this borrowed through the
+    /// shared runtime rather than cloning an [`Arc`] per operation.
+    pub fn span_collector(&self) -> &Arc<SpanCollector> {
+        &self.span_collector
+    }
+
+    /// Create a new root span with a fresh trace ID.
+    ///
+    /// This forwards to the runtime's shared [`SpanCollector`], keeping the
+    /// collector service shared across crate boundaries.
+    pub fn start_span(&self, name: impl Into<Cow<'static, str>>, kind: SpanKind) -> Span {
+        self.span_collector.start_span(name, kind)
+    }
+
+    /// Create a root span from an incoming W3C `traceparent` header.
+    ///
+    /// This forwards to the runtime's shared [`SpanCollector`].
+    pub fn start_span_from_traceparent(
+        &self,
+        traceparent: Option<&str>,
+        name: impl Into<Cow<'static, str>>,
+        kind: SpanKind,
+    ) -> Span {
+        self.span_collector
+            .start_span_from_traceparent(traceparent, name, kind)
+    }
+
+    /// Flush spans recorded on the current thread into the shared collector.
+    pub fn flush_local_spans(&self) {
+        self.span_collector.flush_local();
+    }
+
+    /// Drain completed spans from the shared collector into `buf`.
+    pub fn drain_spans_into(&self, buf: &mut Vec<CompletedSpan>) {
+        self.span_collector.drain_into(buf);
     }
 
     /// Register a metric group and return direct handles to it.

--- a/crates/fast-telemetry/src/runtime.rs
+++ b/crates/fast-telemetry/src/runtime.rs
@@ -12,6 +12,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 /// Configuration for [`Runtime`].
+///
+/// This is currently reserved for future runtime tuning. Use
+/// [`RuntimeConfig::default`] when creating a runtime.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct RuntimeConfig {}

--- a/crates/fast-telemetry/src/runtime.rs
+++ b/crates/fast-telemetry/src/runtime.rs
@@ -1,0 +1,187 @@
+//! Runtime registry for sharing pre-built metric groups.
+//!
+//! The runtime owns metric groups for export/snapshot traversal. Recording
+//! remains a direct call on metric handles owned by the registered metric type.
+
+use crate::{ExportMetrics, MetricVisitor};
+use parking_lot::RwLock;
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Configuration for [`Runtime`].
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct RuntimeConfig {}
+
+/// Logical scope for a registered metric group.
+///
+/// A scope is registry metadata for grouping/filtering registered metric
+/// groups. It does not rewrite metric names emitted by the metric group.
+///
+/// Downstream crates should expose their accepted runtime type and scope names
+/// rather than asking callers to guess the exact dependency edge.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MetricScope {
+    name: Arc<str>,
+}
+
+impl MetricScope {
+    /// Create a metric scope from a stable logical name.
+    pub fn new(name: impl Into<Arc<str>>) -> Self {
+        Self { name: name.into() }
+    }
+
+    /// Return the scope name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl From<&'static str> for MetricScope {
+    fn from(name: &'static str) -> Self {
+        Self::new(name)
+    }
+}
+
+impl From<String> for MetricScope {
+    fn from(name: String) -> Self {
+        Self::new(Arc::<str>::from(name))
+    }
+}
+
+/// Shared telemetry runtime.
+///
+/// Register metric groups once during construction, then keep updating the
+/// returned metric handles directly on hot paths.
+pub struct Runtime {
+    config: RuntimeConfig,
+    registry: RwLock<Vec<RegisteredMetricGroup>>,
+}
+
+impl Runtime {
+    /// Create a runtime wrapped in [`Arc`] for parent/child sharing.
+    pub fn new(config: RuntimeConfig) -> Arc<Self> {
+        Arc::new(Self {
+            config,
+            registry: RwLock::new(Vec::new()),
+        })
+    }
+
+    /// Return this runtime's configuration.
+    pub fn config(&self) -> &RuntimeConfig {
+        &self.config
+    }
+
+    /// Register a metric group and return direct handles to it.
+    ///
+    /// Registry work happens here. Recording should use the returned
+    /// [`RegisteredMetrics`] value, or handles pre-resolved inside `metrics`.
+    pub fn register_metrics<M>(&self, scope: MetricScope, metrics: M) -> RegisteredMetrics<M>
+    where
+        M: ExportMetrics + Send + Sync + 'static,
+    {
+        let metrics = Arc::new(metrics);
+        let erased_metrics: Arc<dyn ErasedExportMetrics> = metrics.clone();
+        self.registry.write().push(RegisteredMetricGroup {
+            scope: scope.clone(),
+            metrics: erased_metrics,
+        });
+
+        RegisteredMetrics { scope, metrics }
+    }
+
+    /// Visit all registered metric groups as structured cumulative metrics.
+    pub fn visit_metrics<V>(&self, visitor: &mut V)
+    where
+        V: MetricVisitor,
+    {
+        for group in self.registry.read().iter() {
+            group.metrics.visit_metrics(visitor);
+        }
+    }
+
+    /// Visit registered metric groups that match `scope`.
+    pub fn visit_metrics_for_scope<V>(&self, scope: &MetricScope, visitor: &mut V)
+    where
+        V: MetricVisitor,
+    {
+        for group in self.registry.read().iter() {
+            if &group.scope == scope {
+                group.metrics.visit_metrics(visitor);
+            }
+        }
+    }
+
+    /// Return the number of registered metric groups.
+    pub fn registered_metrics_len(&self) -> usize {
+        self.registry.read().len()
+    }
+
+    /// Return the registered metric scopes.
+    pub fn scopes(&self) -> Vec<MetricScope> {
+        self.registry
+            .read()
+            .iter()
+            .map(|group| group.scope.clone())
+            .collect()
+    }
+}
+
+/// Direct handles to a metric group registered with a [`Runtime`].
+#[must_use = "keep RegisteredMetrics so hot paths can update direct metric handles"]
+pub struct RegisteredMetrics<M> {
+    scope: MetricScope,
+    metrics: Arc<M>,
+}
+
+impl<M> RegisteredMetrics<M> {
+    /// Return this metric group's scope.
+    pub fn scope(&self) -> &MetricScope {
+        &self.scope
+    }
+
+    /// Return the shared metric group.
+    pub fn metrics(&self) -> &Arc<M> {
+        &self.metrics
+    }
+
+    /// Convert into the shared metric group.
+    pub fn into_metrics(self) -> Arc<M> {
+        self.metrics
+    }
+}
+
+impl<M> Clone for RegisteredMetrics<M> {
+    fn clone(&self) -> Self {
+        Self {
+            scope: self.scope.clone(),
+            metrics: Arc::clone(&self.metrics),
+        }
+    }
+}
+
+impl<M> Deref for RegisteredMetrics<M> {
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        &self.metrics
+    }
+}
+
+struct RegisteredMetricGroup {
+    scope: MetricScope,
+    metrics: Arc<dyn ErasedExportMetrics>,
+}
+
+trait ErasedExportMetrics: Send + Sync {
+    fn visit_metrics(&self, visitor: &mut dyn MetricVisitor);
+}
+
+impl<M> ErasedExportMetrics for M
+where
+    M: ExportMetrics + Send + Sync + 'static,
+{
+    fn visit_metrics(&self, visitor: &mut dyn MetricVisitor) {
+        ExportMetrics::visit_metrics(self, visitor);
+    }
+}

--- a/crates/fast-telemetry/tests/runtime_test.rs
+++ b/crates/fast-telemetry/tests/runtime_test.rs
@@ -2,8 +2,9 @@
 
 use fast_telemetry::{
     Counter, ExportMetrics, HistogramSnapshot, MetricKind, MetricLabels, MetricMeta, MetricScope,
-    MetricVisitor, Runtime, RuntimeConfig,
+    MetricVisitor, Runtime, RuntimeConfig, SpanKind,
 };
+use std::sync::Arc;
 
 #[derive(ExportMetrics)]
 #[metric_prefix = "cache"]
@@ -74,4 +75,31 @@ fn runtime_registers_metrics_and_returns_direct_handles() {
     let mut missing_scope_visitor = CounterVisitor::default();
     runtime.visit_metrics_for_scope(&MetricScope::new("other"), &mut missing_scope_visitor);
     assert!(missing_scope_visitor.counters.is_empty());
+}
+
+#[test]
+fn runtime_owns_shared_span_collector() {
+    let runtime = Runtime::new(RuntimeConfig::default());
+    let exporter_collector = Arc::clone(runtime.span_collector());
+
+    {
+        let mut span = runtime.start_span("cache_lookup", SpanKind::Internal);
+        span.set_attribute("component", "shardmap");
+    }
+
+    {
+        let mut span = runtime.start_span("index_probe", SpanKind::Internal);
+        span.set_attribute("hit", true);
+    }
+
+    runtime.flush_local_spans();
+
+    let mut spans = Vec::new();
+    exporter_collector.drain_into(&mut spans);
+
+    assert!(Arc::ptr_eq(runtime.span_collector(), &exporter_collector));
+    assert_eq!(runtime.span_collector().recorded_count(), 2);
+    assert_eq!(spans.len(), 2);
+    assert!(spans.iter().any(|span| span.name == "cache_lookup"));
+    assert!(spans.iter().any(|span| span.name == "index_probe"));
 }

--- a/crates/fast-telemetry/tests/runtime_test.rs
+++ b/crates/fast-telemetry/tests/runtime_test.rs
@@ -21,6 +21,21 @@ impl CacheTelemetry {
     }
 }
 
+#[derive(ExportMetrics)]
+#[metric_prefix = "queue"]
+struct QueueTelemetry {
+    #[help = "Queue pushes"]
+    pushes: Counter,
+}
+
+impl QueueTelemetry {
+    fn new() -> Self {
+        Self {
+            pushes: Counter::new(4),
+        }
+    }
+}
+
 #[derive(Default)]
 struct CounterVisitor {
     counters: Vec<(String, i64)>,
@@ -78,6 +93,43 @@ fn runtime_registers_metrics_and_returns_direct_handles() {
 }
 
 #[test]
+fn runtime_filters_multiple_metric_scopes() {
+    let runtime = Runtime::new(RuntimeConfig::default());
+    let cache = runtime.register_metrics(MetricScope::new("shardmap.cache"), CacheTelemetry::new());
+    let queue = runtime.register_metrics(MetricScope::new("shardmap.queue"), QueueTelemetry::new());
+
+    cache.hits.add(3);
+    queue.pushes.add(5);
+
+    assert_eq!(runtime.registered_metrics_len(), 2);
+    assert_eq!(
+        runtime
+            .scopes()
+            .iter()
+            .map(|scope| scope.name())
+            .collect::<Vec<_>>(),
+        vec!["shardmap.cache", "shardmap.queue"]
+    );
+
+    let mut all_visitor = CounterVisitor::default();
+    runtime.visit_metrics(&mut all_visitor);
+    assert_eq!(
+        all_visitor.counters,
+        vec![
+            ("cache_hits".to_string(), 3),
+            ("queue_pushes".to_string(), 5),
+        ]
+    );
+
+    let mut queue_visitor = CounterVisitor::default();
+    runtime.visit_metrics_for_scope(&MetricScope::new("shardmap.queue"), &mut queue_visitor);
+    assert_eq!(
+        queue_visitor.counters,
+        vec![("queue_pushes".to_string(), 5)]
+    );
+}
+
+#[test]
 fn runtime_owns_shared_span_collector() {
     let runtime = Runtime::new(RuntimeConfig::default());
     let exporter_collector = Arc::clone(runtime.span_collector());
@@ -102,4 +154,30 @@ fn runtime_owns_shared_span_collector() {
     assert_eq!(spans.len(), 2);
     assert!(spans.iter().any(|span| span.name == "cache_lookup"));
     assert!(spans.iter().any(|span| span.name == "index_probe"));
+}
+
+#[test]
+fn runtime_forwards_traceparent_and_drains_spans() {
+    let runtime = Runtime::new(RuntimeConfig::default());
+    let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    {
+        let mut span =
+            runtime.start_span_from_traceparent(Some(traceparent), "inbound", SpanKind::Server);
+        span.set_attribute("component", "shardmap");
+    }
+
+    runtime.flush_local_spans();
+
+    let mut spans = Vec::new();
+    runtime.drain_spans_into(&mut spans);
+
+    assert_eq!(spans.len(), 1);
+    let span = &spans[0];
+    assert_eq!(span.name, "inbound");
+    assert_eq!(
+        span.trace_id.to_string(),
+        "4bf92f3577b34da6a3ce929d0e0e4736"
+    );
+    assert_eq!(span.parent_span_id.to_string(), "00f067aa0ba902b7");
 }

--- a/crates/fast-telemetry/tests/runtime_test.rs
+++ b/crates/fast-telemetry/tests/runtime_test.rs
@@ -1,0 +1,77 @@
+#![cfg(all(feature = "runtime", feature = "macros"))]
+
+use fast_telemetry::{
+    Counter, ExportMetrics, HistogramSnapshot, MetricKind, MetricLabels, MetricMeta, MetricScope,
+    MetricVisitor, Runtime, RuntimeConfig,
+};
+
+#[derive(ExportMetrics)]
+#[metric_prefix = "cache"]
+struct CacheTelemetry {
+    #[help = "Cache hits"]
+    hits: Counter,
+}
+
+impl CacheTelemetry {
+    fn new() -> Self {
+        Self {
+            hits: Counter::new(4),
+        }
+    }
+}
+
+#[derive(Default)]
+struct CounterVisitor {
+    counters: Vec<(String, i64)>,
+}
+
+impl MetricVisitor for CounterVisitor {
+    fn counter(&mut self, meta: MetricMeta<'_>, labels: MetricLabels<'_>, value: i64) {
+        assert_eq!(meta.kind, MetricKind::Counter);
+        assert_eq!(labels.iter().len(), 0);
+        self.counters.push((meta.name.to_string(), value));
+    }
+
+    fn gauge_i64(&mut self, _meta: MetricMeta<'_>, _labels: MetricLabels<'_>, _value: i64) {}
+
+    fn gauge_f64(&mut self, _meta: MetricMeta<'_>, _labels: MetricLabels<'_>, _value: f64) {}
+
+    fn histogram(
+        &mut self,
+        _meta: MetricMeta<'_>,
+        _labels: MetricLabels<'_>,
+        _histogram: &dyn HistogramSnapshot,
+    ) {
+    }
+}
+
+fn assert_export_metrics<T: fast_telemetry::ExportMetrics>() {}
+
+#[test]
+fn runtime_registers_metrics_and_returns_direct_handles() {
+    assert_export_metrics::<CacheTelemetry>();
+
+    let runtime = Runtime::new(RuntimeConfig::default());
+    let registered =
+        runtime.register_metrics(MetricScope::new("shardmap.cache"), CacheTelemetry::new());
+
+    registered.hits.inc();
+    registered.hits.add(2);
+
+    assert_eq!(registered.scope().name(), "shardmap.cache");
+    assert_eq!(registered.hits.sum(), 3);
+    assert_eq!(runtime.registered_metrics_len(), 1);
+    assert_eq!(runtime.scopes()[0].name(), "shardmap.cache");
+
+    let mut visitor = CounterVisitor::default();
+    runtime.visit_metrics(&mut visitor);
+    assert_eq!(visitor.counters, vec![("cache_hits".to_string(), 3)]);
+
+    let mut scoped_visitor = CounterVisitor::default();
+    runtime.visit_metrics_for_scope(&MetricScope::new("shardmap.cache"), &mut scoped_visitor);
+    assert_eq!(scoped_visitor.counters, vec![("cache_hits".to_string(), 3)]);
+
+    let mut missing_scope_visitor = CounterVisitor::default();
+    runtime.visit_metrics_for_scope(&MetricScope::new("other"), &mut missing_scope_visitor);
+    assert!(missing_scope_visitor.counters.is_empty());
+}


### PR DESCRIPTION
Prepares the 0.6.0 release with an opt-in runtime service for construction-time metric registration and shared span collection while keeping hot paths on direct metric handles and the embedded span collector.