### PR TITLE
Add grouped counter buffer benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.6.0" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.6.0" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.6.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.7.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.7.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.7.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ dynamic metric types. Without it, these APIs are not available.
 
 ```toml
 [dependencies]
-fast-telemetry = "0.6"
+fast-telemetry = "0.7"
 ```
 
 ### Define Metrics
@@ -236,7 +236,7 @@ registration and a shared span collector so export setup happens once.
 
 ```toml
 [dependencies]
-fast-telemetry = { version = "0.6", features = ["runtime"] }
+fast-telemetry = { version = "0.7", features = ["runtime"] }
 ```
 
 ```rust
@@ -715,7 +715,7 @@ sweep and then sum each dynamic metric's `evict_stale(...)` result.
 enable the export crate's `monoio` feature for monoio-native loops:
 
 ```toml
-fast-telemetry-export = { version = "0.6", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.7", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 Use `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, and

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,48 @@
 # Release Notes
 
+## 0.7.0 - 2026-06-29
+
+Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.
+
+Why this is a 0.7.0 bump:
+
+- this release adds bench-only public grouped-counter helpers behind the `bench-tools` feature while evaluating a possible production batching API.
+- all workspace crates are aligned at `0.7.0` so downstream services can keep `fast-telemetry` and `fast-telemetry-export` on the same runtime and metric type boundary.
+
+Highlights:
+
+- grouped counter buffering: added a bench-only `CounterSetBuffer` prototype that accumulates related counter deltas locally and flushes shared atomics every configurable number of logical operations.
+- individual grouped updates: added indexed `CounterSet::inc(...)` and `CounterSet::add(...)` helpers so grouped counters can still be updated one at a time when only part of the group changes.
+- benchmark coverage: added `counter_buffered`, `counter_buffered_indexed`, and `counter_buffered_lookup` harness entities plus `--flush-every` controls to measure direct grouped increments, pre-resolved index updates, and per-op name lookup separately.
+
+Focused mac harness comparison, all runs with verified final counts:
+
+```text
+./crates/fast-telemetry/bench/run-counter-batch-bench.sh \
+  --threads 16 \
+  --runs 7 \
+  --target-writes 512000000 \
+  --batch-sizes 3,4,5,6 \
+  --flush-every 64
+```
+
+| Counters per Op | `counter_multi` | `counter_buffered` | Change |
+| ---: | ---: | ---: | ---: |
+| 3 | 0.92 CPU ns/write | 0.38 CPU ns/write | 58.7% lower |
+| 4 | 0.76 CPU ns/write | 0.27 CPU ns/write | 64.5% lower |
+| 5 | 0.72 CPU ns/write | 0.23 CPU ns/write | 68.1% lower |
+| 6 | 0.69 CPU ns/write | 0.20 CPU ns/write | 71.0% lower |
+
+The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.7"
+fast-telemetry-export = "0.7"
+```
+
 ## 0.5.1 - 2026-05-26
 
 Published crates: `fast-telemetry`, `fast-telemetry-export`. (`fast-telemetry-macros` is unchanged since 0.5.0.)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,8 @@ CPU-cycle equivalent, estimated from the mac CPU-time result at 4.61 cycles/ns:
 | 5 | 3.46 cycles/write | 1.11 cycles/write | 878.07 cycles/write |
 | 6 | 3.37 cycles/write | 0.88 cycles/write | 1175.14 cycles/write |
 
+Across the 3, 4, 5, and 6 counter rows, the estimated averages are 3.67 cycles/incr for independent fast counters, 1.26 cycles/incr for grouped buffered counters, and 1091.12 cycles/incr for OpenTelemetry Rust.
+
 Counter-write throughput:
 
 | Counters | Fast counters | Grouped counters | OTel Rust |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,7 +44,7 @@ CPU-cycle equivalent, estimated from the mac CPU-time result at 4.61 cycles/ns:
 | 5 | 3.46 cycles/write | 1.11 cycles/write | 878.07 cycles/write |
 | 6 | 3.37 cycles/write | 0.88 cycles/write | 1175.14 cycles/write |
 
-Across the 3, 4, 5, and 6 counter rows, the estimated averages are 3.67 cycles/incr for independent fast counters, 1.26 cycles/incr for grouped buffered counters, and 1091.12 cycles/incr for OpenTelemetry Rust.
+The smallest and largest measured groups show the range without averaging across group widths: at 3 counters, estimated costs were 4.24 cycles/incr for independent fast counters, 1.75 cycles/incr for grouped buffered counters, and 1127.65 cycles/incr for OpenTelemetry Rust; at 6 counters, they were 3.37 cycles/incr, 0.88 cycles/incr, and 1175.14 cycles/incr respectively.
 
 Counter-write throughput:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,14 +26,14 @@ Focused mac harness comparison, all runs with verified final counts:
   --flush-every 64
 ```
 
-| Counters | Grouped counters | OTel Rust |
-| ---: | ---: | ---: |
-| 3 | 0.39 CPU ns/write | 232.83 CPU ns/write |
-| 4 | 0.29 CPU ns/write | 297.33 CPU ns/write |
-| 5 | 0.22 CPU ns/write | 196.25 CPU ns/write |
-| 6 | 0.20 CPU ns/write | 258.61 CPU ns/write |
+| Counters | Fast counters | Grouped counters | OTel Rust |
+| ---: | ---: | ---: | ---: |
+| 3 | 0.92 CPU ns/write | 0.39 CPU ns/write | 232.83 CPU ns/write |
+| 4 | 0.78 CPU ns/write | 0.29 CPU ns/write | 297.33 CPU ns/write |
+| 5 | 0.73 CPU ns/write | 0.22 CPU ns/write | 196.25 CPU ns/write |
+| 6 | 0.76 CPU ns/write | 0.20 CPU ns/write | 258.61 CPU ns/write |
 
-The OpenTelemetry comparison uses pre-built Rust `u64_counter` handles and records the same number of counter writes per logical operation. Grouped counters were 597.00x to 1293.05x lower in trimmed CPU ns/write. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 12.66% to 26.12%), but the gap remained multiple orders of magnitude in the trimmed results.
+Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation. Grouped counters were 57.61% to 73.68% lower than independent fast counters and 597.00x to 1293.05x lower than OpenTelemetry Rust in trimmed CPU ns/write. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 12.66% to 26.12%), but the gap remained multiple orders of magnitude in the trimmed results.
 
 The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,8 @@ Focused mac harness comparison, averaged across three full matrix runs with veri
   --flush-every 64
 ```
 
+CPU time per counter write:
+
 | Counters | Fast counters | Grouped counters | OTel Rust |
 | ---: | ---: | ---: | ---: |
 | 3 | 0.92 CPU ns/write | 0.38 CPU ns/write | 244.61 CPU ns/write |
@@ -33,7 +35,16 @@ Focused mac harness comparison, averaged across three full matrix runs with veri
 | 5 | 0.75 CPU ns/write | 0.24 CPU ns/write | 190.47 CPU ns/write |
 | 6 | 0.73 CPU ns/write | 0.19 CPU ns/write | 254.91 CPU ns/write |
 
-Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation and reports the mean of three full matrix summaries. Grouped counters were 58.84% to 73.39% lower than independent fast counters and 643.72x to 1318.50x lower than OpenTelemetry Rust in trimmed CPU ns/write. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 13.19% to 27.79% averaged across the matrix summaries), but the gap remained multiple orders of magnitude in the trimmed results.
+Counter-write throughput:
+
+| Counters | Fast counters | Grouped counters | OTel Rust |
+| ---: | ---: | ---: | ---: |
+| 3 | 16.34B counters/s | 27.19B counters/s | 63.57M counters/s |
+| 4 | 18.19B counters/s | 35.84B counters/s | 63.42M counters/s |
+| 5 | 18.87B counters/s | 39.06B counters/s | 79.87M counters/s |
+| 6 | 18.72B counters/s | 45.77B counters/s | 60.87M counters/s |
+
+Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation and reports the mean of three full matrix summaries. Grouped counters were 58.84% to 73.39% lower than independent fast counters and 643.72x to 1318.50x lower than OpenTelemetry Rust in trimmed CPU ns/write. In wall-clock throughput, grouped counters measured 1.66x to 2.44x more counters/s than independent fast counters and 427.68x to 751.93x more counters/s than OpenTelemetry Rust. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 13.19% to 27.79% averaged across the matrix summaries), but the gap remained multiple orders of magnitude in the trimmed results.
 
 The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,15 @@ CPU time per counter write:
 | 5 | 0.75 CPU ns/write | 0.24 CPU ns/write | 190.47 CPU ns/write |
 | 6 | 0.73 CPU ns/write | 0.19 CPU ns/write | 254.91 CPU ns/write |
 
+CPU-cycle equivalent, estimated from the mac CPU-time result at 4.61 cycles/ns:
+
+| Counters | Fast counters | Grouped counters | OTel Rust |
+| ---: | ---: | ---: | ---: |
+| 3 | 4.24 cycles/write | 1.75 cycles/write | 1127.65 cycles/write |
+| 4 | 3.60 cycles/write | 1.29 cycles/write | 1183.62 cycles/write |
+| 5 | 3.46 cycles/write | 1.11 cycles/write | 878.07 cycles/write |
+| 6 | 3.37 cycles/write | 0.88 cycles/write | 1175.14 cycles/write |
+
 Counter-write throughput:
 
 | Counters | Fast counters | Grouped counters | OTel Rust |
@@ -44,7 +53,7 @@ Counter-write throughput:
 | 5 | 18.87B counters/s | 39.06B counters/s | 79.87M counters/s |
 | 6 | 18.72B counters/s | 45.77B counters/s | 60.87M counters/s |
 
-Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation and reports the mean of three full matrix summaries. Grouped counters were 58.84% to 73.39% lower than independent fast counters and 643.72x to 1318.50x lower than OpenTelemetry Rust in trimmed CPU ns/write. In wall-clock throughput, grouped counters measured 1.66x to 2.44x more counters/s than independent fast counters and 427.68x to 751.93x more counters/s than OpenTelemetry Rust. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 13.19% to 27.79% averaged across the matrix summaries), but the gap remained multiple orders of magnitude in the trimmed results.
+Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation and reports the mean of three full matrix summaries. Grouped counters were 58.84% to 73.39% lower than independent fast counters and 643.72x to 1318.50x lower than OpenTelemetry Rust in trimmed CPU ns/write. In wall-clock throughput, grouped counters measured 1.66x to 2.44x more counters/s than independent fast counters and 427.68x to 751.93x more counters/s than OpenTelemetry Rust. The cycles table is an estimate from the mac CPU-time result; measured hardware cycles are available on Linux by running the counter-batch harness with `--perf-stat`, which records `*_cycles_per_write` in `counter-batch-summary.csv`. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 13.19% to 27.79% averaged across the matrix summaries), but the gap remained multiple orders of magnitude in the trimmed results.
 
 The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@ Highlights:
 - individual grouped updates: added indexed `CounterSet::inc(...)` and `CounterSet::add(...)` helpers so grouped counters can still be updated one at a time when only part of the group changes.
 - benchmark coverage: added `counter_buffered`, `counter_buffered_indexed`, and `counter_buffered_lookup` harness entities plus `--flush-every` controls to measure direct grouped increments, pre-resolved index updates, per-op name lookup, and an OpenTelemetry Rust multi-counter handle loop separately.
 
-Focused mac harness comparison, all runs with verified final counts:
+Focused mac harness comparison, averaged across three full matrix runs with verified final counts:
 
 ```text
 ./crates/fast-telemetry/bench/run-counter-batch-bench.sh \
@@ -28,12 +28,12 @@ Focused mac harness comparison, all runs with verified final counts:
 
 | Counters | Fast counters | Grouped counters | OTel Rust |
 | ---: | ---: | ---: | ---: |
-| 3 | 0.92 CPU ns/write | 0.39 CPU ns/write | 232.83 CPU ns/write |
-| 4 | 0.78 CPU ns/write | 0.29 CPU ns/write | 297.33 CPU ns/write |
-| 5 | 0.73 CPU ns/write | 0.22 CPU ns/write | 196.25 CPU ns/write |
-| 6 | 0.76 CPU ns/write | 0.20 CPU ns/write | 258.61 CPU ns/write |
+| 3 | 0.92 CPU ns/write | 0.38 CPU ns/write | 244.61 CPU ns/write |
+| 4 | 0.78 CPU ns/write | 0.28 CPU ns/write | 256.75 CPU ns/write |
+| 5 | 0.75 CPU ns/write | 0.24 CPU ns/write | 190.47 CPU ns/write |
+| 6 | 0.73 CPU ns/write | 0.19 CPU ns/write | 254.91 CPU ns/write |
 
-Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation. Grouped counters were 57.61% to 73.68% lower than independent fast counters and 597.00x to 1293.05x lower than OpenTelemetry Rust in trimmed CPU ns/write. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 12.66% to 26.12%), but the gap remained multiple orders of magnitude in the trimmed results.
+Fast counters use independent fast-telemetry `Counter` handles, grouped counters use the buffered `CounterSet` prototype, and OpenTelemetry uses pre-built Rust `u64_counter` handles. Each row records the same number of counter writes per logical operation and reports the mean of three full matrix summaries. Grouped counters were 58.84% to 73.39% lower than independent fast counters and 643.72x to 1318.50x lower than OpenTelemetry Rust in trimmed CPU ns/write. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 13.19% to 27.79% averaged across the matrix summaries), but the gap remained multiple orders of magnitude in the trimmed results.
 
 The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 0.7.0 - 2026-06-29
+## 0.7.0 - 2026-06-30
 
 Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.
 
@@ -13,7 +13,7 @@ Highlights:
 
 - grouped counter buffering: added a bench-only `CounterSetBuffer` prototype that accumulates related counter deltas locally and flushes shared atomics every configurable number of logical operations.
 - individual grouped updates: added indexed `CounterSet::inc(...)` and `CounterSet::add(...)` helpers so grouped counters can still be updated one at a time when only part of the group changes.
-- benchmark coverage: added `counter_buffered`, `counter_buffered_indexed`, and `counter_buffered_lookup` harness entities plus `--flush-every` controls to measure direct grouped increments, pre-resolved index updates, and per-op name lookup separately.
+- benchmark coverage: added `counter_buffered`, `counter_buffered_indexed`, and `counter_buffered_lookup` harness entities plus `--flush-every` controls to measure direct grouped increments, pre-resolved index updates, per-op name lookup, and an OpenTelemetry Rust multi-counter handle loop separately.
 
 Focused mac harness comparison, all runs with verified final counts:
 
@@ -26,12 +26,14 @@ Focused mac harness comparison, all runs with verified final counts:
   --flush-every 64
 ```
 
-| Counters per Op | `counter_multi` | `counter_buffered` | Change |
-| ---: | ---: | ---: | ---: |
-| 3 | 0.92 CPU ns/write | 0.38 CPU ns/write | 58.7% lower |
-| 4 | 0.76 CPU ns/write | 0.27 CPU ns/write | 64.5% lower |
-| 5 | 0.72 CPU ns/write | 0.23 CPU ns/write | 68.1% lower |
-| 6 | 0.69 CPU ns/write | 0.20 CPU ns/write | 71.0% lower |
+| Counters per Op | `counter_multi` | `counter_buffered` | OpenTelemetry Rust `counter_multi` | Buffered vs OTel |
+| ---: | ---: | ---: | ---: | ---: |
+| 3 | 0.92 CPU ns/write | 0.39 CPU ns/write | 232.83 CPU ns/write | 597.00x, 99.83% lower |
+| 4 | 0.78 CPU ns/write | 0.29 CPU ns/write | 297.33 CPU ns/write | 1025.28x, 99.90% lower |
+| 5 | 0.73 CPU ns/write | 0.22 CPU ns/write | 196.25 CPU ns/write | 892.05x, 99.89% lower |
+| 6 | 0.76 CPU ns/write | 0.20 CPU ns/write | 258.61 CPU ns/write | 1293.05x, 99.92% lower |
+
+The OpenTelemetry comparison uses pre-built Rust `u64_counter` handles and records the same number of counter writes per logical operation. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 12.66% to 26.12%), but the gap remained multiple orders of magnitude in the trimmed results.
 
 The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,14 +26,14 @@ Focused mac harness comparison, all runs with verified final counts:
   --flush-every 64
 ```
 
-| Counters per Op | `counter_multi` | `counter_buffered` | OpenTelemetry Rust `counter_multi` | Buffered vs OTel |
-| ---: | ---: | ---: | ---: | ---: |
-| 3 | 0.92 CPU ns/write | 0.39 CPU ns/write | 232.83 CPU ns/write | 597.00x, 99.83% lower |
-| 4 | 0.78 CPU ns/write | 0.29 CPU ns/write | 297.33 CPU ns/write | 1025.28x, 99.90% lower |
-| 5 | 0.73 CPU ns/write | 0.22 CPU ns/write | 196.25 CPU ns/write | 892.05x, 99.89% lower |
-| 6 | 0.76 CPU ns/write | 0.20 CPU ns/write | 258.61 CPU ns/write | 1293.05x, 99.92% lower |
+| Counters | Grouped counters | OTel Rust |
+| ---: | ---: | ---: |
+| 3 | 0.39 CPU ns/write | 232.83 CPU ns/write |
+| 4 | 0.29 CPU ns/write | 297.33 CPU ns/write |
+| 5 | 0.22 CPU ns/write | 196.25 CPU ns/write |
+| 6 | 0.20 CPU ns/write | 258.61 CPU ns/write |
 
-The OpenTelemetry comparison uses pre-built Rust `u64_counter` handles and records the same number of counter writes per logical operation. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 12.66% to 26.12%), but the gap remained multiple orders of magnitude in the trimmed results.
+The OpenTelemetry comparison uses pre-built Rust `u64_counter` handles and records the same number of counter writes per logical operation. Grouped counters were 597.00x to 1293.05x lower in trimmed CPU ns/write. The OTel rows had higher CPU-time variance (`cpu_ns_per_counter_write_cv_pct`: 12.66% to 26.12%), but the gap remained multiple orders of magnitude in the trimmed results.
 
 The name-lookup control confirms that registry lookup should stay out of the hot path. With 128 registered metric names and 6 active counters per operation, direct buffered updates measured 0.19 CPU ns/write, pre-resolved indexed updates measured 0.82 CPU ns/write, and per-op `BTreeMap` name lookup measured 30.15 CPU ns/write.
 

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -46,7 +46,7 @@ columns with defaults. Summary metrics are ignored.
 Enable the `monoio` feature to run exporter loops on a monoio runtime:
 
 ```toml
-fast-telemetry-export = { version = "0.6", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.7", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 The monoio entry points mirror the Tokio ones:
@@ -69,7 +69,7 @@ Enable the `compio` feature to run the DogStatsD UDP exporter and sweeper on a
 compio runtime without pulling in Tokio:
 
 ```toml
-fast-telemetry-export = { version = "0.6", default-features = false, features = ["compio"] }
+fast-telemetry-export = { version = "0.7", default-features = false, features = ["compio"] }
 ```
 
 The compio entry points are:

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -75,6 +75,9 @@ The cache harness includes a focused probe for counter batching:
 # Current shape: one logical op updates N counters with N independent Counter::inc calls.
 ./bench/run-cache-bench.sh --entity counter_multi --modes fast --batch-size 8 --threads 16 --runs 5
 
+# OpenTelemetry Rust shape: one logical op updates N pre-built OTel u64_counter handles.
+./bench/run-cache-bench.sh --entity counter_multi --modes otel --batch-size 8 --threads 16 --runs 5
+
 # Prototype shape: one logical op updates N counters through the bench-only batch helper.
 ./bench/run-cache-bench.sh --entity counter_batch --modes fast --batch-size 8 --threads 16 --runs 5
 
@@ -90,15 +93,16 @@ The cache harness includes a focused probe for counter batching:
 # Control: per-op name lookup across a larger registered metric namespace.
 ./bench/run-cache-bench.sh --entity counter_buffered_lookup --modes fast --batch-size 8 --labels 128 --flush-every 64 --threads 16 --runs 5
 
-# Sweep multiple batch sizes and write one comparison summary.
+# Sweep multiple batch sizes and write one comparison summary, including OTel.
 ./bench/run-counter-batch-bench.sh --threads 16 --runs 7 --flush-every 64
 ```
 
 Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
-these runs. `counter_multi`, `counter_batch`, `counter_set`, and
-`counter_buffered` are intentionally `fast`-only because they compare
-fast-telemetry's current write path against candidate batching API shapes, not
-against OpenTelemetry or metrics-rs.
+these runs. `counter_multi` supports both `fast` and `otel` modes, so the
+summary can compare independent fast-telemetry counters against independent
+OpenTelemetry Rust counters for the same number of writes per logical operation.
+`counter_batch`, `counter_set`, and `counter_buffered` are intentionally
+`fast`-only because they compare candidate fast-telemetry batching API shapes.
 
 The buffered prototype uses a bench-only grouped counter buffer. Uniform group
 increments accumulate a shared local delta before flushing; individual counters

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -67,6 +67,29 @@ Each `*-run-*.txt` file and the generated `summary.csv` will include the CPU fie
 so you can compare throughput and CPU cost together on macOS or Linux without
 requiring `perf`.
 
+## Counter Batch Probe
+
+The cache harness includes a focused probe for counter batching:
+
+```bash
+# Current shape: one logical op updates N counters with N independent Counter::inc calls.
+./bench/run-cache-bench.sh --entity counter_multi --modes fast --batch-size 8 --threads 16 --runs 5
+
+# Prototype shape: one logical op updates N counters through the bench-only batch helper.
+./bench/run-cache-bench.sh --entity counter_batch --modes fast --batch-size 8 --threads 16 --runs 5
+
+# Grouped shape: related counters share one row-padded sharded layout.
+./bench/run-cache-bench.sh --entity counter_set --modes fast --batch-size 8 --threads 16 --runs 5
+
+# Sweep multiple batch sizes and write one comparison summary.
+./bench/run-counter-batch-bench.sh --threads 16 --runs 7
+```
+
+Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
+these runs. `counter_multi`, `counter_batch`, and `counter_set` are intentionally
+`fast`-only because they compare fast-telemetry's current write path against
+candidate batching API shapes, not against OpenTelemetry or metrics-rs.
+
 ## metrics-rs Comparison
 
 `run-cache-bench.sh` also supports `mode=metrics`, backed by the
@@ -91,6 +114,7 @@ does not expose a matching distribution primitive.
 ## Entry Points
 
 - `run-cache-bench.sh` -- cache-line contention workloads across metric entities and label access profiles
+- `run-counter-batch-bench.sh` -- mac/Linux sweep comparing one-by-one counter writes against the batch prototype
 - `run-span-bench.sh` -- span creation/export contention workloads across realism scenarios
 - `run-bench-matrix.sh` -- multi-case sweep runner for publishing-ready comparison sets
 - `run-bench-suite.sh` -- full suite with HTML report generation
@@ -126,6 +150,7 @@ does not expose a matching distribution primitive.
 | `--modes <list>`           | Select modes (default: `fast,otel`; options: `fast,otel,atomic,metrics`) |
 | `--entity <name>`          | Metric entity to benchmark                                       |
 | `--labels <N>`             | Label cardinality (default: 16, max: 256)                        |
+| `--batch-size <N>`         | Counters per op for `counter_multi`/`counter_batch`/`counter_set` (default: 8) |
 | `--profile <name>`         | Label access pattern: `uniform`, `hotspot`, `churn`              |
 | `--pin`                    | CPU pinning via `taskset` + round-robin thread affinity          |
 | `--cpu-list <list>`        | Explicit CPU list (e.g., `0-15`)                                 |
@@ -134,9 +159,9 @@ does not expose a matching distribution primitive.
 
 ## Entities
 
-`counter`, `distribution`, `dynamic_counter`, `dynamic_distribution`,
-`dynamic_gauge`, `dynamic_gauge_i64`, `dynamic_histogram`, `labeled_counter`,
-`labeled_gauge`, `labeled_histogram`
+`counter`, `counter_multi`, `counter_batch`, `counter_set`, `distribution`,
+`dynamic_counter`, `dynamic_distribution`, `dynamic_gauge`, `dynamic_gauge_i64`,
+`dynamic_histogram`, `labeled_counter`, `labeled_gauge`, `labeled_histogram`
 
 ## Label Access Profiles
 

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -81,14 +81,33 @@ The cache harness includes a focused probe for counter batching:
 # Grouped shape: related counters share one row-padded sharded layout.
 ./bench/run-cache-bench.sh --entity counter_set --modes fast --batch-size 8 --threads 16 --runs 5
 
+# Buffered shape: update local deltas and flush shared atomics every N operations.
+./bench/run-cache-bench.sh --entity counter_buffered --modes fast --batch-size 8 --flush-every 64 --threads 16 --runs 5
+
+# Control: pre-resolved indexes with individual buffered updates.
+./bench/run-cache-bench.sh --entity counter_buffered_indexed --modes fast --batch-size 8 --flush-every 64 --threads 16 --runs 5
+
+# Control: per-op name lookup across a larger registered metric namespace.
+./bench/run-cache-bench.sh --entity counter_buffered_lookup --modes fast --batch-size 8 --labels 128 --flush-every 64 --threads 16 --runs 5
+
 # Sweep multiple batch sizes and write one comparison summary.
-./bench/run-counter-batch-bench.sh --threads 16 --runs 7
+./bench/run-counter-batch-bench.sh --threads 16 --runs 7 --flush-every 64
 ```
 
 Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
-these runs. `counter_multi`, `counter_batch`, and `counter_set` are intentionally
-`fast`-only because they compare fast-telemetry's current write path against
-candidate batching API shapes, not against OpenTelemetry or metrics-rs.
+these runs. `counter_multi`, `counter_batch`, `counter_set`, and
+`counter_buffered` are intentionally `fast`-only because they compare
+fast-telemetry's current write path against candidate batching API shapes, not
+against OpenTelemetry or metrics-rs.
+
+The buffered prototype uses a bench-only grouped counter buffer. Uniform group
+increments accumulate a shared local delta before flushing; individual counters
+can still be updated with indexed buffer operations, then committed with a
+logical operation boundary and a final flush.
+
+The lookup control intentionally pays a `BTreeMap` name-to-index lookup on every
+counter update. It is a negative/control benchmark for dynamic APIs; production
+hot paths should pre-resolve indexes or typed handles during construction.
 
 ## metrics-rs Comparison
 
@@ -150,7 +169,8 @@ does not expose a matching distribution primitive.
 | `--modes <list>`           | Select modes (default: `fast,otel`; options: `fast,otel,atomic,metrics`) |
 | `--entity <name>`          | Metric entity to benchmark                                       |
 | `--labels <N>`             | Label cardinality (default: 16, max: 256)                        |
-| `--batch-size <N>`         | Counters per op for `counter_multi`/`counter_batch`/`counter_set` (default: 8) |
+| `--batch-size <N>`         | Counters per op for `counter_multi`/`counter_batch`/`counter_set`/`counter_buffered` variants (default: 8) |
+| `--flush-every <N>`        | Local operations per atomic flush for `counter_buffered` variants (default: 64) |
 | `--profile <name>`         | Label access pattern: `uniform`, `hotspot`, `churn`              |
 | `--pin`                    | CPU pinning via `taskset` + round-robin thread affinity          |
 | `--cpu-list <list>`        | Explicit CPU list (e.g., `0-15`)                                 |
@@ -159,7 +179,8 @@ does not expose a matching distribution primitive.
 
 ## Entities
 
-`counter`, `counter_multi`, `counter_batch`, `counter_set`, `distribution`,
+`counter`, `counter_multi`, `counter_batch`, `counter_set`, `counter_buffered`,
+`counter_buffered_indexed`, `counter_buffered_lookup`, `distribution`,
 `dynamic_counter`, `dynamic_distribution`, `dynamic_gauge`, `dynamic_gauge_i64`,
 `dynamic_histogram`, `labeled_counter`, `labeled_gauge`, `labeled_histogram`
 

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -95,6 +95,9 @@ The cache harness includes a focused probe for counter batching:
 
 # Sweep multiple batch sizes and write one comparison summary, including OTel.
 ./bench/run-counter-batch-bench.sh --threads 16 --runs 7 --flush-every 64
+
+# Linux only: include hardware-cycle counters from perf stat.
+./bench/run-counter-batch-bench.sh --threads 16 --runs 7 --flush-every 64 --perf-stat
 ```
 
 Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
@@ -103,6 +106,11 @@ summary can compare independent fast-telemetry counters against independent
 OpenTelemetry Rust counters for the same number of writes per logical operation.
 `counter_batch`, `counter_set`, and `counter_buffered` are intentionally
 `fast`-only because they compare candidate fast-telemetry batching API shapes.
+On Linux, add `--perf-stat` to collect hardware counters and populate
+`*_cycles_per_write` fields in `counter-batch-summary.csv`. macOS runs do not
+expose those hardware cycle counters through this harness, so mac comparisons
+should report CPU ns/write and counters/s unless using an explicitly labeled
+clock-rate estimate.
 
 The buffered prototype uses a bench-only grouped counter buffer. Uniform group
 increments accumulate a shared local delta before flushing; individual counters

--- a/crates/fast-telemetry/bench/run-bench-matrix.sh
+++ b/crates/fast-telemetry/bench/run-bench-matrix.sh
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
       echo "  span scenarios: root,lifecycle,pipeline"
       echo "  default iters: cache=50000000 span=1000000"
       echo "Preset full:"
-      echo "  cache entities: all cache benchmark entities"
+      echo "  cache entities: core cache benchmark entities"
       echo "  cache profiles: uniform,hotspot,churn"
       echo "  span scenarios: root,lifecycle,pipeline"
       echo "  default iters: cache=200000000 span=5000000"

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -22,6 +22,7 @@ MODES_CSV="fast,otel"
 ENTITY="counter"
 LABELS="16"
 BATCH_SIZE="8"
+FLUSH_EVERY="64"
 PROFILE="uniform"
 THREAD_AFFINITY="off"
 VALIDATE_EXPORT=0
@@ -39,6 +40,7 @@ while [[ $# -gt 0 ]]; do
     --entity) ENTITY="$2"; shift 2 ;;
     --labels) LABELS="$2"; shift 2 ;;
     --batch-size) BATCH_SIZE="$2"; shift 2 ;;
+    --flush-every) FLUSH_EVERY="$2"; shift 2 ;;
     --profile) PROFILE="$2"; shift 2 ;;
     --validate-export) VALIDATE_EXPORT=1; shift ;;
     --collector) COLLECTOR=1; shift ;;
@@ -67,14 +69,16 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --help)
-      echo "Usage: $0 [--threads N] [--iters N] [--shards N] [--runs N] [--entity name] [--labels N] [--batch-size N] [--profile name] [--export-interval-ms N] [--modes list] [--validate-export] [--collector|--collector-keep-up] [--pin] [--cpu-list list] [--perf] [--perf-stat] [--perf-record] [--perf-freq N]"
+      echo "Usage: $0 [--threads N] [--iters N] [--shards N] [--runs N] [--entity name] [--labels N] [--batch-size N] [--flush-every N] [--profile name] [--export-interval-ms N] [--modes list] [--validate-export] [--collector|--collector-keep-up] [--pin] [--cpu-list list] [--perf] [--perf-stat] [--perf-record] [--perf-freq N]"
       echo ""
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
-      echo "--entity one of: counter,counter_multi,counter_batch,counter_set,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "--entity one of: counter,counter_multi,counter_batch,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
-      echo "--batch-size counters per op for counter_multi/counter_batch/counter_set (default: 8)"
+      echo "--batch-size counters per op for counter_multi/counter_batch/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup (default: 8)"
+      echo "--flush-every local operations per atomic flush for counter_buffered variants (default: 64)"
+      echo "--labels registered metric names for counter_buffered_lookup (default: 16)"
       echo "--profile access pattern: uniform,hotspot,churn (default: uniform)"
       echo "--validate-export run export/parity acceptance tests before benchmark"
       echo "--collector start local DogStatsD collector and snapshot metrics"
@@ -92,7 +96,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ENTITY" in
-  counter|counter_multi|counter_batch|counter_set|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
+  counter|counter_multi|counter_batch|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
   *)
     echo "ERROR: unsupported --entity '$ENTITY'"
     exit 1
@@ -146,7 +150,7 @@ if [[ "$ENTITY" != "counter" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_multi" || "$ENTITY" == "counter_batch" || "$ENTITY" == "counter_set" ]]; then
+if [[ "$ENTITY" == "counter_multi" || "$ENTITY" == "counter_batch" || "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast"
@@ -166,7 +170,7 @@ fi
 
 mkdir -p "$RESULTS_DIR"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
-RUN_DIR="$RESULTS_DIR/cache_${TIMESTAMP}_${ENTITY}_${PROFILE}_bs${BATCH_SIZE}_$$"
+RUN_DIR="$RESULTS_DIR/cache_${TIMESTAMP}_${ENTITY}_${PROFILE}_bs${BATCH_SIZE}_fe${FLUSH_EVERY}_$$"
 mkdir -p "$RUN_DIR"
 
 if [[ "$PERF_STAT" == "1" || "$PERF_RECORD" == "1" ]]; then
@@ -176,7 +180,7 @@ fi
 
 echo "=== fast-telemetry cache contention benchmark ==="
 echo "threads=$THREADS iters=$ITERS shards=$SHARDS runs=$RUNS"
-echo "entity=$ENTITY labels=$LABELS batch_size=$BATCH_SIZE profile=$PROFILE"
+echo "entity=$ENTITY labels=$LABELS batch_size=$BATCH_SIZE flush_every=$FLUSH_EVERY profile=$PROFILE"
 echo "thread_affinity=$THREAD_AFFINITY"
 echo "export_interval_ms=$EXPORT_INTERVAL_MS"
 echo "validate_export=$VALIDATE_EXPORT"
@@ -212,10 +216,10 @@ if [[ ! -x "$BIN" ]]; then
   exit 1
 fi
 
-FAST_CMD=("$BIN" --mode fast --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
-ATOMIC_CMD=("$BIN" --mode atomic --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
-METRICS_CMD=("$BIN" --mode metrics --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
-OTEL_CMD=("$BIN" --mode otel --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
+FAST_CMD=("$BIN" --mode fast --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --flush-every "$FLUSH_EVERY" --export-interval-ms "$EXPORT_INTERVAL_MS")
+ATOMIC_CMD=("$BIN" --mode atomic --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --flush-every "$FLUSH_EVERY" --export-interval-ms "$EXPORT_INTERVAL_MS")
+METRICS_CMD=("$BIN" --mode metrics --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --flush-every "$FLUSH_EVERY" --export-interval-ms "$EXPORT_INTERVAL_MS")
+OTEL_CMD=("$BIN" --mode otel --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --flush-every "$FLUSH_EVERY" --export-interval-ms "$EXPORT_INTERVAL_MS")
 
 run_cmd() {
   if [[ "$PIN" == "1" ]]; then

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -7,7 +7,7 @@ RESULTS_DIR="$SCRIPT_DIR/results"
 COLLECTOR_SCRIPT="$SCRIPT_DIR/run-dogstatsd-collector.sh"
 COLLECTOR_URL="http://127.0.0.1:9102/metrics"
 
-THREADS="$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)"
+THREADS="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
 ITERS="10000000"
 SHARDS="${THREADS}"
 SHARDS_SET=0
@@ -74,6 +74,7 @@ while [[ $# -gt 0 ]]; do
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
       echo "--entity one of: counter,counter_multi,counter_batch,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "  otel mode supports: counter,counter_multi,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
       echo "--batch-size counters per op for counter_multi/counter_batch/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup (default: 8)"
@@ -150,7 +151,16 @@ if [[ "$ENTITY" != "counter" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_multi" || "$ENTITY" == "counter_batch" || "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" ]]; then
+if [[ "$ENTITY" == "counter_multi" ]]; then
+  for mode in "${MODES_ARR[@]}"; do
+    if [[ "$mode" != "fast" && "$mode" != "otel" ]]; then
+      echo "ERROR: entity=$ENTITY is only valid with --modes fast or otel"
+      exit 1
+    fi
+  done
+fi
+
+if [[ "$ENTITY" == "counter_batch" || "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast"

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -21,6 +21,7 @@ EXPORT_INTERVAL_MS="10"
 MODES_CSV="fast,otel"
 ENTITY="counter"
 LABELS="16"
+BATCH_SIZE="8"
 PROFILE="uniform"
 THREAD_AFFINITY="off"
 VALIDATE_EXPORT=0
@@ -37,6 +38,7 @@ while [[ $# -gt 0 ]]; do
     --modes) MODES_CSV="$2"; shift 2 ;;
     --entity) ENTITY="$2"; shift 2 ;;
     --labels) LABELS="$2"; shift 2 ;;
+    --batch-size) BATCH_SIZE="$2"; shift 2 ;;
     --profile) PROFILE="$2"; shift 2 ;;
     --validate-export) VALIDATE_EXPORT=1; shift ;;
     --collector) COLLECTOR=1; shift ;;
@@ -65,13 +67,14 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --help)
-      echo "Usage: $0 [--threads N] [--iters N] [--shards N] [--runs N] [--entity name] [--labels N] [--profile name] [--export-interval-ms N] [--modes list] [--validate-export] [--collector|--collector-keep-up] [--pin] [--cpu-list list] [--perf] [--perf-stat] [--perf-record] [--perf-freq N]"
+      echo "Usage: $0 [--threads N] [--iters N] [--shards N] [--runs N] [--entity name] [--labels N] [--batch-size N] [--profile name] [--export-interval-ms N] [--modes list] [--validate-export] [--collector|--collector-keep-up] [--pin] [--cpu-list list] [--perf] [--perf-stat] [--perf-record] [--perf-freq N]"
       echo ""
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
-      echo "--entity one of: counter,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "--entity one of: counter,counter_multi,counter_batch,counter_set,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
+      echo "--batch-size counters per op for counter_multi/counter_batch/counter_set (default: 8)"
       echo "--profile access pattern: uniform,hotspot,churn (default: uniform)"
       echo "--validate-export run export/parity acceptance tests before benchmark"
       echo "--collector start local DogStatsD collector and snapshot metrics"
@@ -89,7 +92,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ENTITY" in
-  counter|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
+  counter|counter_multi|counter_batch|counter_set|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
   *)
     echo "ERROR: unsupported --entity '$ENTITY'"
     exit 1
@@ -143,6 +146,15 @@ if [[ "$ENTITY" != "counter" ]]; then
   done
 fi
 
+if [[ "$ENTITY" == "counter_multi" || "$ENTITY" == "counter_batch" || "$ENTITY" == "counter_set" ]]; then
+  for mode in "${MODES_ARR[@]}"; do
+    if [[ "$mode" != "fast" ]]; then
+      echo "ERROR: entity=$ENTITY is only valid with --modes fast"
+      exit 1
+    fi
+  done
+fi
+
 if [[ "$ENTITY" == "distribution" || "$ENTITY" == "dynamic_distribution" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" == "metrics" ]]; then
@@ -154,7 +166,7 @@ fi
 
 mkdir -p "$RESULTS_DIR"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
-RUN_DIR="$RESULTS_DIR/cache_${TIMESTAMP}"
+RUN_DIR="$RESULTS_DIR/cache_${TIMESTAMP}_${ENTITY}_${PROFILE}_bs${BATCH_SIZE}_$$"
 mkdir -p "$RUN_DIR"
 
 if [[ "$PERF_STAT" == "1" || "$PERF_RECORD" == "1" ]]; then
@@ -164,7 +176,7 @@ fi
 
 echo "=== fast-telemetry cache contention benchmark ==="
 echo "threads=$THREADS iters=$ITERS shards=$SHARDS runs=$RUNS"
-echo "entity=$ENTITY labels=$LABELS profile=$PROFILE"
+echo "entity=$ENTITY labels=$LABELS batch_size=$BATCH_SIZE profile=$PROFILE"
 echo "thread_affinity=$THREAD_AFFINITY"
 echo "export_interval_ms=$EXPORT_INTERVAL_MS"
 echo "validate_export=$VALIDATE_EXPORT"
@@ -200,10 +212,10 @@ if [[ ! -x "$BIN" ]]; then
   exit 1
 fi
 
-FAST_CMD=("$BIN" --mode fast --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --export-interval-ms "$EXPORT_INTERVAL_MS")
-ATOMIC_CMD=("$BIN" --mode atomic --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --export-interval-ms "$EXPORT_INTERVAL_MS")
-METRICS_CMD=("$BIN" --mode metrics --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --export-interval-ms "$EXPORT_INTERVAL_MS")
-OTEL_CMD=("$BIN" --mode otel --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --export-interval-ms "$EXPORT_INTERVAL_MS")
+FAST_CMD=("$BIN" --mode fast --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
+ATOMIC_CMD=("$BIN" --mode atomic --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
+METRICS_CMD=("$BIN" --mode metrics --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
+OTEL_CMD=("$BIN" --mode otel --entity "$ENTITY" --profile "$PROFILE" --thread-affinity "$THREAD_AFFINITY" --threads "$THREADS" --iters "$ITERS" --shards "$SHARDS" --labels "$LABELS" --batch-size "$BATCH_SIZE" --export-interval-ms "$EXPORT_INTERVAL_MS")
 
 run_cmd() {
   if [[ "$PIN" == "1" ]]; then
@@ -238,6 +250,8 @@ if [[ "$COLLECTOR" == "1" ]]; then
       run_id="$(basename "$run_file" | sed -E 's/.*-run-([0-9]+)\.txt/\1/')"
       total_ops_per_sec="$(grep -E '^total_ops_per_sec=' "$run_file" | cut -d= -f2)"
       record_ops_per_sec="$(grep -E '^record_ops_per_sec=' "$run_file" | cut -d= -f2)"
+      total_counter_writes_per_sec="$(grep -E '^total_counter_writes_per_sec=' "$run_file" | cut -d= -f2)"
+      record_counter_writes_per_sec="$(grep -E '^record_counter_writes_per_sec=' "$run_file" | cut -d= -f2)"
       export_avg_ms="$(grep -E '^export_avg_ms=' "$run_file" | cut -d= -f2)"
 
       if [[ -n "$total_ops_per_sec" ]]; then
@@ -245,6 +259,12 @@ if [[ "$COLLECTOR" == "1" ]]; then
       fi
       if [[ -n "$record_ops_per_sec" ]]; then
         send_udp_line "ft.bench.record_ops_per_sec:${record_ops_per_sec}|g|#mode:${mode},entity:${ENTITY},profile:${PROFILE},run:${run_id}"
+      fi
+      if [[ -n "$total_counter_writes_per_sec" ]]; then
+        send_udp_line "ft.bench.total_counter_writes_per_sec:${total_counter_writes_per_sec}|g|#mode:${mode},entity:${ENTITY},profile:${PROFILE},run:${run_id}"
+      fi
+      if [[ -n "$record_counter_writes_per_sec" ]]; then
+        send_udp_line "ft.bench.record_counter_writes_per_sec:${record_counter_writes_per_sec}|g|#mode:${mode},entity:${ENTITY},profile:${PROFILE},run:${run_id}"
       fi
       if [[ -n "$export_avg_ms" ]]; then
         send_udp_line "ft.bench.export_avg_ms:${export_avg_ms}|g|#mode:${mode},entity:${ENTITY},profile:${PROFILE},run:${run_id}"

--- a/crates/fast-telemetry/bench/run-counter-batch-bench.sh
+++ b/crates/fast-telemetry/bench/run-counter-batch-bench.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results"
+
+THREADS="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
+RUNS="7"
+TARGET_WRITES="512000000"
+BATCH_SIZES_CSV="1,2,4,8,16,32,64,128"
+EXPORT_INTERVAL_MS="10"
+PIN=0
+CPU_LIST=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threads) THREADS="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --target-writes) TARGET_WRITES="$2"; shift 2 ;;
+    --batch-sizes) BATCH_SIZES_CSV="$2"; shift 2 ;;
+    --export-interval-ms) EXPORT_INTERVAL_MS="$2"; shift 2 ;;
+    --pin) PIN=1; shift ;;
+    --cpu-list) CPU_LIST="$2"; shift 2 ;;
+    --help)
+      echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--export-interval-ms N] [--pin] [--cpu-list list]"
+      echo ""
+      echo "Compares counter_multi against counter_batch and counter_set across batch sizes."
+      echo "Defaults: threads=logical CPUs, runs=7, target-writes=512000000, batch-sizes=1,2,4,8,16,32,64,128"
+      echo "--target-writes is total counter writes per run, not outer benchmark ops."
+      echo "--pin forwards taskset pinning to run-cache-bench.sh on Linux."
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1"
+      exit 1
+      ;;
+  esac
+done
+
+IFS=',' read -r -a BATCH_SIZES <<< "$BATCH_SIZES_CSV"
+if [[ ${#BATCH_SIZES[@]} -eq 0 ]]; then
+  echo "ERROR: --batch-sizes must include at least one size"
+  exit 1
+fi
+
+mkdir -p "$RESULTS_DIR"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+RUN_DIR="$RESULTS_DIR/counter_batch_${TIMESTAMP}_$$"
+mkdir -p "$RUN_DIR"
+SUMMARY_CSV="$RUN_DIR/counter-batch-summary.csv"
+
+echo "batch_size,iters_per_thread,target_counter_writes,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,batch_delta_pct,set_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,multi_dir,batch_dir,set_dir" > "$SUMMARY_CSV"
+
+read_summary_field() {
+  local dir="$1"
+  local field="$2"
+  awk -F, -v field="$field" 'NR == 2 { print $field }' "$dir/summary.csv"
+}
+
+extract_run_dir() {
+  local log_file="$1"
+  awk -F'Done. Results in: ' '/^Done\. Results in: / { print $2 }' "$log_file" | tail -n 1
+}
+
+run_case() {
+  local entity="$1"
+  local batch_size="$2"
+  local iters="$3"
+  local log_file="$RUN_DIR/${entity}-bs${batch_size}.log"
+  local cmd=(
+    "$SCRIPT_DIR/run-cache-bench.sh"
+    --entity "$entity"
+    --modes fast
+    --threads "$THREADS"
+    --iters "$iters"
+    --runs "$RUNS"
+    --batch-size "$batch_size"
+    --export-interval-ms "$EXPORT_INTERVAL_MS"
+  )
+
+  if [[ "$PIN" == "1" ]]; then
+    cmd+=(--pin)
+    if [[ -n "$CPU_LIST" ]]; then
+      cmd+=(--cpu-list "$CPU_LIST")
+    fi
+  fi
+
+  "${cmd[@]}" | tee "$log_file" >&2
+  local case_dir
+  case_dir="$(extract_run_dir "$log_file")"
+  if [[ -z "$case_dir" || ! -f "$case_dir/summary.csv" ]]; then
+    echo "ERROR: could not find summary.csv for $entity batch_size=$batch_size"
+    exit 1
+  fi
+  echo "$case_dir"
+}
+
+printf "\n=== counter batch benchmark harness ===\n"
+printf "threads=%s runs=%s target_writes=%s batch_sizes=%s\n" "$THREADS" "$RUNS" "$TARGET_WRITES" "$BATCH_SIZES_CSV"
+printf "export_interval_ms=%s pin=%s\n" "$EXPORT_INTERVAL_MS" "$PIN"
+printf "results=%s\n\n" "$RUN_DIR"
+
+for batch_size in "${BATCH_SIZES[@]}"; do
+  if ! [[ "$batch_size" =~ ^[0-9]+$ ]] || [[ "$batch_size" -lt 1 ]]; then
+    echo "ERROR: invalid batch size '$batch_size'"
+    exit 1
+  fi
+
+  iters=$((TARGET_WRITES / THREADS / batch_size))
+  if [[ "$iters" -lt 1 ]]; then
+    iters=1
+  fi
+
+  printf "\n[counter-batch] batch_size=%s iters_per_thread=%s\n" "$batch_size" "$iters"
+  multi_dir="$(run_case counter_multi "$batch_size" "$iters")"
+  batch_dir="$(run_case counter_batch "$batch_size" "$iters")"
+  set_dir="$(run_case counter_set "$batch_size" "$iters")"
+
+  multi_ns="$(read_summary_field "$multi_dir" 20)"
+  batch_ns="$(read_summary_field "$batch_dir" 20)"
+  set_ns="$(read_summary_field "$set_dir" 20)"
+  multi_total_ns_per_op="$(read_summary_field "$multi_dir" 25)"
+  batch_total_ns_per_op="$(read_summary_field "$batch_dir" 25)"
+  set_total_ns_per_op="$(read_summary_field "$set_dir" 25)"
+  multi_writes="$(read_summary_field "$multi_dir" 5)"
+  batch_writes="$(read_summary_field "$batch_dir" 5)"
+  set_writes="$(read_summary_field "$set_dir" 5)"
+  multi_cv="$(read_summary_field "$multi_dir" 23)"
+  batch_cv="$(read_summary_field "$batch_dir" 23)"
+  set_cv="$(read_summary_field "$set_dir" 23)"
+  multi_cpu="$(read_summary_field "$multi_dir" 13)"
+  batch_cpu="$(read_summary_field "$batch_dir" 13)"
+  set_cpu="$(read_summary_field "$set_dir" 13)"
+  multi_cores="$(read_summary_field "$multi_dir" 14)"
+  batch_cores="$(read_summary_field "$batch_dir" 14)"
+  set_cores="$(read_summary_field "$set_dir" 14)"
+  batch_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$batch_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
+  set_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$set_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
+
+  echo "$batch_size,$iters,$TARGET_WRITES,$multi_ns,$batch_ns,$set_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$multi_writes,$batch_writes,$set_writes,$multi_cv,$batch_cv,$set_cv,$multi_cpu,$batch_cpu,$set_cpu,$multi_cores,$batch_cores,$set_cores,$multi_dir,$batch_dir,$set_dir" >> "$SUMMARY_CSV"
+done
+
+printf "\nSummary (positive delta means the candidate was faster than counter_multi):\n"
+awk -F, '
+  NR == 1 {
+    next
+  }
+  {
+    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f batch=%6.2f set=%6.2f total_ns/op multi=%6.2f batch=%6.2f set=%6.2f delta batch=%7.2f%% set=%7.2f%% cv=%s/%s/%s\n",
+      $1, $4, $5, $6, $7, $8, $9, $10, $11, $15, $16, $17
+  }
+' "$SUMMARY_CSV"
+
+printf "\nDone. Summary in: %s\n" "$SUMMARY_CSV"

--- a/crates/fast-telemetry/bench/run-counter-batch-bench.sh
+++ b/crates/fast-telemetry/bench/run-counter-batch-bench.sh
@@ -26,7 +26,7 @@ while [[ $# -gt 0 ]]; do
     --help)
       echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--flush-every N] [--export-interval-ms N] [--pin] [--cpu-list list]"
       echo ""
-      echo "Compares counter_multi against counter_batch, counter_set, and counter_buffered across batch sizes."
+      echo "Compares fast counter_multi against counter_batch, counter_set, counter_buffered, and OpenTelemetry counter_multi across batch sizes."
       echo "Defaults: threads=logical CPUs, runs=7, target-writes=512000000, batch-sizes=1,2,4,8,16,32,64,128, flush-every=64"
       echo "--target-writes is total counter writes per run, not outer benchmark ops."
       echo "--flush-every is local operations per atomic flush for counter_buffered."
@@ -52,7 +52,7 @@ RUN_DIR="$RESULTS_DIR/counter_batch_${TIMESTAMP}_$$"
 mkdir -p "$RUN_DIR"
 SUMMARY_CSV="$RUN_DIR/counter-batch-summary.csv"
 
-echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,batch_delta_pct,set_delta_pct,buffered_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,buffered_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,buffered_avg_cores,multi_dir,batch_dir,set_dir,buffered_dir" > "$SUMMARY_CSV"
+echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,otel_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,otel_total_ns_per_op,batch_delta_pct,set_delta_pct,buffered_delta_pct,buffered_vs_otel_speedup,buffered_vs_otel_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,otel_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,buffered_cv_pct,otel_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,otel_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,buffered_avg_cores,otel_avg_cores,multi_dir,batch_dir,set_dir,buffered_dir,otel_dir" > "$SUMMARY_CSV"
 
 read_summary_field() {
   local dir="$1"
@@ -66,14 +66,15 @@ extract_run_dir() {
 }
 
 run_case() {
-  local entity="$1"
-  local batch_size="$2"
-  local iters="$3"
-  local log_file="$RUN_DIR/${entity}-bs${batch_size}.log"
+  local mode="$1"
+  local entity="$2"
+  local batch_size="$3"
+  local iters="$4"
+  local log_file="$RUN_DIR/${mode}-${entity}-bs${batch_size}.log"
   local cmd=(
     "$SCRIPT_DIR/run-cache-bench.sh"
     --entity "$entity"
-    --modes fast
+    --modes "$mode"
     --threads "$THREADS"
     --iters "$iters"
     --runs "$RUNS"
@@ -116,50 +117,59 @@ for batch_size in "${BATCH_SIZES[@]}"; do
   fi
 
   printf "\n[counter-batch] batch_size=%s iters_per_thread=%s\n" "$batch_size" "$iters"
-  multi_dir="$(run_case counter_multi "$batch_size" "$iters")"
-  batch_dir="$(run_case counter_batch "$batch_size" "$iters")"
-  set_dir="$(run_case counter_set "$batch_size" "$iters")"
-  buffered_dir="$(run_case counter_buffered "$batch_size" "$iters")"
+  multi_dir="$(run_case fast counter_multi "$batch_size" "$iters")"
+  batch_dir="$(run_case fast counter_batch "$batch_size" "$iters")"
+  set_dir="$(run_case fast counter_set "$batch_size" "$iters")"
+  buffered_dir="$(run_case fast counter_buffered "$batch_size" "$iters")"
+  otel_dir="$(run_case otel counter_multi "$batch_size" "$iters")"
 
   multi_ns="$(read_summary_field "$multi_dir" 20)"
   batch_ns="$(read_summary_field "$batch_dir" 20)"
   set_ns="$(read_summary_field "$set_dir" 20)"
   buffered_ns="$(read_summary_field "$buffered_dir" 20)"
+  otel_ns="$(read_summary_field "$otel_dir" 20)"
   multi_total_ns_per_op="$(read_summary_field "$multi_dir" 25)"
   batch_total_ns_per_op="$(read_summary_field "$batch_dir" 25)"
   set_total_ns_per_op="$(read_summary_field "$set_dir" 25)"
   buffered_total_ns_per_op="$(read_summary_field "$buffered_dir" 25)"
+  otel_total_ns_per_op="$(read_summary_field "$otel_dir" 25)"
   multi_writes="$(read_summary_field "$multi_dir" 5)"
   batch_writes="$(read_summary_field "$batch_dir" 5)"
   set_writes="$(read_summary_field "$set_dir" 5)"
   buffered_writes="$(read_summary_field "$buffered_dir" 5)"
+  otel_writes="$(read_summary_field "$otel_dir" 5)"
   multi_cv="$(read_summary_field "$multi_dir" 23)"
   batch_cv="$(read_summary_field "$batch_dir" 23)"
   set_cv="$(read_summary_field "$set_dir" 23)"
   buffered_cv="$(read_summary_field "$buffered_dir" 23)"
+  otel_cv="$(read_summary_field "$otel_dir" 23)"
   multi_cpu="$(read_summary_field "$multi_dir" 13)"
   batch_cpu="$(read_summary_field "$batch_dir" 13)"
   set_cpu="$(read_summary_field "$set_dir" 13)"
   buffered_cpu="$(read_summary_field "$buffered_dir" 13)"
+  otel_cpu="$(read_summary_field "$otel_dir" 13)"
   multi_cores="$(read_summary_field "$multi_dir" 14)"
   batch_cores="$(read_summary_field "$batch_dir" 14)"
   set_cores="$(read_summary_field "$set_dir" 14)"
   buffered_cores="$(read_summary_field "$buffered_dir" 14)"
+  otel_cores="$(read_summary_field "$otel_dir" 14)"
   batch_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$batch_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   set_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$set_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   buffered_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$buffered_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
+  buffered_vs_otel_speedup="$(awk -v otel="$otel_ns" -v buffered="$buffered_ns" 'BEGIN { if (buffered == 0) print "0.00"; else printf "%.2f", otel / buffered }')"
+  buffered_vs_otel_delta_pct="$(awk -v otel="$otel_ns" -v buffered="$buffered_ns" 'BEGIN { if (otel == 0) print "0.00"; else printf "%.2f", ((otel - buffered) / otel) * 100.0 }')"
 
-  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$batch_ns,$set_ns,$buffered_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$buffered_delta_pct,$multi_writes,$batch_writes,$set_writes,$buffered_writes,$multi_cv,$batch_cv,$set_cv,$buffered_cv,$multi_cpu,$batch_cpu,$set_cpu,$buffered_cpu,$multi_cores,$batch_cores,$set_cores,$buffered_cores,$multi_dir,$batch_dir,$set_dir,$buffered_dir" >> "$SUMMARY_CSV"
+  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$batch_ns,$set_ns,$buffered_ns,$otel_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$otel_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$buffered_delta_pct,$buffered_vs_otel_speedup,$buffered_vs_otel_delta_pct,$multi_writes,$batch_writes,$set_writes,$buffered_writes,$otel_writes,$multi_cv,$batch_cv,$set_cv,$buffered_cv,$otel_cv,$multi_cpu,$batch_cpu,$set_cpu,$buffered_cpu,$otel_cpu,$multi_cores,$batch_cores,$set_cores,$buffered_cores,$otel_cores,$multi_dir,$batch_dir,$set_dir,$buffered_dir,$otel_dir" >> "$SUMMARY_CSV"
 done
 
-printf "\nSummary (positive delta means the candidate was faster than counter_multi):\n"
+printf "\nSummary (positive delta means the fast candidate was faster than fast counter_multi):\n"
 awk -F, '
   NR == 1 {
     next
   }
   {
-    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f total_ns/op multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f delta batch=%7.2f%% set=%7.2f%% buffered=%7.2f%% cv=%s/%s/%s/%s\n",
-      $1, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $20, $21, $22, $23
+    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f otel=%6.2f total_ns/op multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f otel=%6.2f delta batch=%7.2f%% set=%7.2f%% buffered=%7.2f%% buffered/otel=%6.2fx (%7.2f%% lower) cv=%s/%s/%s/%s/%s\n",
+      $1, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $25, $26, $27, $28, $29
   }
 ' "$SUMMARY_CSV"
 

--- a/crates/fast-telemetry/bench/run-counter-batch-bench.sh
+++ b/crates/fast-telemetry/bench/run-counter-batch-bench.sh
@@ -9,6 +9,7 @@ RUNS="7"
 TARGET_WRITES="512000000"
 BATCH_SIZES_CSV="1,2,4,8,16,32,64,128"
 EXPORT_INTERVAL_MS="10"
+FLUSH_EVERY="64"
 PIN=0
 CPU_LIST=""
 
@@ -19,14 +20,16 @@ while [[ $# -gt 0 ]]; do
     --target-writes) TARGET_WRITES="$2"; shift 2 ;;
     --batch-sizes) BATCH_SIZES_CSV="$2"; shift 2 ;;
     --export-interval-ms) EXPORT_INTERVAL_MS="$2"; shift 2 ;;
+    --flush-every) FLUSH_EVERY="$2"; shift 2 ;;
     --pin) PIN=1; shift ;;
     --cpu-list) CPU_LIST="$2"; shift 2 ;;
     --help)
-      echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--export-interval-ms N] [--pin] [--cpu-list list]"
+      echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--flush-every N] [--export-interval-ms N] [--pin] [--cpu-list list]"
       echo ""
-      echo "Compares counter_multi against counter_batch and counter_set across batch sizes."
-      echo "Defaults: threads=logical CPUs, runs=7, target-writes=512000000, batch-sizes=1,2,4,8,16,32,64,128"
+      echo "Compares counter_multi against counter_batch, counter_set, and counter_buffered across batch sizes."
+      echo "Defaults: threads=logical CPUs, runs=7, target-writes=512000000, batch-sizes=1,2,4,8,16,32,64,128, flush-every=64"
       echo "--target-writes is total counter writes per run, not outer benchmark ops."
+      echo "--flush-every is local operations per atomic flush for counter_buffered."
       echo "--pin forwards taskset pinning to run-cache-bench.sh on Linux."
       exit 0
       ;;
@@ -49,7 +52,7 @@ RUN_DIR="$RESULTS_DIR/counter_batch_${TIMESTAMP}_$$"
 mkdir -p "$RUN_DIR"
 SUMMARY_CSV="$RUN_DIR/counter-batch-summary.csv"
 
-echo "batch_size,iters_per_thread,target_counter_writes,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,batch_delta_pct,set_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,multi_dir,batch_dir,set_dir" > "$SUMMARY_CSV"
+echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,batch_delta_pct,set_delta_pct,buffered_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,buffered_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,buffered_avg_cores,multi_dir,batch_dir,set_dir,buffered_dir" > "$SUMMARY_CSV"
 
 read_summary_field() {
   local dir="$1"
@@ -75,6 +78,7 @@ run_case() {
     --iters "$iters"
     --runs "$RUNS"
     --batch-size "$batch_size"
+    --flush-every "$FLUSH_EVERY"
     --export-interval-ms "$EXPORT_INTERVAL_MS"
   )
 
@@ -97,7 +101,7 @@ run_case() {
 
 printf "\n=== counter batch benchmark harness ===\n"
 printf "threads=%s runs=%s target_writes=%s batch_sizes=%s\n" "$THREADS" "$RUNS" "$TARGET_WRITES" "$BATCH_SIZES_CSV"
-printf "export_interval_ms=%s pin=%s\n" "$EXPORT_INTERVAL_MS" "$PIN"
+printf "flush_every=%s export_interval_ms=%s pin=%s\n" "$FLUSH_EVERY" "$EXPORT_INTERVAL_MS" "$PIN"
 printf "results=%s\n\n" "$RUN_DIR"
 
 for batch_size in "${BATCH_SIZES[@]}"; do
@@ -115,29 +119,37 @@ for batch_size in "${BATCH_SIZES[@]}"; do
   multi_dir="$(run_case counter_multi "$batch_size" "$iters")"
   batch_dir="$(run_case counter_batch "$batch_size" "$iters")"
   set_dir="$(run_case counter_set "$batch_size" "$iters")"
+  buffered_dir="$(run_case counter_buffered "$batch_size" "$iters")"
 
   multi_ns="$(read_summary_field "$multi_dir" 20)"
   batch_ns="$(read_summary_field "$batch_dir" 20)"
   set_ns="$(read_summary_field "$set_dir" 20)"
+  buffered_ns="$(read_summary_field "$buffered_dir" 20)"
   multi_total_ns_per_op="$(read_summary_field "$multi_dir" 25)"
   batch_total_ns_per_op="$(read_summary_field "$batch_dir" 25)"
   set_total_ns_per_op="$(read_summary_field "$set_dir" 25)"
+  buffered_total_ns_per_op="$(read_summary_field "$buffered_dir" 25)"
   multi_writes="$(read_summary_field "$multi_dir" 5)"
   batch_writes="$(read_summary_field "$batch_dir" 5)"
   set_writes="$(read_summary_field "$set_dir" 5)"
+  buffered_writes="$(read_summary_field "$buffered_dir" 5)"
   multi_cv="$(read_summary_field "$multi_dir" 23)"
   batch_cv="$(read_summary_field "$batch_dir" 23)"
   set_cv="$(read_summary_field "$set_dir" 23)"
+  buffered_cv="$(read_summary_field "$buffered_dir" 23)"
   multi_cpu="$(read_summary_field "$multi_dir" 13)"
   batch_cpu="$(read_summary_field "$batch_dir" 13)"
   set_cpu="$(read_summary_field "$set_dir" 13)"
+  buffered_cpu="$(read_summary_field "$buffered_dir" 13)"
   multi_cores="$(read_summary_field "$multi_dir" 14)"
   batch_cores="$(read_summary_field "$batch_dir" 14)"
   set_cores="$(read_summary_field "$set_dir" 14)"
+  buffered_cores="$(read_summary_field "$buffered_dir" 14)"
   batch_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$batch_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   set_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$set_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
+  buffered_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$buffered_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
 
-  echo "$batch_size,$iters,$TARGET_WRITES,$multi_ns,$batch_ns,$set_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$multi_writes,$batch_writes,$set_writes,$multi_cv,$batch_cv,$set_cv,$multi_cpu,$batch_cpu,$set_cpu,$multi_cores,$batch_cores,$set_cores,$multi_dir,$batch_dir,$set_dir" >> "$SUMMARY_CSV"
+  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$batch_ns,$set_ns,$buffered_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$buffered_delta_pct,$multi_writes,$batch_writes,$set_writes,$buffered_writes,$multi_cv,$batch_cv,$set_cv,$buffered_cv,$multi_cpu,$batch_cpu,$set_cpu,$buffered_cpu,$multi_cores,$batch_cores,$set_cores,$buffered_cores,$multi_dir,$batch_dir,$set_dir,$buffered_dir" >> "$SUMMARY_CSV"
 done
 
 printf "\nSummary (positive delta means the candidate was faster than counter_multi):\n"
@@ -146,8 +158,8 @@ awk -F, '
     next
   }
   {
-    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f batch=%6.2f set=%6.2f total_ns/op multi=%6.2f batch=%6.2f set=%6.2f delta batch=%7.2f%% set=%7.2f%% cv=%s/%s/%s\n",
-      $1, $4, $5, $6, $7, $8, $9, $10, $11, $15, $16, $17
+    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f total_ns/op multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f delta batch=%7.2f%% set=%7.2f%% buffered=%7.2f%% cv=%s/%s/%s/%s\n",
+      $1, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $20, $21, $22, $23
   }
 ' "$SUMMARY_CSV"
 

--- a/crates/fast-telemetry/bench/run-counter-batch-bench.sh
+++ b/crates/fast-telemetry/bench/run-counter-batch-bench.sh
@@ -12,6 +12,7 @@ EXPORT_INTERVAL_MS="10"
 FLUSH_EVERY="64"
 PIN=0
 CPU_LIST=""
+PERF_STAT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -23,14 +24,16 @@ while [[ $# -gt 0 ]]; do
     --flush-every) FLUSH_EVERY="$2"; shift 2 ;;
     --pin) PIN=1; shift ;;
     --cpu-list) CPU_LIST="$2"; shift 2 ;;
+    --perf-stat) PERF_STAT=1; shift ;;
     --help)
-      echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--flush-every N] [--export-interval-ms N] [--pin] [--cpu-list list]"
+      echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--flush-every N] [--export-interval-ms N] [--pin] [--cpu-list list] [--perf-stat]"
       echo ""
       echo "Compares fast counter_multi against counter_batch, counter_set, counter_buffered, and OpenTelemetry counter_multi across batch sizes."
       echo "Defaults: threads=logical CPUs, runs=7, target-writes=512000000, batch-sizes=1,2,4,8,16,32,64,128, flush-every=64"
       echo "--target-writes is total counter writes per run, not outer benchmark ops."
       echo "--flush-every is local operations per atomic flush for counter_buffered."
       echo "--pin forwards taskset pinning to run-cache-bench.sh on Linux."
+      echo "--perf-stat forwards Linux perf stat collection to run-cache-bench.sh and records cycles/write."
       exit 0
       ;;
     *)
@@ -52,12 +55,35 @@ RUN_DIR="$RESULTS_DIR/counter_batch_${TIMESTAMP}_$$"
 mkdir -p "$RUN_DIR"
 SUMMARY_CSV="$RUN_DIR/counter-batch-summary.csv"
 
-echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,otel_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,otel_total_ns_per_op,batch_delta_pct,set_delta_pct,buffered_delta_pct,buffered_vs_otel_speedup,buffered_vs_otel_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,otel_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,buffered_cv_pct,otel_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,otel_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,buffered_avg_cores,otel_avg_cores,multi_dir,batch_dir,set_dir,buffered_dir,otel_dir" > "$SUMMARY_CSV"
+echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,otel_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,otel_total_ns_per_op,batch_delta_pct,set_delta_pct,buffered_delta_pct,buffered_vs_otel_speedup,buffered_vs_otel_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,otel_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,buffered_cv_pct,otel_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,otel_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,buffered_avg_cores,otel_avg_cores,multi_cycles_per_write,batch_cycles_per_write,set_cycles_per_write,buffered_cycles_per_write,otel_cycles_per_write,multi_dir,batch_dir,set_dir,buffered_dir,otel_dir" > "$SUMMARY_CSV"
 
 read_summary_field() {
   local dir="$1"
   local field="$2"
   awk -F, -v field="$field" 'NR == 2 { print $field }' "$dir/summary.csv"
+}
+
+read_perf_summary_field() {
+  local dir="$1"
+  local field="$2"
+  if [[ ! -f "$dir/perf-summary.csv" ]]; then
+    echo ""
+    return
+  fi
+  awk -F, -v field="$field" '
+    NR == 1 {
+      for (i = 1; i <= NF; i++) {
+        if ($i == field) {
+          col = i
+          break
+        }
+      }
+      next
+    }
+    NR == 2 && col {
+      print $col
+    }
+  ' "$dir/perf-summary.csv"
 }
 
 extract_run_dir() {
@@ -89,6 +115,9 @@ run_case() {
       cmd+=(--cpu-list "$CPU_LIST")
     fi
   fi
+  if [[ "$PERF_STAT" == "1" ]]; then
+    cmd+=(--perf-stat)
+  fi
 
   "${cmd[@]}" | tee "$log_file" >&2
   local case_dir
@@ -102,7 +131,7 @@ run_case() {
 
 printf "\n=== counter batch benchmark harness ===\n"
 printf "threads=%s runs=%s target_writes=%s batch_sizes=%s\n" "$THREADS" "$RUNS" "$TARGET_WRITES" "$BATCH_SIZES_CSV"
-printf "flush_every=%s export_interval_ms=%s pin=%s\n" "$FLUSH_EVERY" "$EXPORT_INTERVAL_MS" "$PIN"
+printf "flush_every=%s export_interval_ms=%s pin=%s perf_stat=%s\n" "$FLUSH_EVERY" "$EXPORT_INTERVAL_MS" "$PIN" "$PERF_STAT"
 printf "results=%s\n\n" "$RUN_DIR"
 
 for batch_size in "${BATCH_SIZES[@]}"; do
@@ -153,13 +182,18 @@ for batch_size in "${BATCH_SIZES[@]}"; do
   set_cores="$(read_summary_field "$set_dir" 14)"
   buffered_cores="$(read_summary_field "$buffered_dir" 14)"
   otel_cores="$(read_summary_field "$otel_dir" 14)"
+  multi_cycles="$(read_perf_summary_field "$multi_dir" "cycles_per_counter_write")"
+  batch_cycles="$(read_perf_summary_field "$batch_dir" "cycles_per_counter_write")"
+  set_cycles="$(read_perf_summary_field "$set_dir" "cycles_per_counter_write")"
+  buffered_cycles="$(read_perf_summary_field "$buffered_dir" "cycles_per_counter_write")"
+  otel_cycles="$(read_perf_summary_field "$otel_dir" "cycles_per_counter_write")"
   batch_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$batch_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   set_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$set_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   buffered_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$buffered_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   buffered_vs_otel_speedup="$(awk -v otel="$otel_ns" -v buffered="$buffered_ns" 'BEGIN { if (buffered == 0) print "0.00"; else printf "%.2f", otel / buffered }')"
   buffered_vs_otel_delta_pct="$(awk -v otel="$otel_ns" -v buffered="$buffered_ns" 'BEGIN { if (otel == 0) print "0.00"; else printf "%.2f", ((otel - buffered) / otel) * 100.0 }')"
 
-  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$batch_ns,$set_ns,$buffered_ns,$otel_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$otel_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$buffered_delta_pct,$buffered_vs_otel_speedup,$buffered_vs_otel_delta_pct,$multi_writes,$batch_writes,$set_writes,$buffered_writes,$otel_writes,$multi_cv,$batch_cv,$set_cv,$buffered_cv,$otel_cv,$multi_cpu,$batch_cpu,$set_cpu,$buffered_cpu,$otel_cpu,$multi_cores,$batch_cores,$set_cores,$buffered_cores,$otel_cores,$multi_dir,$batch_dir,$set_dir,$buffered_dir,$otel_dir" >> "$SUMMARY_CSV"
+  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$batch_ns,$set_ns,$buffered_ns,$otel_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$otel_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$buffered_delta_pct,$buffered_vs_otel_speedup,$buffered_vs_otel_delta_pct,$multi_writes,$batch_writes,$set_writes,$buffered_writes,$otel_writes,$multi_cv,$batch_cv,$set_cv,$buffered_cv,$otel_cv,$multi_cpu,$batch_cpu,$set_cpu,$buffered_cpu,$otel_cpu,$multi_cores,$batch_cores,$set_cores,$buffered_cores,$otel_cores,$multi_cycles,$batch_cycles,$set_cycles,$buffered_cycles,$otel_cycles,$multi_dir,$batch_dir,$set_dir,$buffered_dir,$otel_dir" >> "$SUMMARY_CSV"
 done
 
 printf "\nSummary (positive delta means the fast candidate was faster than fast counter_multi):\n"

--- a/crates/fast-telemetry/bench/summarize_bench.py
+++ b/crates/fast-telemetry/bench/summarize_bench.py
@@ -41,9 +41,18 @@ def parse_mode(run_dir: pathlib.Path, mode: str):
     cpu_core_vals = []
     cpu_util_vals = []
     cpu_ns_per_op_vals = []
+    cpu_ns_per_counter_write_vals = []
+    record_ns_per_op_vals = []
+    total_ns_per_op_vals = []
+    record_ns_per_counter_write_vals = []
+    total_ns_per_counter_write_vals = []
+    record_counter_write_vals = []
+    total_counter_write_vals = []
     for path in sorted(run_dir.glob(f"{mode}-run-*.txt")):
         record = None
         total = None
+        record_counter_writes = None
+        total_counter_writes = None
         export_avg = None
         cpu_user = None
         cpu_system = None
@@ -51,11 +60,20 @@ def parse_mode(run_dir: pathlib.Path, mode: str):
         cpu_avg_cores = None
         cpu_utilization = None
         cpu_ns_per_op = None
+        cpu_ns_per_counter_write = None
+        record_ns_per_op = None
+        total_ns_per_op = None
+        record_ns_per_counter_write = None
+        total_ns_per_counter_write = None
         for line in path.read_text().splitlines():
             if line.startswith("record_ops_per_sec="):
                 record = float(line.split("=", 1)[1])
             elif line.startswith("total_ops_per_sec="):
                 total = float(line.split("=", 1)[1])
+            elif line.startswith("record_counter_writes_per_sec="):
+                record_counter_writes = float(line.split("=", 1)[1])
+            elif line.startswith("total_counter_writes_per_sec="):
+                total_counter_writes = float(line.split("=", 1)[1])
             elif line.startswith("export_avg_ms="):
                 export_avg = float(line.split("=", 1)[1])
             elif line.startswith("cpu_user_seconds="):
@@ -70,10 +88,24 @@ def parse_mode(run_dir: pathlib.Path, mode: str):
                 cpu_utilization = float(line.split("=", 1)[1])
             elif line.startswith("cpu_ns_per_op="):
                 cpu_ns_per_op = float(line.split("=", 1)[1])
+            elif line.startswith("cpu_ns_per_counter_write="):
+                cpu_ns_per_counter_write = float(line.split("=", 1)[1])
+            elif line.startswith("record_ns_per_op="):
+                record_ns_per_op = float(line.split("=", 1)[1])
+            elif line.startswith("total_ns_per_op="):
+                total_ns_per_op = float(line.split("=", 1)[1])
+            elif line.startswith("record_ns_per_counter_write="):
+                record_ns_per_counter_write = float(line.split("=", 1)[1])
+            elif line.startswith("total_ns_per_counter_write="):
+                total_ns_per_counter_write = float(line.split("=", 1)[1])
         if record is not None:
             record_vals.append(record)
         if total is not None:
             total_vals.append(total)
+        if record_counter_writes is not None:
+            record_counter_write_vals.append(record_counter_writes)
+        if total_counter_writes is not None:
+            total_counter_write_vals.append(total_counter_writes)
         if export_avg is not None:
             export_vals.append(export_avg)
         if cpu_user is not None:
@@ -88,9 +120,21 @@ def parse_mode(run_dir: pathlib.Path, mode: str):
             cpu_util_vals.append(cpu_utilization)
         if cpu_ns_per_op is not None:
             cpu_ns_per_op_vals.append(cpu_ns_per_op)
+        if cpu_ns_per_counter_write is not None:
+            cpu_ns_per_counter_write_vals.append(cpu_ns_per_counter_write)
+        if record_ns_per_op is not None:
+            record_ns_per_op_vals.append(record_ns_per_op)
+        if total_ns_per_op is not None:
+            total_ns_per_op_vals.append(total_ns_per_op)
+        if record_ns_per_counter_write is not None:
+            record_ns_per_counter_write_vals.append(record_ns_per_counter_write)
+        if total_ns_per_counter_write is not None:
+            total_ns_per_counter_write_vals.append(total_ns_per_counter_write)
     return {
         "record": record_vals,
         "total": total_vals,
+        "record_counter_writes": record_counter_write_vals,
+        "total_counter_writes": total_counter_write_vals,
         "export": export_vals,
         "cpu_user": cpu_user_vals,
         "cpu_system": cpu_system_vals,
@@ -98,6 +142,11 @@ def parse_mode(run_dir: pathlib.Path, mode: str):
         "cpu_cores": cpu_core_vals,
         "cpu_util": cpu_util_vals,
         "cpu_ns_per_op": cpu_ns_per_op_vals,
+        "cpu_ns_per_counter_write": cpu_ns_per_counter_write_vals,
+        "record_ns_per_op": record_ns_per_op_vals,
+        "total_ns_per_op": total_ns_per_op_vals,
+        "record_ns_per_counter_write": record_ns_per_counter_write_vals,
+        "total_ns_per_counter_write": total_ns_per_counter_write_vals,
     }
 
 
@@ -115,6 +164,8 @@ def main() -> int:
             "n": len(vals["total"]),
             "record_tm": trimmed_mean(vals["record"]),
             "total_tm": trimmed_mean(vals["total"]),
+            "record_counter_writes_tm": trimmed_mean(vals["record_counter_writes"]),
+            "total_counter_writes_tm": trimmed_mean(vals["total_counter_writes"]),
             "total_min": min(vals["total"]),
             "total_max": max(vals["total"]),
             # Wall-time-derived throughput is noise-contaminated by scheduler
@@ -135,23 +186,45 @@ def main() -> int:
             "cpu_ns_per_op_min": min(vals["cpu_ns_per_op"]) if vals["cpu_ns_per_op"] else 0.0,
             "cpu_ns_per_op_max": max(vals["cpu_ns_per_op"]) if vals["cpu_ns_per_op"] else 0.0,
             "cpu_ns_per_op_cv_pct": cv_pct(vals["cpu_ns_per_op"]),
+            "cpu_ns_per_counter_write_tm": trimmed_mean(vals["cpu_ns_per_counter_write"]),
+            "cpu_ns_per_counter_write_min": min(vals["cpu_ns_per_counter_write"]) if vals["cpu_ns_per_counter_write"] else 0.0,
+            "cpu_ns_per_counter_write_max": max(vals["cpu_ns_per_counter_write"]) if vals["cpu_ns_per_counter_write"] else 0.0,
+            "cpu_ns_per_counter_write_cv_pct": cv_pct(vals["cpu_ns_per_counter_write"]),
+            "record_ns_per_op_tm": trimmed_mean(vals["record_ns_per_op"]),
+            "total_ns_per_op_tm": trimmed_mean(vals["total_ns_per_op"]),
+            "record_ns_per_counter_write_tm": trimmed_mean(vals["record_ns_per_counter_write"]),
+            "total_ns_per_counter_write_tm": trimmed_mean(vals["total_ns_per_counter_write"]),
         })
 
     csv_lines = [
         "mode,runs,trimmed_record_ops_per_sec,trimmed_total_ops_per_sec,"
+        "trimmed_record_counter_writes_per_sec,trimmed_total_counter_writes_per_sec,"
         "min_total_ops_per_sec,max_total_ops_per_sec,total_cv_pct,"
         "trimmed_export_avg_ms,trimmed_cpu_user_seconds,trimmed_cpu_system_seconds,"
         "trimmed_cpu_total_seconds,trimmed_cpu_avg_cores,trimmed_cpu_utilization_pct,"
-        "trimmed_cpu_ns_per_op,min_cpu_ns_per_op,max_cpu_ns_per_op,cpu_ns_per_op_cv_pct"
+        "trimmed_cpu_ns_per_op,min_cpu_ns_per_op,max_cpu_ns_per_op,cpu_ns_per_op_cv_pct,"
+        "trimmed_cpu_ns_per_counter_write,min_cpu_ns_per_counter_write,"
+        "max_cpu_ns_per_counter_write,cpu_ns_per_counter_write_cv_pct,"
+        "trimmed_record_ns_per_op,trimmed_total_ns_per_op,"
+        "trimmed_record_ns_per_counter_write,trimmed_total_ns_per_counter_write"
     ]
     for r in rows:
         csv_lines.append(
             f"{r['mode']},{r['n']},{r['record_tm']:.2f},{r['total_tm']:.2f},"
+            f"{r['record_counter_writes_tm']:.2f},{r['total_counter_writes_tm']:.2f},"
             f"{r['total_min']:.2f},{r['total_max']:.2f},{r['total_cv_pct']:.2f},"
             f"{r['export_tm']:.6f},{r['cpu_user_tm']:.6f},{r['cpu_system_tm']:.6f},"
             f"{r['cpu_total_tm']:.6f},{r['cpu_cores_tm']:.6f},{r['cpu_util_tm']:.2f},"
             f"{r['cpu_ns_per_op_tm']:.2f},{r['cpu_ns_per_op_min']:.2f},"
-            f"{r['cpu_ns_per_op_max']:.2f},{r['cpu_ns_per_op_cv_pct']:.2f}"
+            f"{r['cpu_ns_per_op_max']:.2f},{r['cpu_ns_per_op_cv_pct']:.2f},"
+            f"{r['cpu_ns_per_counter_write_tm']:.2f},"
+            f"{r['cpu_ns_per_counter_write_min']:.2f},"
+            f"{r['cpu_ns_per_counter_write_max']:.2f},"
+            f"{r['cpu_ns_per_counter_write_cv_pct']:.2f},"
+            f"{r['record_ns_per_op_tm']:.2f},"
+            f"{r['total_ns_per_op_tm']:.2f},"
+            f"{r['record_ns_per_counter_write_tm']:.2f},"
+            f"{r['total_ns_per_counter_write_tm']:.2f}"
         )
     (run_dir / "summary.csv").write_text("\n".join(csv_lines) + "\n")
 
@@ -165,7 +238,10 @@ def main() -> int:
             f"  {r['mode']:6s} runs={r['n']} "
             f"cpu_ns_per_op={r['cpu_ns_per_op_tm']:.2f} (cv={cpu_cv:.1f}%{cpu_cv_marker}, "
             f"min={r['cpu_ns_per_op_min']:.2f} max={r['cpu_ns_per_op_max']:.2f})  "
+            f"cpu_ns_per_counter_write={r['cpu_ns_per_counter_write_tm']:.2f}  "
+            f"total_ns_per_op={r['total_ns_per_op_tm']:.2f}  "
             f"total_ops/s={r['total_tm']:,.0f} (wall_cv={wall_cv:.1f}%)  "
+            f"total_counter_writes/s={r['total_counter_writes_tm']:,.0f}  "
             f"cpu_total_s={r['cpu_total_tm']:.3f} cpu_avg_cores={r['cpu_cores_tm']:.2f} "
             f"export_avg_ms={r['export_tm']:.4f}"
         )

--- a/crates/fast-telemetry/bench/summarize_perf.py
+++ b/crates/fast-telemetry/bench/summarize_perf.py
@@ -19,14 +19,29 @@ def parse_perf_file(path: pathlib.Path):
     values = {key: 0 for key in FIELDS.keys()}
     text = path.read_text()
     for line in text.splitlines():
-        match = re.match(r"\s*([\d,]+)\s+.*?/([^/]+)/", line)
+        match = re.match(r"\s*([\d,]+)\s+([^\s#]+)", line)
         if not match:
             continue
         value = int(match.group(1).replace(",", ""))
-        event = match.group(2)
+        event = match.group(2).strip()
+        event_name = event.split("/")[-2] if "/" in event else event
         for key, needle in FIELDS.items():
-            if event == needle:
+            if event_name == needle:
                 values[key] += value
+    return values
+
+
+def parse_run_totals(path: pathlib.Path):
+    values = {"total_ops": 0, "total_counter_writes": 0}
+    if not path.exists():
+        return values
+
+    for line in path.read_text().splitlines():
+        if line.startswith("total_ops="):
+            values["total_ops"] = int(line.split("=", 1)[1])
+        elif line.startswith("total_counter_writes="):
+            values["total_counter_writes"] = int(line.split("=", 1)[1])
+
     return values
 
 
@@ -34,6 +49,7 @@ def main() -> int:
     run_dir = pathlib.Path(sys.argv[1])
     modes = [m for m in sys.argv[2].split(",") if m]
 
+    rows = []
     print("")
     print("Perf Summary (summed counters):")
     for mode in modes:
@@ -52,13 +68,59 @@ def main() -> int:
         ipc = (instructions / cycles) if cycles else 0.0
         cache_miss_rate = (100.0 * cache_misses / cache_refs) if cache_refs else 0.0
         l1_miss_rate = (100.0 * l1_misses / l1_loads) if l1_loads else 0.0
+        totals = parse_run_totals(run_dir / f"{mode}-run-1.txt")
+        total_ops = totals["total_ops"]
+        total_counter_writes = totals["total_counter_writes"]
+        cycles_per_op = (cycles / total_ops) if total_ops else 0.0
+        cycles_per_counter_write = (
+            cycles / total_counter_writes
+            if total_counter_writes
+            else 0.0
+        )
+        instructions_per_counter_write = (
+            instructions / total_counter_writes
+            if total_counter_writes
+            else 0.0
+        )
+
+        rows.append({
+            "mode": mode,
+            "cycles": cycles,
+            "instructions": instructions,
+            "ipc": ipc,
+            "cache_miss_rate": cache_miss_rate,
+            "l1_miss_rate": l1_miss_rate,
+            "total_ops": total_ops,
+            "total_counter_writes": total_counter_writes,
+            "cycles_per_op": cycles_per_op,
+            "cycles_per_counter_write": cycles_per_counter_write,
+            "instructions_per_counter_write": instructions_per_counter_write,
+        })
 
         print(
             f"  {mode:6s} ipc={ipc:.3f} "
             f"cache_miss_rate={cache_miss_rate:.3f}% "
             f"l1_miss_rate={l1_miss_rate:.3f}% "
+            f"cycles_per_counter_write={cycles_per_counter_write:.2f} "
             f"cycles={cycles:,} instructions={instructions:,}"
         )
+
+    if rows:
+        csv_lines = [
+            "mode,cycles,instructions,ipc,cache_miss_rate_pct,l1_miss_rate_pct,"
+            "total_ops,total_counter_writes,cycles_per_op,"
+            "cycles_per_counter_write,instructions_per_counter_write"
+        ]
+        for row in rows:
+            csv_lines.append(
+                f"{row['mode']},{row['cycles']},{row['instructions']},"
+                f"{row['ipc']:.6f},{row['cache_miss_rate']:.6f},"
+                f"{row['l1_miss_rate']:.6f},{row['total_ops']},"
+                f"{row['total_counter_writes']},{row['cycles_per_op']:.6f},"
+                f"{row['cycles_per_counter_write']:.6f},"
+                f"{row['instructions_per_counter_write']:.6f}"
+            )
+        (run_dir / "perf-summary.csv").write_text("\n".join(csv_lines) + "\n")
 
     return 0
 

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -3,6 +3,7 @@
 // Build and run directly:
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter --threads 16 --iters 10000000 --shards 16
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_multi --threads 16 --iters 10000000 --shards 16 --batch-size 8
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity counter_multi --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_batch --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_set --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_buffered --threads 16 --iters 10000000 --shards 16 --batch-size 8 --flush-every 64
@@ -1564,6 +1565,7 @@ fn run_metrics(entity: Entity, cfg: &Config) -> RunResult {
 fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
     let threads = cfg.threads;
     let iters = cfg.iters;
+    let batch_size = cfg.batch_size;
     let labels = cfg.labels;
     let profile = cfg.profile;
     let thread_affinity = cfg.thread_affinity;
@@ -1575,7 +1577,12 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
             .build(),
     );
     let meter = provider.meter("fast-telemetry.bench_cache_contention");
-    let expected_final_count = (threads * (iters + (iters / 10).max(1))) as isize;
+    let expected_counter_writes_per_op = match entity {
+        Entity::CounterMulti => batch_size,
+        _ => 1,
+    };
+    let expected_final_count =
+        (threads * (iters + (iters / 10).max(1)) * expected_counter_writes_per_op) as isize;
 
     let attrs: Arc<Vec<KeyValue>> = Arc::new(
         (0..labels)
@@ -1621,8 +1628,49 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
-        Entity::CounterMulti
-        | Entity::CounterBatch
+        Entity::CounterMulti => {
+            let counters: Arc<Vec<OTelCounter<u64>>> = Arc::new(
+                (0..batch_size)
+                    .map(|idx| meter.u64_counter(format!("contention_counter_{idx}")).build())
+                    .collect(),
+            );
+            let worker_counters = Arc::clone(&counters);
+            let exporter_provider = Arc::clone(&provider);
+            let exporter_exporter = exporter.clone();
+
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        for _ in 0..n {
+                            for counter in worker_counters.iter() {
+                                counter.add(1, &[]);
+                            }
+                        }
+                    },
+                    move || {
+                        let _ = exporter_provider.force_flush();
+                        let _ = exporter_exporter.get_finished_metrics();
+                        exporter_exporter.reset();
+                        0usize
+                    },
+                );
+
+            let _ = provider.force_flush();
+            let _ = exporter.get_finished_metrics();
+            RunResult {
+                final_count: expected_final_count,
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterBatch
         | Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -2,13 +2,16 @@
 //
 // Build and run directly:
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter --threads 16 --iters 10000000 --shards 16
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_multi --threads 16 --iters 10000000 --shards 16 --batch-size 8
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_batch --threads 16 --iters 10000000 --shards 16 --batch-size 8
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_set --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity labeled_counter --threads 16 --iters 10000000 --labels 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter --threads 16 --iters 10000000 --labels 64 --shards 16
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity dynamic_counter --threads 16 --iters 10000000 --labels 64
 
 use fast_telemetry::{
-    Counter, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge, DynamicGaugeI64,
-    DynamicHistogram, LabelEnum, LabeledCounter, LabeledGauge, LabeledHistogram,
+    Counter, CounterSet, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge,
+    DynamicGaugeI64, DynamicHistogram, LabelEnum, LabeledCounter, LabeledGauge, LabeledHistogram,
 };
 use metrics::atomics::AtomicU64 as MetricsAtomicU64;
 use metrics::{
@@ -47,6 +50,9 @@ enum Mode {
 #[derive(Copy, Clone, Debug)]
 enum Entity {
     Counter,
+    CounterMulti,
+    CounterBatch,
+    CounterSet,
     Distribution,
     DynamicCounter,
     DynamicDistribution,
@@ -92,6 +98,7 @@ struct Config {
     iters: usize,
     shards: usize,
     labels: usize,
+    batch_size: usize,
     profile: WorkloadProfile,
     thread_affinity: ThreadAffinityMode,
     export_interval_ms: u64,
@@ -114,6 +121,7 @@ fn parse_args() -> Config {
     let mut shards = threads;
     let mut shards_set = false;
     let mut labels = 16usize;
+    let mut batch_size = 8usize;
     let mut profile = WorkloadProfile::Uniform;
     let mut thread_affinity = ThreadAffinityMode::Off;
     let mut export_interval_ms = 10u64;
@@ -135,6 +143,9 @@ fn parse_args() -> Config {
             "--entity" if i + 1 < args.len() => {
                 entity = match args[i + 1].as_str() {
                     "counter" => Entity::Counter,
+                    "counter_multi" => Entity::CounterMulti,
+                    "counter_batch" => Entity::CounterBatch,
+                    "counter_set" => Entity::CounterSet,
                     "distribution" => Entity::Distribution,
                     "dynamic_counter" => Entity::DynamicCounter,
                     "dynamic_distribution" => Entity::DynamicDistribution,
@@ -145,7 +156,7 @@ fn parse_args() -> Config {
                     "labeled_gauge" => Entity::LabeledGauge,
                     "labeled_histogram" => Entity::LabeledHistogram,
                     value => panic!(
-                        "invalid --entity: {value} (expected counter|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
+                        "invalid --entity: {value} (expected counter|counter_multi|counter_batch|counter_set|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
                     ),
                 };
                 i += 2;
@@ -186,6 +197,12 @@ fn parse_args() -> Config {
                 labels = args[i + 1].parse().expect("--labels must be an integer");
                 i += 2;
             }
+            "--batch-size" if i + 1 < args.len() => {
+                batch_size = args[i + 1]
+                    .parse()
+                    .expect("--batch-size must be an integer");
+                i += 2;
+            }
             "--export-interval-ms" if i + 1 < args.len() => {
                 export_interval_ms = args[i + 1]
                     .parse()
@@ -194,9 +211,12 @@ fn parse_args() -> Config {
             }
             "--help" => {
                 println!(
-                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
+                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_batch|counter_set|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
                 );
                 println!("  --profile <uniform|hotspot|churn> controls label access pattern");
+                println!(
+                    "  --batch-size <n> controls counters per op for counter_multi, counter_batch, and counter_set"
+                );
                 println!("  metrics mode uses metrics + metrics-util::Registry<_, AtomicStorage>");
                 std::process::exit(0);
             }
@@ -209,6 +229,7 @@ fn parse_args() -> Config {
     }
 
     assert!(labels >= 1, "--labels must be >= 1");
+    assert!(batch_size >= 1, "--batch-size must be >= 1");
     assert!(
         labels <= BenchLabel::CARDINALITY,
         "--labels must be <= {}",
@@ -222,6 +243,7 @@ fn parse_args() -> Config {
         iters,
         shards,
         labels,
+        batch_size,
         profile,
         thread_affinity,
         export_interval_ms,
@@ -402,6 +424,10 @@ fn metrics_gauge_value(cell: &MetricsGaugeCell) -> f64 {
     f64::from_bits(cell.load(Ordering::Relaxed))
 }
 
+fn counter_batch_final_count(counters: &[Counter]) -> isize {
+    counters.iter().map(Counter::sum).sum()
+}
+
 fn export_metrics_histogram(cell: &MetricsHistogramCell) -> u64 {
     let mut total = 0u64;
     cell.clear_with(|block| {
@@ -416,6 +442,7 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
     let iters = cfg.iters;
     let shards = cfg.shards;
     let labels = cfg.labels;
+    let batch_size = cfg.batch_size;
     let profile = cfg.profile;
     let thread_affinity = cfg.thread_affinity;
     let export_interval_ms = cfg.export_interval_ms;
@@ -440,6 +467,93 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
 
             RunResult {
                 final_count: counter.sum(),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterMulti => {
+            let counters: Arc<Vec<Counter>> =
+                Arc::new((0..batch_size).map(|_| Counter::new(shards)).collect());
+            let worker_counters = Arc::clone(&counters);
+            let exporter_counters = Arc::clone(&counters);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        for _ in 0..n {
+                            for counter in worker_counters.iter() {
+                                counter.inc();
+                            }
+                        }
+                    },
+                    move || counter_batch_final_count(&exporter_counters),
+                );
+
+            RunResult {
+                final_count: counter_batch_final_count(&counters),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterBatch => {
+            let counters: Arc<Vec<Counter>> =
+                Arc::new((0..batch_size).map(|_| Counter::new(shards)).collect());
+            let worker_counters = Arc::clone(&counters);
+            let exporter_counters = Arc::clone(&counters);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        for _ in 0..n {
+                            Counter::inc_many(worker_counters.as_slice());
+                        }
+                    },
+                    move || counter_batch_final_count(&exporter_counters),
+                );
+
+            RunResult {
+                final_count: counter_batch_final_count(&counters),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterSet => {
+            let counters = Arc::new(CounterSet::new(shards, batch_size));
+            let values: Arc<Vec<isize>> = Arc::new(vec![1; batch_size]);
+            let worker_counters = Arc::clone(&counters);
+            let worker_values = Arc::clone(&values);
+            let exporter_counters = Arc::clone(&counters);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        for _ in 0..n {
+                            worker_counters.add_values(&worker_values);
+                        }
+                    },
+                    move || exporter_counters.sum_all(),
+                );
+
+            RunResult {
+                final_count: counters.sum_all(),
                 record_seconds,
                 total_seconds,
                 export_count,
@@ -946,6 +1060,9 @@ fn run_metrics(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
+        Entity::CounterMulti | Entity::CounterBatch | Entity::CounterSet => {
+            panic!("metrics mode does not support entity={entity:?}; use mode=fast")
+        }
         Entity::Distribution | Entity::DynamicDistribution => {
             panic!("metrics mode does not support entity={entity:?}; metrics-rs exposes histograms but not a distribution primitive")
         }
@@ -1360,6 +1477,9 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
                 export_seconds,
                 cpu_usage,
             }
+        }
+        Entity::CounterMulti | Entity::CounterBatch | Entity::CounterSet => {
+            panic!("otel mode does not support entity={entity:?}; use mode=fast")
         }
         Entity::Distribution => {
             // OTel histogram as the closest equivalent to Distribution
@@ -1788,6 +1908,11 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
 fn main() {
     let cfg = parse_args();
     let total_ops = cfg.threads * cfg.iters;
+    let counter_writes_per_op = match cfg.entity {
+        Entity::CounterMulti | Entity::CounterBatch | Entity::CounterSet => cfg.batch_size,
+        _ => 1,
+    };
+    let total_counter_writes = total_ops * counter_writes_per_op;
 
     let result = match cfg.mode {
         Mode::Fast => run_fast(cfg.entity, &cfg),
@@ -1799,6 +1924,16 @@ fn main() {
 
     let record_ops_per_sec = (total_ops as f64) / result.record_seconds;
     let total_ops_per_sec = (total_ops as f64) / result.total_seconds;
+    let record_counter_writes_per_sec =
+        (total_counter_writes as f64) / result.record_seconds;
+    let total_counter_writes_per_sec =
+        (total_counter_writes as f64) / result.total_seconds;
+    let record_ns_per_op = (result.record_seconds * 1_000_000_000.0) / (total_ops as f64);
+    let total_ns_per_op = (result.total_seconds * 1_000_000_000.0) / (total_ops as f64);
+    let record_ns_per_counter_write =
+        (result.record_seconds * 1_000_000_000.0) / (total_counter_writes as f64);
+    let total_ns_per_counter_write =
+        (result.total_seconds * 1_000_000_000.0) / (total_counter_writes as f64);
     let export_avg_ms = if result.export_count == 0 {
         0.0
     } else {
@@ -1812,6 +1947,9 @@ fn main() {
     };
     let entity = match cfg.entity {
         Entity::Counter => "counter",
+        Entity::CounterMulti => "counter_multi",
+        Entity::CounterBatch => "counter_batch",
+        Entity::CounterSet => "counter_set",
         Entity::Distribution => "distribution",
         Entity::DynamicCounter => "dynamic_counter",
         Entity::DynamicDistribution => "dynamic_distribution",
@@ -1830,10 +1968,13 @@ fn main() {
     };
 
     let warmup_ops = cfg.threads * (cfg.iters / 10).max(1);
-    let expected_count = (total_ops + warmup_ops) as isize;
+    let expected_count = ((total_ops + warmup_ops) * counter_writes_per_op) as isize;
     let verify_count = matches!(
         cfg.entity,
         Entity::Counter
+            | Entity::CounterMulti
+            | Entity::CounterBatch
+            | Entity::CounterSet
             | Entity::Distribution
             | Entity::DynamicCounter
             | Entity::DynamicDistribution
@@ -1856,6 +1997,11 @@ fn main() {
     } else {
         0.0
     };
+    let cpu_ns_per_counter_write = if total_counter_writes > 0 {
+        (cpu_total_seconds * 1_000_000_000.0) / (total_counter_writes as f64)
+    } else {
+        0.0
+    };
 
     println!("mode={mode}");
     println!("entity={entity}");
@@ -1865,13 +2011,22 @@ fn main() {
     println!("iters_per_thread={}", cfg.iters);
     println!("shards={}", cfg.shards);
     println!("labels={}", cfg.labels);
+    println!("batch_size={}", cfg.batch_size);
+    println!("counter_writes_per_op={counter_writes_per_op}");
     println!("export_interval_ms={}", cfg.export_interval_ms);
     println!("total_ops={total_ops}");
+    println!("total_counter_writes={total_counter_writes}");
     println!("record_seconds={:.6}", result.record_seconds);
     println!("total_seconds={:.6}", result.total_seconds);
     println!("record_ops_per_sec={record_ops_per_sec:.2}");
     println!("total_ops_per_sec={total_ops_per_sec:.2}");
     println!("ops_per_sec={total_ops_per_sec:.2}");
+    println!("record_counter_writes_per_sec={record_counter_writes_per_sec:.2}");
+    println!("total_counter_writes_per_sec={total_counter_writes_per_sec:.2}");
+    println!("record_ns_per_op={record_ns_per_op:.2}");
+    println!("total_ns_per_op={total_ns_per_op:.2}");
+    println!("record_ns_per_counter_write={record_ns_per_counter_write:.2}");
+    println!("total_ns_per_counter_write={total_ns_per_counter_write:.2}");
     println!("export_count={}", result.export_count);
     println!("export_seconds={:.6}", result.export_seconds);
     println!("export_avg_ms={export_avg_ms:.6}");
@@ -1882,6 +2037,7 @@ fn main() {
     println!("cpu_avg_cores={cpu_avg_cores:.6}");
     println!("cpu_utilization_pct={cpu_utilization_pct:.2}");
     println!("cpu_ns_per_op={cpu_ns_per_op:.2}");
+    println!("cpu_ns_per_counter_write={cpu_ns_per_counter_write:.2}");
     println!("final_count={}", result.final_count);
     if verify_count {
         println!("expected_count={expected_count}");

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -5,13 +5,15 @@
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_multi --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_batch --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_set --threads 16 --iters 10000000 --shards 16 --batch-size 8
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_buffered --threads 16 --iters 10000000 --shards 16 --batch-size 8 --flush-every 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity labeled_counter --threads 16 --iters 10000000 --labels 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter --threads 16 --iters 10000000 --labels 64 --shards 16
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity dynamic_counter --threads 16 --iters 10000000 --labels 64
 
 use fast_telemetry::{
-    Counter, CounterSet, Distribution, DynamicCounter, DynamicDistribution, DynamicGauge,
-    DynamicGaugeI64, DynamicHistogram, LabelEnum, LabeledCounter, LabeledGauge, LabeledHistogram,
+    Counter, CounterSet, CounterSetBuffer, Distribution, DynamicCounter, DynamicDistribution,
+    DynamicGauge, DynamicGaugeI64, DynamicHistogram, LabelEnum, LabeledCounter, LabeledGauge,
+    LabeledHistogram,
 };
 use metrics::atomics::AtomicU64 as MetricsAtomicU64;
 use metrics::{
@@ -25,6 +27,7 @@ use opentelemetry::{
     metrics::Histogram as OTelHistogram, KeyValue,
 };
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
+use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::sync::{Arc, Barrier};
@@ -53,6 +56,9 @@ enum Entity {
     CounterMulti,
     CounterBatch,
     CounterSet,
+    CounterBuffered,
+    CounterBufferedIndexed,
+    CounterBufferedLookup,
     Distribution,
     DynamicCounter,
     DynamicDistribution,
@@ -99,6 +105,7 @@ struct Config {
     shards: usize,
     labels: usize,
     batch_size: usize,
+    flush_every: usize,
     profile: WorkloadProfile,
     thread_affinity: ThreadAffinityMode,
     export_interval_ms: u64,
@@ -122,6 +129,7 @@ fn parse_args() -> Config {
     let mut shards_set = false;
     let mut labels = 16usize;
     let mut batch_size = 8usize;
+    let mut flush_every = 64usize;
     let mut profile = WorkloadProfile::Uniform;
     let mut thread_affinity = ThreadAffinityMode::Off;
     let mut export_interval_ms = 10u64;
@@ -146,6 +154,9 @@ fn parse_args() -> Config {
                     "counter_multi" => Entity::CounterMulti,
                     "counter_batch" => Entity::CounterBatch,
                     "counter_set" => Entity::CounterSet,
+                    "counter_buffered" => Entity::CounterBuffered,
+                    "counter_buffered_indexed" => Entity::CounterBufferedIndexed,
+                    "counter_buffered_lookup" => Entity::CounterBufferedLookup,
                     "distribution" => Entity::Distribution,
                     "dynamic_counter" => Entity::DynamicCounter,
                     "dynamic_distribution" => Entity::DynamicDistribution,
@@ -156,7 +167,7 @@ fn parse_args() -> Config {
                     "labeled_gauge" => Entity::LabeledGauge,
                     "labeled_histogram" => Entity::LabeledHistogram,
                     value => panic!(
-                        "invalid --entity: {value} (expected counter|counter_multi|counter_batch|counter_set|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
+                        "invalid --entity: {value} (expected counter|counter_multi|counter_batch|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
                     ),
                 };
                 i += 2;
@@ -203,6 +214,12 @@ fn parse_args() -> Config {
                     .expect("--batch-size must be an integer");
                 i += 2;
             }
+            "--flush-every" if i + 1 < args.len() => {
+                flush_every = args[i + 1]
+                    .parse()
+                    .expect("--flush-every must be an integer");
+                i += 2;
+            }
             "--export-interval-ms" if i + 1 < args.len() => {
                 export_interval_ms = args[i + 1]
                     .parse()
@@ -211,12 +228,14 @@ fn parse_args() -> Config {
             }
             "--help" => {
                 println!(
-                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_batch|counter_set|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
+                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_batch|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
                 );
                 println!("  --profile <uniform|hotspot|churn> controls label access pattern");
                 println!(
-                    "  --batch-size <n> controls counters per op for counter_multi, counter_batch, and counter_set"
+                    "  --batch-size <n> controls counters per op for counter_multi, counter_batch, counter_set, counter_buffered, counter_buffered_indexed, and counter_buffered_lookup"
                 );
+                println!("  --flush-every <n> controls local-delta flush cadence for counter_buffered");
+                println!("  --labels <n> controls registered metric names for counter_buffered_lookup");
                 println!("  metrics mode uses metrics + metrics-util::Registry<_, AtomicStorage>");
                 std::process::exit(0);
             }
@@ -230,6 +249,7 @@ fn parse_args() -> Config {
 
     assert!(labels >= 1, "--labels must be >= 1");
     assert!(batch_size >= 1, "--batch-size must be >= 1");
+    assert!(flush_every >= 1, "--flush-every must be >= 1");
     assert!(
         labels <= BenchLabel::CARDINALITY,
         "--labels must be <= {}",
@@ -244,6 +264,7 @@ fn parse_args() -> Config {
         shards,
         labels,
         batch_size,
+        flush_every,
         profile,
         thread_affinity,
         export_interval_ms,
@@ -443,6 +464,7 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
     let shards = cfg.shards;
     let labels = cfg.labels;
     let batch_size = cfg.batch_size;
+    let flush_every = cfg.flush_every;
     let profile = cfg.profile;
     let thread_affinity = cfg.thread_affinity;
     let export_interval_ms = cfg.export_interval_ms;
@@ -548,6 +570,122 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
                         for _ in 0..n {
                             worker_counters.add_values(&worker_values);
                         }
+                    },
+                    move || exporter_counters.sum_all(),
+                );
+
+            RunResult {
+                final_count: counters.sum_all(),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterBuffered => {
+            let counters = Arc::new(CounterSet::new(shards, batch_size));
+            let worker_counters = Arc::clone(&counters);
+            let exporter_counters = Arc::clone(&counters);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        let mut buffer = CounterSetBuffer::new(&worker_counters, flush_every);
+                        for _ in 0..n {
+                            buffer.inc_all();
+                        }
+                        buffer.flush();
+                    },
+                    move || exporter_counters.sum_all(),
+                );
+
+            RunResult {
+                final_count: counters.sum_all(),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterBufferedIndexed => {
+            let counters = Arc::new(CounterSet::new(shards, batch_size));
+            let indexes: Arc<Vec<usize>> = Arc::new((0..batch_size).collect());
+            let worker_counters = Arc::clone(&counters);
+            let worker_indexes = Arc::clone(&indexes);
+            let exporter_counters = Arc::clone(&counters);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        let mut buffer = CounterSetBuffer::new(&worker_counters, flush_every);
+                        for _ in 0..n {
+                            for index in worker_indexes.iter().copied() {
+                                buffer.inc(index);
+                            }
+                            buffer.finish_op();
+                        }
+                        buffer.flush();
+                    },
+                    move || exporter_counters.sum_all(),
+                );
+
+            RunResult {
+                final_count: counters.sum_all(),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::CounterBufferedLookup => {
+            let counters = Arc::new(CounterSet::new(shards, batch_size));
+            let lookup_metric_count = labels.max(batch_size);
+            let mut lookup = BTreeMap::new();
+            let mut active_names = Vec::with_capacity(batch_size);
+            for metric_idx in 0..lookup_metric_count {
+                let name = format!("bench.lookup.metric.{metric_idx}");
+                let local_idx = if metric_idx < batch_size {
+                    active_names.push(name.clone());
+                    metric_idx
+                } else {
+                    0
+                };
+                lookup.insert(name, local_idx);
+            }
+
+            let lookup = Arc::new(lookup);
+            let active_names = Arc::new(active_names);
+            let worker_counters = Arc::clone(&counters);
+            let worker_lookup = Arc::clone(&lookup);
+            let worker_names = Arc::clone(&active_names);
+            let exporter_counters = Arc::clone(&counters);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |_, n| {
+                        let mut buffer = CounterSetBuffer::new(&worker_counters, flush_every);
+                        for _ in 0..n {
+                            for name in worker_names.iter() {
+                                let index = *worker_lookup
+                                    .get(name.as_str())
+                                    .expect("metric name should be registered");
+                                buffer.inc(index);
+                            }
+                            buffer.finish_op();
+                        }
+                        buffer.flush();
                     },
                     move || exporter_counters.sum_all(),
                 );
@@ -1060,7 +1198,12 @@ fn run_metrics(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
-        Entity::CounterMulti | Entity::CounterBatch | Entity::CounterSet => {
+        Entity::CounterMulti
+        | Entity::CounterBatch
+        | Entity::CounterSet
+        | Entity::CounterBuffered
+        | Entity::CounterBufferedIndexed
+        | Entity::CounterBufferedLookup => {
             panic!("metrics mode does not support entity={entity:?}; use mode=fast")
         }
         Entity::Distribution | Entity::DynamicDistribution => {
@@ -1478,7 +1621,12 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
-        Entity::CounterMulti | Entity::CounterBatch | Entity::CounterSet => {
+        Entity::CounterMulti
+        | Entity::CounterBatch
+        | Entity::CounterSet
+        | Entity::CounterBuffered
+        | Entity::CounterBufferedIndexed
+        | Entity::CounterBufferedLookup => {
             panic!("otel mode does not support entity={entity:?}; use mode=fast")
         }
         Entity::Distribution => {
@@ -1909,7 +2057,12 @@ fn main() {
     let cfg = parse_args();
     let total_ops = cfg.threads * cfg.iters;
     let counter_writes_per_op = match cfg.entity {
-        Entity::CounterMulti | Entity::CounterBatch | Entity::CounterSet => cfg.batch_size,
+        Entity::CounterMulti
+        | Entity::CounterBatch
+        | Entity::CounterSet
+        | Entity::CounterBuffered
+        | Entity::CounterBufferedIndexed
+        | Entity::CounterBufferedLookup => cfg.batch_size,
         _ => 1,
     };
     let total_counter_writes = total_ops * counter_writes_per_op;
@@ -1950,6 +2103,9 @@ fn main() {
         Entity::CounterMulti => "counter_multi",
         Entity::CounterBatch => "counter_batch",
         Entity::CounterSet => "counter_set",
+        Entity::CounterBuffered => "counter_buffered",
+        Entity::CounterBufferedIndexed => "counter_buffered_indexed",
+        Entity::CounterBufferedLookup => "counter_buffered_lookup",
         Entity::Distribution => "distribution",
         Entity::DynamicCounter => "dynamic_counter",
         Entity::DynamicDistribution => "dynamic_distribution",
@@ -1975,6 +2131,9 @@ fn main() {
             | Entity::CounterMulti
             | Entity::CounterBatch
             | Entity::CounterSet
+            | Entity::CounterBuffered
+            | Entity::CounterBufferedIndexed
+            | Entity::CounterBufferedLookup
             | Entity::Distribution
             | Entity::DynamicCounter
             | Entity::DynamicDistribution
@@ -2012,6 +2171,7 @@ fn main() {
     println!("shards={}", cfg.shards);
     println!("labels={}", cfg.labels);
     println!("batch_size={}", cfg.batch_size);
+    println!("flush_every={}", cfg.flush_every);
     println!("counter_writes_per_op={counter_writes_per_op}");
     println!("export_interval_ms={}", cfg.export_interval_ms);
     println!("total_ops={total_ops}");

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -49,6 +49,9 @@ pub mod __macro_support {
         FastFormat,
     };
 }
+#[cfg(feature = "bench-tools")]
+#[doc(hidden)]
+pub use metric::CounterSet;
 pub use metric::ExportMetrics;
 pub use metric::{
     Counter, Distribution, DistributionSnapshot, DynamicCounter, DynamicCounterSeries,

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -49,9 +49,6 @@ pub mod __macro_support {
         FastFormat,
     };
 }
-#[cfg(feature = "bench-tools")]
-#[doc(hidden)]
-pub use metric::CounterSet;
 pub use metric::ExportMetrics;
 pub use metric::{
     Counter, Distribution, DistributionSnapshot, DynamicCounter, DynamicCounterSeries,
@@ -62,6 +59,9 @@ pub use metric::{
     MaxGaugeF64, MetricKind, MetricLabel, MetricLabels, MetricLabelsIter, MetricMeta,
     MetricVisitor, MinGauge, MinGaugeF64, SampledTimer, SampledTimerGuard,
 };
+#[cfg(feature = "bench-tools")]
+#[doc(hidden)]
+pub use metric::{CounterSet, CounterSetBuffer};
 #[cfg(feature = "eviction")]
 pub use metric::{advance_cycle, current_cycle};
 #[cfg(feature = "runtime")]

--- a/crates/fast-telemetry/src/metric/counter.rs
+++ b/crates/fast-telemetry/src/metric/counter.rs
@@ -208,6 +208,21 @@ impl CounterSet {
         }
     }
 
+    /// Increments one counter in the current thread's shard row.
+    #[inline]
+    pub fn inc(&self, counter_idx: usize) {
+        self.add(counter_idx, 1);
+    }
+
+    /// Adds a value to one counter in the current thread's shard row.
+    #[inline]
+    pub fn add(&self, counter_idx: usize, value: isize) {
+        assert!(counter_idx < self.counters, "counter index out of bounds");
+        let offset = self.current_shard_offset();
+        self.cell_at(offset + counter_idx)
+            .fetch_add(value, Ordering::Relaxed);
+    }
+
     /// Increments all counters in the current thread's shard row.
     #[inline]
     pub fn inc_all(&self) {
@@ -215,7 +230,7 @@ impl CounterSet {
     }
 
     /// Adds the same value to all counters in the current thread's shard row.
-    #[inline]
+    #[inline(always)]
     pub fn add_all(&self, value: isize) {
         let offset = self.current_shard_offset();
         let row = if cfg!(debug_assertions) {
@@ -273,21 +288,79 @@ impl CounterSet {
     }
 
     /// Adds one value per counter in the current thread's shard row.
-    #[inline]
+    #[inline(always)]
     pub fn add_values(&self, values: &[isize]) {
         assert_eq!(values.len(), self.counters, "values must match counters");
         let offset = self.current_shard_offset();
-        let row = if cfg!(debug_assertions) {
-            self.cells
-                .get(offset..offset + self.counters)
-                .expect("row index out of bounds")
-        } else {
-            // SAFETY: current_shard_offset derives from shard_mask and stride,
-            // and counters <= stride by construction.
-            unsafe { std::slice::from_raw_parts(self.cells.as_ptr().add(offset), self.counters) }
-        };
-        for (cell, value) in row.iter().zip(values.iter().copied()) {
-            cell.fetch_add(value, Ordering::Relaxed);
+        match values {
+            [a] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+            }
+            [a, b] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+            }
+            [a, b, c] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+            }
+            [a, b, c, d] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+            }
+            [a, b, c, d, e] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+            }
+            [a, b, c, d, e, f] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+                self.cell_at(offset + 5).fetch_add(*f, Ordering::Relaxed);
+            }
+            [a, b, c, d, e, f, g] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+                self.cell_at(offset + 5).fetch_add(*f, Ordering::Relaxed);
+                self.cell_at(offset + 6).fetch_add(*g, Ordering::Relaxed);
+            }
+            [a, b, c, d, e, f, g, h] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+                self.cell_at(offset + 5).fetch_add(*f, Ordering::Relaxed);
+                self.cell_at(offset + 6).fetch_add(*g, Ordering::Relaxed);
+                self.cell_at(offset + 7).fetch_add(*h, Ordering::Relaxed);
+            }
+            values => {
+                let row = if cfg!(debug_assertions) {
+                    self.cells
+                        .get(offset..offset + self.counters)
+                        .expect("row index out of bounds")
+                } else {
+                    // SAFETY: current_shard_offset derives from shard_mask and
+                    // stride, and counters <= stride by construction.
+                    unsafe {
+                        std::slice::from_raw_parts(self.cells.as_ptr().add(offset), self.counters)
+                    }
+                };
+                for (cell, value) in row.iter().zip(values.iter().copied()) {
+                    cell.fetch_add(value, Ordering::Relaxed);
+                }
+            }
         }
     }
 
@@ -316,6 +389,118 @@ impl CounterSet {
             }
         }
         total
+    }
+}
+
+/// Benchmark-only prototype for buffering related counter updates locally.
+#[cfg(feature = "bench-tools")]
+#[doc(hidden)]
+pub struct CounterSetBuffer<'a> {
+    counters: &'a CounterSet,
+    deltas: Vec<isize>,
+    all_delta: isize,
+    ops_since_flush: usize,
+    flush_every: usize,
+    op_dirty: bool,
+}
+
+#[cfg(feature = "bench-tools")]
+impl<'a> CounterSetBuffer<'a> {
+    /// Creates a local buffer for a grouped counter set.
+    #[inline]
+    pub fn new(counters: &'a CounterSet, flush_every: usize) -> Self {
+        assert!(flush_every >= 1, "flush_every must be >= 1");
+        Self {
+            counters,
+            deltas: vec![0; counters.len()],
+            all_delta: 0,
+            ops_since_flush: 0,
+            flush_every,
+            op_dirty: false,
+        }
+    }
+
+    /// Increments one buffered counter.
+    #[inline]
+    pub fn inc(&mut self, counter_idx: usize) {
+        self.add(counter_idx, 1);
+    }
+
+    /// Adds a value to one buffered counter.
+    #[inline]
+    pub fn add(&mut self, counter_idx: usize, value: isize) {
+        assert!(
+            counter_idx < self.deltas.len(),
+            "counter index out of bounds"
+        );
+        self.deltas[counter_idx] += value;
+        self.op_dirty = true;
+    }
+
+    /// Increments every buffered counter and marks one logical operation complete.
+    #[inline(always)]
+    pub fn inc_all(&mut self) {
+        self.all_delta += 1;
+        self.finish_group_op();
+    }
+
+    /// Adds the same value to every buffered counter and marks one logical operation complete.
+    #[inline(always)]
+    pub fn add_all(&mut self, value: isize) {
+        self.all_delta += value;
+        self.finish_group_op();
+    }
+
+    /// Adds one value per buffered counter and marks one logical operation complete.
+    #[inline]
+    pub fn add_values(&mut self, values: &[isize]) {
+        assert_eq!(
+            values.len(),
+            self.deltas.len(),
+            "values must match counters"
+        );
+        for (delta, value) in self.deltas.iter_mut().zip(values.iter().copied()) {
+            *delta += value;
+        }
+        self.finish_group_op();
+    }
+
+    /// Marks the current logical operation complete.
+    #[inline]
+    pub fn finish_op(&mut self) {
+        if !self.op_dirty {
+            return;
+        }
+
+        self.op_dirty = false;
+        self.finish_group_op();
+    }
+
+    #[inline(always)]
+    fn finish_group_op(&mut self) {
+        self.ops_since_flush += 1;
+        if self.ops_since_flush >= self.flush_every {
+            self.flush();
+        }
+    }
+
+    /// Flushes buffered deltas to the backing grouped counter set.
+    #[inline]
+    pub fn flush(&mut self) {
+        if self.ops_since_flush == 0 && !self.op_dirty {
+            return;
+        }
+
+        if self.all_delta != 0 {
+            self.counters.add_all(self.all_delta);
+            self.all_delta = 0;
+        }
+        if self.deltas.iter().any(|delta| *delta != 0) {
+            self.counters.add_values(&self.deltas);
+            self.deltas.fill(0);
+        }
+        self.ops_since_flush = 0;
+        self.op_dirty = false;
     }
 }
 
@@ -418,6 +603,8 @@ mod tests {
     fn counter_set_updates_grouped_counters() {
         let counters = CounterSet::new(4, 3);
 
+        counters.inc(0);
+        counters.add(1, 2);
         counters.inc_all();
         counters.add_values(&[2, 3, 4]);
         counters.add_indices(&[0, 2], 1);
@@ -425,9 +612,38 @@ mod tests {
 
         assert_eq!(counters.len(), 3);
         assert!(!counters.is_empty());
-        assert_eq!(counters.sum(0), 4);
-        assert_eq!(counters.sum(1), 6);
+        assert_eq!(counters.sum(0), 5);
+        assert_eq!(counters.sum(1), 8);
         assert_eq!(counters.sum(2), 9);
-        assert_eq!(counters.sum_all(), 19);
+        assert_eq!(counters.sum_all(), 22);
+    }
+
+    #[cfg(feature = "bench-tools")]
+    #[test]
+    fn counter_set_buffer_flushes_grouped_and_individual_updates() {
+        let counters = CounterSet::new(4, 3);
+
+        {
+            let mut buffer = CounterSetBuffer::new(&counters, 2);
+
+            buffer.inc(0);
+            buffer.add(1, 2);
+            buffer.finish_op();
+            assert_eq!(counters.sum_all(), 0);
+
+            buffer.inc_all();
+            assert_eq!(counters.sum(0), 2);
+            assert_eq!(counters.sum(1), 3);
+            assert_eq!(counters.sum(2), 1);
+
+            buffer.add(2, 4);
+            buffer.finish_op();
+            buffer.flush();
+        }
+
+        assert_eq!(counters.sum(0), 2);
+        assert_eq!(counters.sum(1), 3);
+        assert_eq!(counters.sum(2), 5);
+        assert_eq!(counters.sum_all(), 10);
     }
 }

--- a/crates/fast-telemetry/src/metric/counter.rs
+++ b/crates/fast-telemetry/src/metric/counter.rs
@@ -14,6 +14,11 @@ fn make_padded_counter() -> CachePadded<AtomicIsize> {
     CachePadded::new(AtomicIsize::new(0))
 }
 
+#[cfg(feature = "bench-tools")]
+fn make_counter_cell() -> AtomicIsize {
+    AtomicIsize::new(0)
+}
+
 /// A sharded atomic counter.
 ///
 /// Shards cache-line aligned AtomicIsize values across a vector for faster
@@ -55,10 +60,9 @@ impl Counter {
         self.add(1)
     }
 
-    /// Adds a value to the counter with the specified ordering.
     #[inline]
-    pub fn add_with_ordering(&self, value: isize, ordering: Ordering) {
-        let idx = thread_id() & (self.cells.len() - 1);
+    fn add_with_thread_id(&self, thread_id: usize, value: isize, ordering: Ordering) {
+        let idx = thread_id & (self.cells.len() - 1);
         // SAFETY: idx is always < cells.len() due to power-of-two masking
         let cell = if cfg!(debug_assertions) {
             self.cells.get(idx).expect("index out of bounds")
@@ -66,6 +70,39 @@ impl Counter {
             unsafe { self.cells.get_unchecked(idx) }
         };
         cell.fetch_add(value, ordering);
+    }
+
+    /// Adds a value to the counter with the specified ordering.
+    #[inline]
+    pub fn add_with_ordering(&self, value: isize, ordering: Ordering) {
+        self.add_with_thread_id(thread_id(), value, ordering);
+    }
+
+    /// Benchmark-only prototype for batching increments across multiple counters.
+    #[cfg(feature = "bench-tools")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn inc_many(counters: &[Counter]) {
+        Self::add_many(counters, 1);
+    }
+
+    /// Benchmark-only prototype for batching additions across multiple counters.
+    #[cfg(feature = "bench-tools")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn add_many(counters: &[Counter], value: isize) {
+        Self::add_many_with_ordering(counters, value, Ordering::Relaxed);
+    }
+
+    /// Benchmark-only prototype for batching additions across multiple counters.
+    #[cfg(feature = "bench-tools")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn add_many_with_ordering(counters: &[Counter], value: isize, ordering: Ordering) {
+        let thread_id = thread_id();
+        for counter in counters {
+            counter.add_with_thread_id(thread_id, value, ordering);
+        }
     }
 
     /// Returns the sum of all shards using relaxed ordering.
@@ -104,6 +141,181 @@ impl Counter {
             .iter()
             .map(|c| c.swap(0, Ordering::Relaxed))
             .sum()
+    }
+}
+
+/// Benchmark-only prototype for grouping related counters in one sharded layout.
+#[cfg(feature = "bench-tools")]
+#[doc(hidden)]
+pub struct CounterSet {
+    cells: Vec<AtomicIsize>,
+    counters: usize,
+    stride: usize,
+    shard_mask: usize,
+}
+
+#[cfg(feature = "bench-tools")]
+impl CounterSet {
+    /// Creates a grouped counter set with `counters` counters per shard.
+    ///
+    /// Shards are padded by row instead of by cell, so related counters updated
+    /// by the same thread sit contiguously while adjacent shard rows remain
+    /// separated enough to avoid false sharing.
+    pub fn new(shards: usize, counters: usize) -> Self {
+        assert!(counters >= 1, "counters must be >= 1");
+        let shards = shards.next_power_of_two();
+        let cells_per_padded_counter =
+            std::mem::size_of::<CachePadded<AtomicIsize>>() / std::mem::size_of::<AtomicIsize>();
+        let row_padding = cells_per_padded_counter.max(1);
+        let stride = counters.div_ceil(row_padding) * row_padding;
+        let cells = (0..(shards * stride))
+            .map(|_| make_counter_cell())
+            .collect();
+
+        Self {
+            cells,
+            counters,
+            stride,
+            shard_mask: shards - 1,
+        }
+    }
+
+    /// Returns the number of counters in each shard row.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.counters
+    }
+
+    /// Returns true if there are no counters in the set.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.counters == 0
+    }
+
+    #[inline]
+    fn current_shard_offset(&self) -> usize {
+        (thread_id() & self.shard_mask) * self.stride
+    }
+
+    #[inline]
+    fn cell_at(&self, index: usize) -> &AtomicIsize {
+        if cfg!(debug_assertions) {
+            self.cells.get(index).expect("index out of bounds")
+        } else {
+            // SAFETY: callers compute indexes from checked counter indexes and
+            // row offsets derived from the shard mask.
+            unsafe { self.cells.get_unchecked(index) }
+        }
+    }
+
+    /// Increments all counters in the current thread's shard row.
+    #[inline]
+    pub fn inc_all(&self) {
+        self.add_all(1);
+    }
+
+    /// Adds the same value to all counters in the current thread's shard row.
+    #[inline]
+    pub fn add_all(&self, value: isize) {
+        let offset = self.current_shard_offset();
+        let row = if cfg!(debug_assertions) {
+            self.cells
+                .get(offset..offset + self.counters)
+                .expect("row index out of bounds")
+        } else {
+            // SAFETY: current_shard_offset derives from shard_mask and stride,
+            // and counters <= stride by construction.
+            unsafe { std::slice::from_raw_parts(self.cells.as_ptr().add(offset), self.counters) }
+        };
+        for cell in row {
+            cell.fetch_add(value, Ordering::Relaxed);
+        }
+    }
+
+    /// Adds the same value to selected counters in the current thread's shard row.
+    #[inline]
+    pub fn add_indices(&self, indexes: &[usize], value: isize) {
+        let offset = self.current_shard_offset();
+        if cfg!(debug_assertions) {
+            for index in indexes {
+                assert!(*index < self.counters, "counter index out of bounds");
+            }
+        }
+        for index in indexes {
+            self.cell_at(offset + *index)
+                .fetch_add(value, Ordering::Relaxed);
+        }
+    }
+
+    /// Adds one value per selected counter in the current thread's shard row.
+    #[inline]
+    pub fn add_index_values(&self, updates: &[(usize, isize)]) {
+        let offset = self.current_shard_offset();
+        if cfg!(debug_assertions) {
+            for (index, _) in updates {
+                assert!(*index < self.counters, "counter index out of bounds");
+            }
+        }
+        for (index, value) in updates {
+            self.cell_at(offset + *index)
+                .fetch_add(*value, Ordering::Relaxed);
+        }
+    }
+
+    /// Adds the same value to all counters in the current thread's shard row.
+    #[inline]
+    pub fn add_all_indexed(&self, value: isize) {
+        let offset = self.current_shard_offset();
+        for counter_idx in 0..self.counters {
+            self.cell_at(offset + counter_idx)
+                .fetch_add(value, Ordering::Relaxed);
+        }
+    }
+
+    /// Adds one value per counter in the current thread's shard row.
+    #[inline]
+    pub fn add_values(&self, values: &[isize]) {
+        assert_eq!(values.len(), self.counters, "values must match counters");
+        let offset = self.current_shard_offset();
+        let row = if cfg!(debug_assertions) {
+            self.cells
+                .get(offset..offset + self.counters)
+                .expect("row index out of bounds")
+        } else {
+            // SAFETY: current_shard_offset derives from shard_mask and stride,
+            // and counters <= stride by construction.
+            unsafe { std::slice::from_raw_parts(self.cells.as_ptr().add(offset), self.counters) }
+        };
+        for (cell, value) in row.iter().zip(values.iter().copied()) {
+            cell.fetch_add(value, Ordering::Relaxed);
+        }
+    }
+
+    /// Returns the sum for one counter across all shards.
+    #[inline]
+    pub fn sum(&self, counter_idx: usize) -> isize {
+        assert!(counter_idx < self.counters, "counter index out of bounds");
+        let shards = self.cells.len() / self.stride;
+        (0..shards)
+            .map(|shard| {
+                self.cell_at((shard * self.stride) + counter_idx)
+                    .load(Ordering::Relaxed)
+            })
+            .sum()
+    }
+
+    /// Returns the sum of all counters across all shards.
+    #[inline]
+    pub fn sum_all(&self) -> isize {
+        let shards = self.cells.len() / self.stride;
+        let mut total = 0isize;
+        for shard in 0..shards {
+            let offset = shard * self.stride;
+            for counter_idx in 0..self.counters {
+                total += self.cell_at(offset + counter_idx).load(Ordering::Relaxed);
+            }
+        }
+        total
     }
 }
 
@@ -186,5 +398,36 @@ mod tests {
         let debug = format!("{counter:?}");
         assert!(debug.contains("sum: 42"));
         assert!(debug.contains("cells: 8"));
+    }
+
+    #[cfg(feature = "bench-tools")]
+    #[test]
+    fn inc_many_updates_all_counters() {
+        let counters = vec![Counter::new(4), Counter::new(4), Counter::new(4)];
+
+        Counter::inc_many(&counters);
+        Counter::add_many(&counters, 2);
+
+        for counter in &counters {
+            assert_eq!(counter.sum(), 3);
+        }
+    }
+
+    #[cfg(feature = "bench-tools")]
+    #[test]
+    fn counter_set_updates_grouped_counters() {
+        let counters = CounterSet::new(4, 3);
+
+        counters.inc_all();
+        counters.add_values(&[2, 3, 4]);
+        counters.add_indices(&[0, 2], 1);
+        counters.add_index_values(&[(1, 2), (2, 3)]);
+
+        assert_eq!(counters.len(), 3);
+        assert!(!counters.is_empty());
+        assert_eq!(counters.sum(0), 4);
+        assert_eq!(counters.sum(1), 6);
+        assert_eq!(counters.sum(2), 9);
+        assert_eq!(counters.sum_all(), 19);
     }
 }

--- a/crates/fast-telemetry/src/metric/mod.rs
+++ b/crates/fast-telemetry/src/metric/mod.rs
@@ -17,7 +17,7 @@ mod visitor;
 
 pub use counter::Counter;
 #[cfg(feature = "bench-tools")]
-pub use counter::CounterSet;
+pub use counter::{CounterSet, CounterSetBuffer};
 pub use distribution::Distribution;
 pub use dynamic::{
     DynamicCounter, DynamicCounterSeries, DynamicDistribution, DynamicDistributionSeries,

--- a/crates/fast-telemetry/src/metric/mod.rs
+++ b/crates/fast-telemetry/src/metric/mod.rs
@@ -16,6 +16,8 @@ mod sampled_timer;
 mod visitor;
 
 pub use counter::Counter;
+#[cfg(feature = "bench-tools")]
+pub use counter::CounterSet;
 pub use distribution::Distribution;
 pub use dynamic::{
     DynamicCounter, DynamicCounterSeries, DynamicDistribution, DynamicDistributionSeries,


### PR DESCRIPTION
Adds grouped counter buffer benchmarks and 0.7.0 release notes with averaged mac harness results across three full matrix runs.

CPU time per counter write:

| Counters | Fast counters | Grouped counters | OTel Rust |
| ---: | ---: | ---: | ---: |
| 3 | 0.92 CPU ns/write | 0.38 CPU ns/write | 244.61 CPU ns/write |
| 4 | 0.78 CPU ns/write | 0.28 CPU ns/write | 256.75 CPU ns/write |
| 5 | 0.75 CPU ns/write | 0.24 CPU ns/write | 190.47 CPU ns/write |
| 6 | 0.73 CPU ns/write | 0.19 CPU ns/write | 254.91 CPU ns/write |

CPU-cycle equivalent, estimated from the mac CPU-time result at 4.61 cycles/ns:

| Counters | Fast counters | Grouped counters | OTel Rust |
| ---: | ---: | ---: | ---: |
| 3 | 4.24 cycles/write | 1.75 cycles/write | 1127.65 cycles/write |
| 4 | 3.60 cycles/write | 1.29 cycles/write | 1183.62 cycles/write |
| 5 | 3.46 cycles/write | 1.11 cycles/write | 878.07 cycles/write |
| 6 | 3.37 cycles/write | 0.88 cycles/write | 1175.14 cycles/write |

Counter-write throughput:

| Counters | Fast counters | Grouped counters | OTel Rust |
| ---: | ---: | ---: | ---: |
| 3 | 16.34B counters/s | 27.19B counters/s | 63.57M counters/s |
| 4 | 18.19B counters/s | 35.84B counters/s | 63.42M counters/s |
| 5 | 18.87B counters/s | 39.06B counters/s | 79.87M counters/s |
| 6 | 18.72B counters/s | 45.77B counters/s | 60.87M counters/s |

Grouped counters were 58.84% to 73.39% lower than independent fast counters and 643.72x to 1318.50x lower than OpenTelemetry Rust in trimmed CPU ns/write. In wall-clock throughput, grouped counters measured 1.66x to 2.44x more counters/s than independent fast counters and 427.68x to 751.93x more counters/s than OpenTelemetry Rust. Measured hardware cycles are available on Linux by running the counter-batch harness with `--perf-stat`, which records `*_cycles_per_write` in `counter-batch-summary.csv`.

Validation:
- cargo fmt --all
- bash -n crates/fast-telemetry/bench/run-cache-bench.sh
- bash -n crates/fast-telemetry/bench/run-counter-batch-bench.sh
- python3 -m py_compile crates/fast-telemetry/bench/summarize_perf.py
- cargo check -p fast-telemetry --features bench-tools
- cargo test -p fast-telemetry --features bench-tools metric::counter::tests
- cargo clippy -p fast-telemetry --features bench-tools -- -D warnings
- ./crates/fast-telemetry/bench/run-counter-batch-bench.sh --threads 16 --runs 7 --target-writes 512000000 --batch-sizes 3,4,5,6 --flush-every 64 (3 full matrix runs)