### PR TITLE
Remove counter batch helper path

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+- Removed the hidden `Counter::inc_many(...)` / `Counter::add_many(...)` helpers and the `counter_batch` benchmark entity so production grouping is standardized on `CounterSet` and `CounterSetBuffer`.
+
 ## 0.7.1 - 2026-06-30
 
 Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -78,9 +78,6 @@ The cache harness includes a focused probe for counter batching:
 # OpenTelemetry Rust shape: one logical op updates N pre-built OTel u64_counter handles.
 ./bench/run-cache-bench.sh --entity counter_multi --modes otel --batch-size 8 --threads 16 --runs 5
 
-# Prototype shape: one logical op updates N counters through the bench-only batch helper.
-./bench/run-cache-bench.sh --entity counter_batch --modes fast --batch-size 8 --threads 16 --runs 5
-
 # Grouped shape: related counters share one row-padded sharded layout.
 ./bench/run-cache-bench.sh --entity counter_set --modes fast --batch-size 8 --threads 16 --runs 5
 
@@ -104,18 +101,19 @@ Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
 these runs. `counter_multi` supports both `fast` and `otel` modes, so the
 summary can compare independent fast-telemetry counters against independent
 OpenTelemetry Rust counters for the same number of writes per logical operation.
-`counter_batch`, `counter_set`, and `counter_buffered` are intentionally
-`fast`-only because they compare candidate fast-telemetry batching API shapes.
+`counter_set`, `counter_buffered`, `counter_buffered_indexed`, and
+`counter_buffered_lookup` are intentionally `fast`-only because they exercise
+fast-telemetry's grouped counter APIs.
 On Linux, add `--perf-stat` to collect hardware counters and populate
 `*_cycles_per_write` fields in `counter-batch-summary.csv`. macOS runs do not
 expose those hardware cycle counters through this harness, so mac comparisons
 should report CPU ns/write and counters/s unless using an explicitly labeled
 clock-rate estimate.
 
-The buffered prototype uses a bench-only grouped counter buffer. Uniform group
-increments accumulate a shared local delta before flushing; individual counters
-can still be updated with indexed buffer operations, then committed with a
-logical operation boundary and a final flush.
+The buffered grouped counter case uses the production `CounterSetBuffer` API.
+Uniform group increments accumulate a shared local delta before flushing;
+individual counters can still be updated with indexed buffer operations, then
+committed with a logical operation boundary and a final flush.
 
 The lookup control intentionally pays a `BTreeMap` name-to-index lookup on every
 counter update. It is a negative/control benchmark for dynamic APIs; production
@@ -145,7 +143,7 @@ does not expose a matching distribution primitive.
 ## Entry Points
 
 - `run-cache-bench.sh` -- cache-line contention workloads across metric entities and label access profiles
-- `run-counter-batch-bench.sh` -- mac/Linux sweep comparing one-by-one counter writes against the batch prototype
+- `run-counter-batch-bench.sh` -- mac/Linux sweep comparing independent counters against grouped counter APIs
 - `run-span-bench.sh` -- span creation/export contention workloads across realism scenarios
 - `run-bench-matrix.sh` -- multi-case sweep runner for publishing-ready comparison sets
 - `run-bench-suite.sh` -- full suite with HTML report generation
@@ -181,7 +179,7 @@ does not expose a matching distribution primitive.
 | `--modes <list>`           | Select modes (default: `fast,otel`; options: `fast,otel,atomic,metrics`) |
 | `--entity <name>`          | Metric entity to benchmark                                       |
 | `--labels <N>`             | Label cardinality (default: 16, max: 256)                        |
-| `--batch-size <N>`         | Counters per op for `counter_multi`/`counter_batch`/`counter_set`/`counter_buffered` variants (default: 8) |
+| `--batch-size <N>`         | Counters per op for `counter_multi`/`counter_set`/`counter_buffered` variants (default: 8) |
 | `--flush-every <N>`        | Local operations per atomic flush for `counter_buffered` variants (default: 64) |
 | `--profile <name>`         | Label access pattern: `uniform`, `hotspot`, `churn`              |
 | `--pin`                    | CPU pinning via `taskset` + round-robin thread affinity          |
@@ -191,7 +189,7 @@ does not expose a matching distribution primitive.
 
 ## Entities
 
-`counter`, `counter_multi`, `counter_batch`, `counter_set`, `counter_buffered`,
+`counter`, `counter_multi`, `counter_set`, `counter_buffered`,
 `counter_buffered_indexed`, `counter_buffered_lookup`, `distribution`,
 `dynamic_counter`, `dynamic_distribution`, `dynamic_gauge`, `dynamic_gauge_i64`,
 `dynamic_histogram`, `labeled_counter`, `labeled_gauge`, `labeled_histogram`

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -73,11 +73,11 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
-      echo "--entity one of: counter,counter_multi,counter_batch,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "--entity one of: counter,counter_multi,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  otel mode supports: counter,counter_multi,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
-      echo "--batch-size counters per op for counter_multi/counter_batch/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup (default: 8)"
+      echo "--batch-size counters per op for counter_multi/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup (default: 8)"
       echo "--flush-every local operations per atomic flush for counter_buffered variants (default: 64)"
       echo "--labels registered metric names for counter_buffered_lookup (default: 16)"
       echo "--profile access pattern: uniform,hotspot,churn (default: uniform)"
@@ -97,7 +97,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ENTITY" in
-  counter|counter_multi|counter_batch|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
+  counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
   *)
     echo "ERROR: unsupported --entity '$ENTITY'"
     exit 1
@@ -160,7 +160,7 @@ if [[ "$ENTITY" == "counter_multi" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_batch" || "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" ]]; then
+if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast"

--- a/crates/fast-telemetry/bench/run-counter-batch-bench.sh
+++ b/crates/fast-telemetry/bench/run-counter-batch-bench.sh
@@ -28,7 +28,7 @@ while [[ $# -gt 0 ]]; do
     --help)
       echo "Usage: $0 [--threads N] [--runs N] [--target-writes N] [--batch-sizes list] [--flush-every N] [--export-interval-ms N] [--pin] [--cpu-list list] [--perf-stat]"
       echo ""
-      echo "Compares fast counter_multi against counter_batch, counter_set, counter_buffered, and OpenTelemetry counter_multi across batch sizes."
+      echo "Compares fast counter_multi against counter_set, counter_buffered, and OpenTelemetry counter_multi across batch sizes."
       echo "Defaults: threads=logical CPUs, runs=7, target-writes=512000000, batch-sizes=1,2,4,8,16,32,64,128, flush-every=64"
       echo "--target-writes is total counter writes per run, not outer benchmark ops."
       echo "--flush-every is local operations per atomic flush for counter_buffered."
@@ -51,11 +51,11 @@ fi
 
 mkdir -p "$RESULTS_DIR"
 TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
-RUN_DIR="$RESULTS_DIR/counter_batch_${TIMESTAMP}_$$"
+RUN_DIR="$RESULTS_DIR/counter_group_${TIMESTAMP}_$$"
 mkdir -p "$RUN_DIR"
 SUMMARY_CSV="$RUN_DIR/counter-batch-summary.csv"
 
-echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,batch_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,otel_cpu_ns_per_write,multi_total_ns_per_op,batch_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,otel_total_ns_per_op,batch_delta_pct,set_delta_pct,buffered_delta_pct,buffered_vs_otel_speedup,buffered_vs_otel_delta_pct,multi_counter_writes_per_sec,batch_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,otel_counter_writes_per_sec,multi_cv_pct,batch_cv_pct,set_cv_pct,buffered_cv_pct,otel_cv_pct,multi_cpu_total_seconds,batch_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,otel_cpu_total_seconds,multi_avg_cores,batch_avg_cores,set_avg_cores,buffered_avg_cores,otel_avg_cores,multi_cycles_per_write,batch_cycles_per_write,set_cycles_per_write,buffered_cycles_per_write,otel_cycles_per_write,multi_dir,batch_dir,set_dir,buffered_dir,otel_dir" > "$SUMMARY_CSV"
+echo "batch_size,iters_per_thread,target_counter_writes,flush_every,multi_cpu_ns_per_write,set_cpu_ns_per_write,buffered_cpu_ns_per_write,otel_cpu_ns_per_write,multi_total_ns_per_op,set_total_ns_per_op,buffered_total_ns_per_op,otel_total_ns_per_op,set_delta_pct,buffered_delta_pct,buffered_vs_otel_speedup,buffered_vs_otel_delta_pct,multi_counter_writes_per_sec,set_counter_writes_per_sec,buffered_counter_writes_per_sec,otel_counter_writes_per_sec,multi_cv_pct,set_cv_pct,buffered_cv_pct,otel_cv_pct,multi_cpu_total_seconds,set_cpu_total_seconds,buffered_cpu_total_seconds,otel_cpu_total_seconds,multi_avg_cores,set_avg_cores,buffered_avg_cores,otel_avg_cores,multi_cycles_per_write,set_cycles_per_write,buffered_cycles_per_write,otel_cycles_per_write,multi_dir,set_dir,buffered_dir,otel_dir" > "$SUMMARY_CSV"
 
 read_summary_field() {
   local dir="$1"
@@ -145,55 +145,46 @@ for batch_size in "${BATCH_SIZES[@]}"; do
     iters=1
   fi
 
-  printf "\n[counter-batch] batch_size=%s iters_per_thread=%s\n" "$batch_size" "$iters"
+  printf "\n[counter-group] batch_size=%s iters_per_thread=%s\n" "$batch_size" "$iters"
   multi_dir="$(run_case fast counter_multi "$batch_size" "$iters")"
-  batch_dir="$(run_case fast counter_batch "$batch_size" "$iters")"
   set_dir="$(run_case fast counter_set "$batch_size" "$iters")"
   buffered_dir="$(run_case fast counter_buffered "$batch_size" "$iters")"
   otel_dir="$(run_case otel counter_multi "$batch_size" "$iters")"
 
   multi_ns="$(read_summary_field "$multi_dir" 20)"
-  batch_ns="$(read_summary_field "$batch_dir" 20)"
   set_ns="$(read_summary_field "$set_dir" 20)"
   buffered_ns="$(read_summary_field "$buffered_dir" 20)"
   otel_ns="$(read_summary_field "$otel_dir" 20)"
   multi_total_ns_per_op="$(read_summary_field "$multi_dir" 25)"
-  batch_total_ns_per_op="$(read_summary_field "$batch_dir" 25)"
   set_total_ns_per_op="$(read_summary_field "$set_dir" 25)"
   buffered_total_ns_per_op="$(read_summary_field "$buffered_dir" 25)"
   otel_total_ns_per_op="$(read_summary_field "$otel_dir" 25)"
   multi_writes="$(read_summary_field "$multi_dir" 5)"
-  batch_writes="$(read_summary_field "$batch_dir" 5)"
   set_writes="$(read_summary_field "$set_dir" 5)"
   buffered_writes="$(read_summary_field "$buffered_dir" 5)"
   otel_writes="$(read_summary_field "$otel_dir" 5)"
   multi_cv="$(read_summary_field "$multi_dir" 23)"
-  batch_cv="$(read_summary_field "$batch_dir" 23)"
   set_cv="$(read_summary_field "$set_dir" 23)"
   buffered_cv="$(read_summary_field "$buffered_dir" 23)"
   otel_cv="$(read_summary_field "$otel_dir" 23)"
   multi_cpu="$(read_summary_field "$multi_dir" 13)"
-  batch_cpu="$(read_summary_field "$batch_dir" 13)"
   set_cpu="$(read_summary_field "$set_dir" 13)"
   buffered_cpu="$(read_summary_field "$buffered_dir" 13)"
   otel_cpu="$(read_summary_field "$otel_dir" 13)"
   multi_cores="$(read_summary_field "$multi_dir" 14)"
-  batch_cores="$(read_summary_field "$batch_dir" 14)"
   set_cores="$(read_summary_field "$set_dir" 14)"
   buffered_cores="$(read_summary_field "$buffered_dir" 14)"
   otel_cores="$(read_summary_field "$otel_dir" 14)"
   multi_cycles="$(read_perf_summary_field "$multi_dir" "cycles_per_counter_write")"
-  batch_cycles="$(read_perf_summary_field "$batch_dir" "cycles_per_counter_write")"
   set_cycles="$(read_perf_summary_field "$set_dir" "cycles_per_counter_write")"
   buffered_cycles="$(read_perf_summary_field "$buffered_dir" "cycles_per_counter_write")"
   otel_cycles="$(read_perf_summary_field "$otel_dir" "cycles_per_counter_write")"
-  batch_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$batch_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   set_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$set_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   buffered_delta_pct="$(awk -v multi="$multi_ns" -v candidate="$buffered_ns" 'BEGIN { if (multi == 0) print "0.00"; else printf "%.2f", ((multi - candidate) / multi) * 100.0 }')"
   buffered_vs_otel_speedup="$(awk -v otel="$otel_ns" -v buffered="$buffered_ns" 'BEGIN { if (buffered == 0) print "0.00"; else printf "%.2f", otel / buffered }')"
   buffered_vs_otel_delta_pct="$(awk -v otel="$otel_ns" -v buffered="$buffered_ns" 'BEGIN { if (otel == 0) print "0.00"; else printf "%.2f", ((otel - buffered) / otel) * 100.0 }')"
 
-  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$batch_ns,$set_ns,$buffered_ns,$otel_ns,$multi_total_ns_per_op,$batch_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$otel_total_ns_per_op,$batch_delta_pct,$set_delta_pct,$buffered_delta_pct,$buffered_vs_otel_speedup,$buffered_vs_otel_delta_pct,$multi_writes,$batch_writes,$set_writes,$buffered_writes,$otel_writes,$multi_cv,$batch_cv,$set_cv,$buffered_cv,$otel_cv,$multi_cpu,$batch_cpu,$set_cpu,$buffered_cpu,$otel_cpu,$multi_cores,$batch_cores,$set_cores,$buffered_cores,$otel_cores,$multi_cycles,$batch_cycles,$set_cycles,$buffered_cycles,$otel_cycles,$multi_dir,$batch_dir,$set_dir,$buffered_dir,$otel_dir" >> "$SUMMARY_CSV"
+  echo "$batch_size,$iters,$TARGET_WRITES,$FLUSH_EVERY,$multi_ns,$set_ns,$buffered_ns,$otel_ns,$multi_total_ns_per_op,$set_total_ns_per_op,$buffered_total_ns_per_op,$otel_total_ns_per_op,$set_delta_pct,$buffered_delta_pct,$buffered_vs_otel_speedup,$buffered_vs_otel_delta_pct,$multi_writes,$set_writes,$buffered_writes,$otel_writes,$multi_cv,$set_cv,$buffered_cv,$otel_cv,$multi_cpu,$set_cpu,$buffered_cpu,$otel_cpu,$multi_cores,$set_cores,$buffered_cores,$otel_cores,$multi_cycles,$set_cycles,$buffered_cycles,$otel_cycles,$multi_dir,$set_dir,$buffered_dir,$otel_dir" >> "$SUMMARY_CSV"
 done
 
 printf "\nSummary (positive delta means the fast candidate was faster than fast counter_multi):\n"
@@ -202,8 +193,8 @@ awk -F, '
     next
   }
   {
-    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f otel=%6.2f total_ns/op multi=%6.2f batch=%6.2f set=%6.2f buffered=%6.2f otel=%6.2f delta batch=%7.2f%% set=%7.2f%% buffered=%7.2f%% buffered/otel=%6.2fx (%7.2f%% lower) cv=%s/%s/%s/%s/%s\n",
-      $1, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $25, $26, $27, $28, $29
+    printf "  batch_size=%-4s cpu_ns/write multi=%6.2f set=%6.2f buffered=%6.2f otel=%6.2f total_ns/op multi=%6.2f set=%6.2f buffered=%6.2f otel=%6.2f delta set=%7.2f%% buffered=%7.2f%% buffered/otel=%6.2fx (%7.2f%% lower) cv=%s/%s/%s/%s\n",
+      $1, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $21, $22, $23, $24
   }
 ' "$SUMMARY_CSV"
 

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -4,7 +4,6 @@
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter --threads 16 --iters 10000000 --shards 16
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_multi --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity counter_multi --threads 16 --iters 10000000 --shards 16 --batch-size 8
-// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_batch --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_set --threads 16 --iters 10000000 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_buffered --threads 16 --iters 10000000 --shards 16 --batch-size 8 --flush-every 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity labeled_counter --threads 16 --iters 10000000 --labels 64
@@ -55,7 +54,6 @@ enum Mode {
 enum Entity {
     Counter,
     CounterMulti,
-    CounterBatch,
     CounterSet,
     CounterBuffered,
     CounterBufferedIndexed,
@@ -153,7 +151,6 @@ fn parse_args() -> Config {
                 entity = match args[i + 1].as_str() {
                     "counter" => Entity::Counter,
                     "counter_multi" => Entity::CounterMulti,
-                    "counter_batch" => Entity::CounterBatch,
                     "counter_set" => Entity::CounterSet,
                     "counter_buffered" => Entity::CounterBuffered,
                     "counter_buffered_indexed" => Entity::CounterBufferedIndexed,
@@ -168,7 +165,7 @@ fn parse_args() -> Config {
                     "labeled_gauge" => Entity::LabeledGauge,
                     "labeled_histogram" => Entity::LabeledHistogram,
                     value => panic!(
-                        "invalid --entity: {value} (expected counter|counter_multi|counter_batch|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
+                        "invalid --entity: {value} (expected counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
                     ),
                 };
                 i += 2;
@@ -229,11 +226,11 @@ fn parse_args() -> Config {
             }
             "--help" => {
                 println!(
-                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_batch|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
+                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
                 );
                 println!("  --profile <uniform|hotspot|churn> controls label access pattern");
                 println!(
-                    "  --batch-size <n> controls counters per op for counter_multi, counter_batch, counter_set, counter_buffered, counter_buffered_indexed, and counter_buffered_lookup"
+                    "  --batch-size <n> controls counters per op for counter_multi, counter_set, counter_buffered, counter_buffered_indexed, and counter_buffered_lookup"
                 );
                 println!("  --flush-every <n> controls local-delta flush cadence for counter_buffered");
                 println!("  --labels <n> controls registered metric names for counter_buffered_lookup");
@@ -446,7 +443,7 @@ fn metrics_gauge_value(cell: &MetricsGaugeCell) -> f64 {
     f64::from_bits(cell.load(Ordering::Relaxed))
 }
 
-fn counter_batch_final_count(counters: &[Counter]) -> isize {
+fn counter_multi_final_count(counters: &[Counter]) -> isize {
     counters.iter().map(Counter::sum).sum()
 }
 
@@ -515,39 +512,11 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
                             }
                         }
                     },
-                    move || counter_batch_final_count(&exporter_counters),
+                    move || counter_multi_final_count(&exporter_counters),
                 );
 
             RunResult {
-                final_count: counter_batch_final_count(&counters),
-                record_seconds,
-                total_seconds,
-                export_count,
-                export_seconds,
-                cpu_usage,
-            }
-        }
-        Entity::CounterBatch => {
-            let counters: Arc<Vec<Counter>> =
-                Arc::new((0..batch_size).map(|_| Counter::new(shards)).collect());
-            let worker_counters = Arc::clone(&counters);
-            let exporter_counters = Arc::clone(&counters);
-            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
-                run_with_threads(
-                    threads,
-                    iters,
-                    thread_affinity,
-                    export_interval_ms,
-                    move |_, n| {
-                        for _ in 0..n {
-                            Counter::inc_many(worker_counters.as_slice());
-                        }
-                    },
-                    move || counter_batch_final_count(&exporter_counters),
-                );
-
-            RunResult {
-                final_count: counter_batch_final_count(&counters),
+                final_count: counter_multi_final_count(&counters),
                 record_seconds,
                 total_seconds,
                 export_count,
@@ -1200,7 +1169,6 @@ fn run_metrics(entity: Entity, cfg: &Config) -> RunResult {
             }
         }
         Entity::CounterMulti
-        | Entity::CounterBatch
         | Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
@@ -1670,8 +1638,7 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
-        Entity::CounterBatch
-        | Entity::CounterSet
+        Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
         | Entity::CounterBufferedLookup => {
@@ -2106,7 +2073,6 @@ fn main() {
     let total_ops = cfg.threads * cfg.iters;
     let counter_writes_per_op = match cfg.entity {
         Entity::CounterMulti
-        | Entity::CounterBatch
         | Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
@@ -2149,7 +2115,6 @@ fn main() {
     let entity = match cfg.entity {
         Entity::Counter => "counter",
         Entity::CounterMulti => "counter_multi",
-        Entity::CounterBatch => "counter_batch",
         Entity::CounterSet => "counter_set",
         Entity::CounterBuffered => "counter_buffered",
         Entity::CounterBufferedIndexed => "counter_buffered_indexed",
@@ -2177,7 +2142,6 @@ fn main() {
         cfg.entity,
         Entity::Counter
             | Entity::CounterMulti
-            | Entity::CounterBatch
             | Entity::CounterSet
             | Entity::CounterBuffered
             | Entity::CounterBufferedIndexed

--- a/crates/fast-telemetry/src/metric/counter.rs
+++ b/crates/fast-telemetry/src/metric/counter.rs
@@ -77,33 +77,6 @@ impl Counter {
         self.add_with_thread_id(thread_id(), value, ordering);
     }
 
-    /// Benchmark-only prototype for batching increments across multiple counters.
-    #[cfg(feature = "bench-tools")]
-    #[doc(hidden)]
-    #[inline]
-    pub fn inc_many(counters: &[Counter]) {
-        Self::add_many(counters, 1);
-    }
-
-    /// Benchmark-only prototype for batching additions across multiple counters.
-    #[cfg(feature = "bench-tools")]
-    #[doc(hidden)]
-    #[inline]
-    pub fn add_many(counters: &[Counter], value: isize) {
-        Self::add_many_with_ordering(counters, value, Ordering::Relaxed);
-    }
-
-    /// Benchmark-only prototype for batching additions across multiple counters.
-    #[cfg(feature = "bench-tools")]
-    #[doc(hidden)]
-    #[inline]
-    pub fn add_many_with_ordering(counters: &[Counter], value: isize, ordering: Ordering) {
-        let thread_id = thread_id();
-        for counter in counters {
-            counter.add_with_thread_id(thread_id, value, ordering);
-        }
-    }
-
     /// Returns the sum of all shards using relaxed ordering.
     ///
     /// # Eventual Consistency
@@ -640,19 +613,6 @@ mod tests {
         let debug = format!("{counter:?}");
         assert!(debug.contains("sum: 42"));
         assert!(debug.contains("cells: 8"));
-    }
-
-    #[cfg(feature = "bench-tools")]
-    #[test]
-    fn inc_many_updates_all_counters() {
-        let counters = vec![Counter::new(4), Counter::new(4), Counter::new(4)];
-
-        Counter::inc_many(&counters);
-        Counter::add_many(&counters, 2);
-
-        for counter in &counters {
-            assert_eq!(counter.sum(), 3);
-        }
     }
 
     #[test]


### PR DESCRIPTION
Removes the hidden counter batching helpers and counter_batch benchmark path so grouped counter work uses CounterSet and CounterSetBuffer.