### PR TITLE
Add dynamic grouped counters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.7.1" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.7.1" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.7.1" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.8.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.8.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.8.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Grouped buffered counters use the production `CounterSet` and
 group of related counters, and resolve counter indexes once during construction
 so the hot path stays on direct indexed updates.
 
+For runtime labels, `DynamicCounterSet` applies the same grouped-counter pattern
+to dynamic series: resolve the label-keyed series and counter indexes once, then
+record related counters in one grouped call.
+
 ## Quick Start
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Enable the shared runtime when a parent service should own telemetry and pass it
 to child crates:
 
 ```toml
-fast-telemetry = { version = "0.7", features = ["runtime"] }
+fast-telemetry = { version = "0.8", features = ["runtime"] }
 ```
 
 ## Why

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,62 @@
 
 ## Unreleased
 
+## 0.8.0 - 2026-07-09
+
+Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.
+
+Why this is a 0.8.0 bump:
+
+- this release adds the public `DynamicCounterSet` and `DynamicCounterSetSeries` API for runtime-labeled grouped counters.
+- all workspace crates are aligned at `0.8.0` so downstream services can keep `fast-telemetry`, `fast-telemetry-macros`, and `fast-telemetry-export` on the same release line.
+
+Highlights:
+
 - Removed the hidden `Counter::inc_many(...)` / `Counter::add_many(...)` helpers and the `counter_batch` benchmark entity so production grouping is standardized on `CounterSet` and `CounterSetBuffer`.
 - Added `DynamicCounterSet` / `DynamicCounterSetSeries` for runtime-labeled grouped counters, plus `CounterSet` snapshot/reset helpers for delta collectors.
+- Added `dynamic_counter_multi` and `dynamic_counter_set` harness entities so grouped dynamic counters can be benchmarked against explicit independent `DynamicCounter` updates.
+
+Focused mac harness comparison with verified final counts:
+
+```text
+./crates/fast-telemetry/bench/run-cache-bench.sh \
+  --entity dynamic_counter_multi \
+  --modes fast \
+  --threads 18 \
+  --labels 128 \
+  --profile hotspot \
+  --batch-size 3
+
+./crates/fast-telemetry/bench/run-cache-bench.sh \
+  --entity dynamic_counter_set \
+  --modes fast \
+  --threads 18 \
+  --labels 128 \
+  --profile hotspot \
+  --batch-size 3
+```
+
+CPU time per logical operation:
+
+| Counters | Independent dynamic counters | DynamicCounterSet | Improvement |
+| ---: | ---: | ---: | ---: |
+| 3 | 22.30 CPU ns/op | 2.75 CPU ns/op | 8.1x lower CPU |
+| 6 | 83.06 CPU ns/op | 4.36 CPU ns/op | 19.1x lower CPU |
+
+CPU time per counter write:
+
+| Counters | Independent dynamic counters | DynamicCounterSet |
+| ---: | ---: | ---: |
+| 3 | 7.43 CPU ns/write | 0.92 CPU ns/write |
+| 6 | 13.85 CPU ns/write | 0.73 CPU ns/write |
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.8.0"
+fast-telemetry-export = "0.8.0"
+```
 
 ## 0.7.1 - 2026-06-30
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@ Highlights:
 
 - Removed the hidden `Counter::inc_many(...)` / `Counter::add_many(...)` helpers and the `counter_batch` benchmark entity so production grouping is standardized on `CounterSet` and `CounterSetBuffer`.
 - Added `DynamicCounterSet` / `DynamicCounterSetSeries` for runtime-labeled grouped counters, plus `CounterSet` snapshot/reset helpers for delta collectors.
-- Added `dynamic_counter_multi` and `dynamic_counter_set` harness entities so grouped dynamic counters can be benchmarked against explicit independent `DynamicCounter` updates.
+- Added `dynamic_counter_multi` and `dynamic_counter_set` harness entities so grouped dynamic counters can be benchmarked against explicit independent `DynamicCounter` updates and matching OpenTelemetry Rust counter adds.
 
 Focused mac harness comparison with verified final counts:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Removed the hidden `Counter::inc_many(...)` / `Counter::add_many(...)` helpers and the `counter_batch` benchmark entity so production grouping is standardized on `CounterSet` and `CounterSetBuffer`.
+- Added `DynamicCounterSet` / `DynamicCounterSetSeries` for runtime-labeled grouped counters, plus `CounterSet` snapshot/reset helpers for delta collectors.
 
 ## 0.7.1 - 2026-06-30
 

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -46,7 +46,7 @@ columns with defaults. Summary metrics are ignored.
 Enable the `monoio` feature to run exporter loops on a monoio runtime:
 
 ```toml
-fast-telemetry-export = { version = "0.7", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.8", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 The monoio entry points mirror the Tokio ones:
@@ -69,7 +69,7 @@ Enable the `compio` feature to run the DogStatsD UDP exporter and sweeper on a
 compio runtime without pulling in Tokio:
 
 ```toml
-fast-telemetry-export = { version = "0.7", default-features = false, features = ["compio"] }
+fast-telemetry-export = { version = "0.8", default-features = false, features = ["compio"] }
 ```
 
 The compio entry points are:

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/README.md
+++ b/crates/fast-telemetry/README.md
@@ -18,6 +18,10 @@ Use `CounterSet` and `CounterSetBuffer` for production grouped counters when one
 hot-path operation updates a fixed set of related counters. Resolve indexes once
 and record by index on the hot path.
 
+Use `DynamicCounterSet` when that grouped-counter pattern needs runtime labels.
+Resolve the dynamic series and counter indexes once, then record related
+counters by index on the hot path.
+
 See the [workspace README](../../README.md) for full documentation, examples,
 runtime integration rules, and API reference.
 

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -81,6 +81,9 @@ The cache harness includes a focused probe for counter batching:
 # Grouped shape: related counters share one row-padded sharded layout.
 ./bench/run-cache-bench.sh --entity counter_set --modes fast --batch-size 8 --threads 16 --runs 5
 
+# Dynamic grouped shape: runtime label set plus one grouped counter update.
+./bench/run-cache-bench.sh --entity dynamic_counter_set --modes fast --labels 128 --batch-size 8 --threads 16 --runs 5
+
 # Buffered shape: update local deltas and flush shared atomics every N operations.
 ./bench/run-cache-bench.sh --entity counter_buffered --modes fast --batch-size 8 --flush-every 64 --threads 16 --runs 5
 
@@ -101,9 +104,9 @@ Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
 these runs. `counter_multi` supports both `fast` and `otel` modes, so the
 summary can compare independent fast-telemetry counters against independent
 OpenTelemetry Rust counters for the same number of writes per logical operation.
-`counter_set`, `counter_buffered`, `counter_buffered_indexed`, and
-`counter_buffered_lookup` are intentionally `fast`-only because they exercise
-fast-telemetry's grouped counter APIs.
+`counter_set`, `dynamic_counter_set`, `counter_buffered`,
+`counter_buffered_indexed`, and `counter_buffered_lookup` are intentionally
+`fast`-only because they exercise fast-telemetry's grouped counter APIs.
 On Linux, add `--perf-stat` to collect hardware counters and populate
 `*_cycles_per_write` fields in `counter-batch-summary.csv`. macOS runs do not
 expose those hardware cycle counters through this harness, so mac comparisons

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -87,6 +87,9 @@ The cache harness includes a focused probe for counter batching:
 # Dynamic before/control shape: runtime label set plus N independent dynamic counters.
 ./bench/run-cache-bench.sh --entity dynamic_counter_multi --modes fast --labels 128 --batch-size 8 --threads 16 --runs 5
 
+# OpenTelemetry Rust dynamic shape: same runtime label set plus N OTel counters.
+./bench/run-cache-bench.sh --entity dynamic_counter_multi --modes otel --labels 128 --batch-size 8 --threads 16 --runs 5
+
 # Buffered shape: update local deltas and flush shared atomics every N operations.
 ./bench/run-cache-bench.sh --entity counter_buffered --modes fast --batch-size 8 --flush-every 64 --threads 16 --runs 5
 
@@ -104,10 +107,10 @@ The cache harness includes a focused probe for counter batching:
 ```
 
 Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
-these runs. `counter_multi` supports both `fast` and `otel` modes, so the
-summary can compare independent fast-telemetry counters against independent
-OpenTelemetry Rust counters for the same number of writes per logical operation.
-`counter_set`, `dynamic_counter_multi`, `dynamic_counter_set`,
+these runs. `counter_multi` and `dynamic_counter_multi` support both `fast` and
+`otel` modes, so the summary can compare independent fast-telemetry counters
+against independent OpenTelemetry Rust counters for the same number of writes
+per logical operation. `counter_set`, `dynamic_counter_set`,
 `counter_buffered`, `counter_buffered_indexed`, and `counter_buffered_lookup`
 are intentionally `fast`-only because they exercise fast-telemetry's grouped
 counter APIs.

--- a/crates/fast-telemetry/bench/README.md
+++ b/crates/fast-telemetry/bench/README.md
@@ -84,6 +84,9 @@ The cache harness includes a focused probe for counter batching:
 # Dynamic grouped shape: runtime label set plus one grouped counter update.
 ./bench/run-cache-bench.sh --entity dynamic_counter_set --modes fast --labels 128 --batch-size 8 --threads 16 --runs 5
 
+# Dynamic before/control shape: runtime label set plus N independent dynamic counters.
+./bench/run-cache-bench.sh --entity dynamic_counter_multi --modes fast --labels 128 --batch-size 8 --threads 16 --runs 5
+
 # Buffered shape: update local deltas and flush shared atomics every N operations.
 ./bench/run-cache-bench.sh --entity counter_buffered --modes fast --batch-size 8 --flush-every 64 --threads 16 --runs 5
 
@@ -104,9 +107,10 @@ Use `cpu_ns_per_counter_write` and `total_counter_writes_per_sec` when comparing
 these runs. `counter_multi` supports both `fast` and `otel` modes, so the
 summary can compare independent fast-telemetry counters against independent
 OpenTelemetry Rust counters for the same number of writes per logical operation.
-`counter_set`, `dynamic_counter_set`, `counter_buffered`,
-`counter_buffered_indexed`, and `counter_buffered_lookup` are intentionally
-`fast`-only because they exercise fast-telemetry's grouped counter APIs.
+`counter_set`, `dynamic_counter_multi`, `dynamic_counter_set`,
+`counter_buffered`, `counter_buffered_indexed`, and `counter_buffered_lookup`
+are intentionally `fast`-only because they exercise fast-telemetry's grouped
+counter APIs.
 On Linux, add `--perf-stat` to collect hardware counters and populate
 `*_cycles_per_write` fields in `counter-batch-summary.csv`. macOS runs do not
 expose those hardware cycle counters through this harness, so mac comparisons

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -73,11 +73,11 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
-      echo "--entity one of: counter,counter_multi,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "--entity one of: counter,counter_multi,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_counter_set,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  otel mode supports: counter,counter_multi,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
-      echo "--batch-size counters per op for counter_multi/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup (default: 8)"
+      echo "--batch-size counters per op for counter_multi/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup/dynamic_counter_set (default: 8)"
       echo "--flush-every local operations per atomic flush for counter_buffered variants (default: 64)"
       echo "--labels registered metric names for counter_buffered_lookup (default: 16)"
       echo "--profile access pattern: uniform,hotspot,churn (default: uniform)"
@@ -97,7 +97,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ENTITY" in
-  counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
+  counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_set|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
   *)
     echo "ERROR: unsupported --entity '$ENTITY'"
     exit 1
@@ -160,7 +160,7 @@ if [[ "$ENTITY" == "counter_multi" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" ]]; then
+if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" || "$ENTITY" == "dynamic_counter_set" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast"

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -74,7 +74,7 @@ while [[ $# -gt 0 ]]; do
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
       echo "--entity one of: counter,counter_multi,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_counter_multi,dynamic_counter_set,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
-      echo "  otel mode supports: counter,counter_multi,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "  otel mode supports: counter,counter_multi,distribution,dynamic_counter,dynamic_counter_multi,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
       echo "--batch-size counters per op for counter_multi/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup/dynamic_counter_multi/dynamic_counter_set (default: 8)"
@@ -151,7 +151,7 @@ if [[ "$ENTITY" != "counter" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_multi" ]]; then
+if [[ "$ENTITY" == "counter_multi" || "$ENTITY" == "dynamic_counter_multi" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" && "$mode" != "otel" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast or otel"
@@ -160,7 +160,7 @@ if [[ "$ENTITY" == "counter_multi" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" || "$ENTITY" == "dynamic_counter_multi" || "$ENTITY" == "dynamic_counter_set" ]]; then
+if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" || "$ENTITY" == "dynamic_counter_set" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast"

--- a/crates/fast-telemetry/bench/run-cache-bench.sh
+++ b/crates/fast-telemetry/bench/run-cache-bench.sh
@@ -73,11 +73,11 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Defaults: threads=nproc, iters=10000000, shards=threads, runs=3"
       echo "--modes comma-separated modes: fast,otel,atomic,metrics (default: fast,otel)"
-      echo "--entity one of: counter,counter_multi,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_counter_set,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
+      echo "--entity one of: counter,counter_multi,counter_set,counter_buffered,counter_buffered_indexed,counter_buffered_lookup,distribution,dynamic_counter,dynamic_counter_multi,dynamic_counter_set,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  otel mode supports: counter,counter_multi,distribution,dynamic_counter,dynamic_distribution,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "  metrics mode supports: counter,dynamic_counter,dynamic_gauge,dynamic_gauge_i64,dynamic_histogram,labeled_counter,labeled_gauge,labeled_histogram"
       echo "--labels label cardinality for labeled entities (default: 16)"
-      echo "--batch-size counters per op for counter_multi/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup/dynamic_counter_set (default: 8)"
+      echo "--batch-size counters per op for counter_multi/counter_set/counter_buffered/counter_buffered_indexed/counter_buffered_lookup/dynamic_counter_multi/dynamic_counter_set (default: 8)"
       echo "--flush-every local operations per atomic flush for counter_buffered variants (default: 64)"
       echo "--labels registered metric names for counter_buffered_lookup (default: 16)"
       echo "--profile access pattern: uniform,hotspot,churn (default: uniform)"
@@ -97,7 +97,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$ENTITY" in
-  counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_set|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
+  counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_multi|dynamic_counter_set|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram) ;;
   *)
     echo "ERROR: unsupported --entity '$ENTITY'"
     exit 1
@@ -160,7 +160,7 @@ if [[ "$ENTITY" == "counter_multi" ]]; then
   done
 fi
 
-if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" || "$ENTITY" == "dynamic_counter_set" ]]; then
+if [[ "$ENTITY" == "counter_set" || "$ENTITY" == "counter_buffered" || "$ENTITY" == "counter_buffered_indexed" || "$ENTITY" == "counter_buffered_lookup" || "$ENTITY" == "dynamic_counter_multi" || "$ENTITY" == "dynamic_counter_set" ]]; then
   for mode in "${MODES_ARR[@]}"; do
     if [[ "$mode" != "fast" ]]; then
       echo "ERROR: entity=$ENTITY is only valid with --modes fast"

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -8,12 +8,13 @@
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_buffered --threads 16 --iters 10000000 --shards 16 --batch-size 8 --flush-every 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity labeled_counter --threads 16 --iters 10000000 --labels 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter --threads 16 --iters 10000000 --labels 64 --shards 16
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter_set --threads 16 --iters 10000000 --labels 64 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity dynamic_counter --threads 16 --iters 10000000 --labels 64
 
 use fast_telemetry::{
     Counter, CounterSet, CounterSetBuffer, Distribution, DynamicCounter, DynamicDistribution,
-    DynamicGauge, DynamicGaugeI64, DynamicHistogram, LabelEnum, LabeledCounter, LabeledGauge,
-    LabeledHistogram,
+    DynamicCounterSet, DynamicGauge, DynamicGaugeI64, DynamicHistogram, LabelEnum,
+    LabeledCounter, LabeledGauge, LabeledHistogram,
 };
 use metrics::atomics::AtomicU64 as MetricsAtomicU64;
 use metrics::{
@@ -60,6 +61,7 @@ enum Entity {
     CounterBufferedLookup,
     Distribution,
     DynamicCounter,
+    DynamicCounterSet,
     DynamicDistribution,
     DynamicGauge,
     DynamicGaugeI64,
@@ -157,6 +159,7 @@ fn parse_args() -> Config {
                     "counter_buffered_lookup" => Entity::CounterBufferedLookup,
                     "distribution" => Entity::Distribution,
                     "dynamic_counter" => Entity::DynamicCounter,
+                    "dynamic_counter_set" => Entity::DynamicCounterSet,
                     "dynamic_distribution" => Entity::DynamicDistribution,
                     "dynamic_gauge" => Entity::DynamicGauge,
                     "dynamic_gauge_i64" => Entity::DynamicGaugeI64,
@@ -165,7 +168,7 @@ fn parse_args() -> Config {
                     "labeled_gauge" => Entity::LabeledGauge,
                     "labeled_histogram" => Entity::LabeledHistogram,
                     value => panic!(
-                        "invalid --entity: {value} (expected counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
+                        "invalid --entity: {value} (expected counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_set|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
                     ),
                 };
                 i += 2;
@@ -226,11 +229,11 @@ fn parse_args() -> Config {
             }
             "--help" => {
                 println!(
-                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
+                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_set|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
                 );
                 println!("  --profile <uniform|hotspot|churn> controls label access pattern");
                 println!(
-                    "  --batch-size <n> controls counters per op for counter_multi, counter_set, counter_buffered, counter_buffered_indexed, and counter_buffered_lookup"
+                    "  --batch-size <n> controls counters per op for counter_multi, counter_set, counter_buffered, counter_buffered_indexed, counter_buffered_lookup, and dynamic_counter_set"
                 );
                 println!("  --flush-every <n> controls local-delta flush cadence for counter_buffered");
                 println!("  --labels <n> controls registered metric names for counter_buffered_lookup");
@@ -740,6 +743,56 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
+        Entity::DynamicCounterSet => {
+            let counter_names: Vec<String> =
+                (0..batch_size).map(|idx| format!("metric{idx}")).collect();
+            let metric = Arc::new(DynamicCounterSet::with_shards(
+                shards,
+                counter_names.iter().map(String::as_str),
+            ));
+            let values: Arc<Vec<isize>> = Arc::new(vec![1; batch_size]);
+            let endpoint_values: Arc<Vec<String>> =
+                Arc::new((0..labels).map(|i| format!("ep{i}")).collect());
+            let org_cardinality = usize::max(1, labels / 4);
+            let org_values: Arc<Vec<String>> =
+                Arc::new((0..org_cardinality).map(|i| format!("org{i}")).collect());
+            let worker_metric = Arc::clone(&metric);
+            let worker_values = Arc::clone(&values);
+            let worker_endpoints = Arc::clone(&endpoint_values);
+            let worker_orgs = Arc::clone(&org_values);
+            let exporter_metric = Arc::clone(&metric);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |t, n| {
+                        let mut series_handles = Vec::with_capacity(worker_endpoints.len());
+                        for (endpoint_idx, endpoint) in worker_endpoints.iter().enumerate() {
+                            let org_idx = endpoint_idx % worker_orgs.len();
+                            series_handles.push(worker_metric.series(&[
+                                ("endpoint_uuid", endpoint.as_str()),
+                                ("org_id", worker_orgs[org_idx].as_str()),
+                            ]));
+                        }
+                        for i in 0..n {
+                            let idx = profile_index(profile, t, i, series_handles.len());
+                            series_handles[idx].add_all_values(&worker_values);
+                        }
+                    },
+                    move || exporter_metric.sum_all(),
+                );
+
+            RunResult {
+                final_count: metric.sum_all(),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
         Entity::DynamicDistribution => {
             let metric = Arc::new(DynamicDistribution::new(shards));
             let endpoint_values: Arc<Vec<String>> =
@@ -1172,7 +1225,8 @@ fn run_metrics(entity: Entity, cfg: &Config) -> RunResult {
         | Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
-        | Entity::CounterBufferedLookup => {
+        | Entity::CounterBufferedLookup
+        | Entity::DynamicCounterSet => {
             panic!("metrics mode does not support entity={entity:?}; use mode=fast")
         }
         Entity::Distribution | Entity::DynamicDistribution => {
@@ -1641,7 +1695,8 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
         Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
-        | Entity::CounterBufferedLookup => {
+        | Entity::CounterBufferedLookup
+        | Entity::DynamicCounterSet => {
             panic!("otel mode does not support entity={entity:?}; use mode=fast")
         }
         Entity::Distribution => {
@@ -2076,7 +2131,8 @@ fn main() {
         | Entity::CounterSet
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
-        | Entity::CounterBufferedLookup => cfg.batch_size,
+        | Entity::CounterBufferedLookup
+        | Entity::DynamicCounterSet => cfg.batch_size,
         _ => 1,
     };
     let total_counter_writes = total_ops * counter_writes_per_op;
@@ -2121,6 +2177,7 @@ fn main() {
         Entity::CounterBufferedLookup => "counter_buffered_lookup",
         Entity::Distribution => "distribution",
         Entity::DynamicCounter => "dynamic_counter",
+        Entity::DynamicCounterSet => "dynamic_counter_set",
         Entity::DynamicDistribution => "dynamic_distribution",
         Entity::DynamicGauge => "dynamic_gauge",
         Entity::DynamicGaugeI64 => "dynamic_gauge_i64",
@@ -2148,6 +2205,7 @@ fn main() {
             | Entity::CounterBufferedLookup
             | Entity::Distribution
             | Entity::DynamicCounter
+            | Entity::DynamicCounterSet
             | Entity::DynamicDistribution
             | Entity::DynamicHistogram
             | Entity::LabeledCounter

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -8,6 +8,7 @@
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity counter_buffered --threads 16 --iters 10000000 --shards 16 --batch-size 8 --flush-every 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity labeled_counter --threads 16 --iters 10000000 --labels 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter --threads 16 --iters 10000000 --labels 64 --shards 16
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter_multi --threads 16 --iters 10000000 --labels 64 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter_set --threads 16 --iters 10000000 --labels 64 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity dynamic_counter --threads 16 --iters 10000000 --labels 64
 
@@ -61,6 +62,7 @@ enum Entity {
     CounterBufferedLookup,
     Distribution,
     DynamicCounter,
+    DynamicCounterMulti,
     DynamicCounterSet,
     DynamicDistribution,
     DynamicGauge,
@@ -159,6 +161,7 @@ fn parse_args() -> Config {
                     "counter_buffered_lookup" => Entity::CounterBufferedLookup,
                     "distribution" => Entity::Distribution,
                     "dynamic_counter" => Entity::DynamicCounter,
+                    "dynamic_counter_multi" => Entity::DynamicCounterMulti,
                     "dynamic_counter_set" => Entity::DynamicCounterSet,
                     "dynamic_distribution" => Entity::DynamicDistribution,
                     "dynamic_gauge" => Entity::DynamicGauge,
@@ -168,7 +171,7 @@ fn parse_args() -> Config {
                     "labeled_gauge" => Entity::LabeledGauge,
                     "labeled_histogram" => Entity::LabeledHistogram,
                     value => panic!(
-                        "invalid --entity: {value} (expected counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_set|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
+                        "invalid --entity: {value} (expected counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_multi|dynamic_counter_set|dynamic_distribution|dynamic_gauge|dynamic_gauge_i64|dynamic_histogram|labeled_counter|labeled_gauge|labeled_histogram)"
                     ),
                 };
                 i += 2;
@@ -229,11 +232,11 @@ fn parse_args() -> Config {
             }
             "--help" => {
                 println!(
-                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_set|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
+                    "Usage: bench_cache_contention --mode <fast|atomic|metrics|otel> --entity <counter|counter_multi|counter_set|counter_buffered|counter_buffered_indexed|counter_buffered_lookup|distribution|dynamic_counter|dynamic_counter_multi|dynamic_counter_set|labeled_counter|labeled_gauge|labeled_histogram> --threads <n> --iters <n> [--shards <n>] [--labels <n>] [--batch-size <n>] [--flush-every <n>] [--profile <uniform|hotspot|churn>] [--thread-affinity <off|round_robin|rr>] [--export-interval-ms <n>]"
                 );
                 println!("  --profile <uniform|hotspot|churn> controls label access pattern");
                 println!(
-                    "  --batch-size <n> controls counters per op for counter_multi, counter_set, counter_buffered, counter_buffered_indexed, counter_buffered_lookup, and dynamic_counter_set"
+                    "  --batch-size <n> controls counters per op for counter_multi, counter_set, counter_buffered, counter_buffered_indexed, counter_buffered_lookup, dynamic_counter_multi, and dynamic_counter_set"
                 );
                 println!("  --flush-every <n> controls local-delta flush cadence for counter_buffered");
                 println!("  --labels <n> controls registered metric names for counter_buffered_lookup");
@@ -743,6 +746,62 @@ fn run_fast(entity: Entity, cfg: &Config) -> RunResult {
                 cpu_usage,
             }
         }
+        Entity::DynamicCounterMulti => {
+            let metrics: Arc<Vec<DynamicCounter>> =
+                Arc::new((0..batch_size).map(|_| DynamicCounter::new(shards)).collect());
+            let endpoint_values: Arc<Vec<String>> =
+                Arc::new((0..labels).map(|i| format!("ep{i}")).collect());
+            let org_cardinality = usize::max(1, labels / 4);
+            let org_values: Arc<Vec<String>> =
+                Arc::new((0..org_cardinality).map(|i| format!("org{i}")).collect());
+            let worker_metrics = Arc::clone(&metrics);
+            let worker_endpoints = Arc::clone(&endpoint_values);
+            let worker_orgs = Arc::clone(&org_values);
+            let exporter_metrics = Arc::clone(&metrics);
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |t, n| {
+                        let mut series_handles = Vec::with_capacity(worker_endpoints.len());
+                        for (endpoint_idx, endpoint) in worker_endpoints.iter().enumerate() {
+                            let org_idx = endpoint_idx % worker_orgs.len();
+                            let labels = [
+                                ("endpoint_uuid", endpoint.as_str()),
+                                ("org_id", worker_orgs[org_idx].as_str()),
+                            ];
+                            let mut label_series = Vec::with_capacity(worker_metrics.len());
+                            for metric in worker_metrics.iter() {
+                                label_series.push(metric.series(&labels));
+                            }
+                            series_handles.push(label_series);
+                        }
+                        for i in 0..n {
+                            let idx = profile_index(profile, t, i, series_handles.len());
+                            for series in series_handles[idx].iter() {
+                                series.inc();
+                            }
+                        }
+                    },
+                    move || {
+                        exporter_metrics
+                            .iter()
+                            .map(DynamicCounter::sum_all)
+                            .sum::<isize>()
+                    },
+                );
+
+            RunResult {
+                final_count: metrics.iter().map(DynamicCounter::sum_all).sum(),
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
         Entity::DynamicCounterSet => {
             let counter_names: Vec<String> =
                 (0..batch_size).map(|idx| format!("metric{idx}")).collect();
@@ -1226,6 +1285,7 @@ fn run_metrics(entity: Entity, cfg: &Config) -> RunResult {
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
         | Entity::CounterBufferedLookup
+        | Entity::DynamicCounterMulti
         | Entity::DynamicCounterSet => {
             panic!("metrics mode does not support entity={entity:?}; use mode=fast")
         }
@@ -1696,6 +1756,7 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
         | Entity::CounterBufferedLookup
+        | Entity::DynamicCounterMulti
         | Entity::DynamicCounterSet => {
             panic!("otel mode does not support entity={entity:?}; use mode=fast")
         }
@@ -2132,6 +2193,7 @@ fn main() {
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
         | Entity::CounterBufferedLookup
+        | Entity::DynamicCounterMulti
         | Entity::DynamicCounterSet => cfg.batch_size,
         _ => 1,
     };
@@ -2177,6 +2239,7 @@ fn main() {
         Entity::CounterBufferedLookup => "counter_buffered_lookup",
         Entity::Distribution => "distribution",
         Entity::DynamicCounter => "dynamic_counter",
+        Entity::DynamicCounterMulti => "dynamic_counter_multi",
         Entity::DynamicCounterSet => "dynamic_counter_set",
         Entity::DynamicDistribution => "dynamic_distribution",
         Entity::DynamicGauge => "dynamic_gauge",
@@ -2205,6 +2268,7 @@ fn main() {
             | Entity::CounterBufferedLookup
             | Entity::Distribution
             | Entity::DynamicCounter
+            | Entity::DynamicCounterMulti
             | Entity::DynamicCounterSet
             | Entity::DynamicDistribution
             | Entity::DynamicHistogram

--- a/crates/fast-telemetry/bench/workloads/cache_contention.rs
+++ b/crates/fast-telemetry/bench/workloads/cache_contention.rs
@@ -9,6 +9,7 @@
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity labeled_counter --threads 16 --iters 10000000 --labels 64
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter --threads 16 --iters 10000000 --labels 64 --shards 16
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter_multi --threads 16 --iters 10000000 --labels 64 --shards 16 --batch-size 8
+// - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity dynamic_counter_multi --threads 16 --iters 1000000 --labels 64 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode fast --entity dynamic_counter_set --threads 16 --iters 10000000 --labels 64 --shards 16 --batch-size 8
 // - cargo run --release --bin bench_cache_contention --features bench-tools -- --mode otel --entity dynamic_counter --threads 16 --iters 10000000 --labels 64
 
@@ -1660,7 +1661,7 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
     );
     let meter = provider.meter("fast-telemetry.bench_cache_contention");
     let expected_counter_writes_per_op = match entity {
-        Entity::CounterMulti => batch_size,
+        Entity::CounterMulti | Entity::DynamicCounterMulti => batch_size,
         _ => 1,
     };
     let expected_final_count =
@@ -1756,7 +1757,6 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
         | Entity::CounterBuffered
         | Entity::CounterBufferedIndexed
         | Entity::CounterBufferedLookup
-        | Entity::DynamicCounterMulti
         | Entity::DynamicCounterSet => {
             panic!("otel mode does not support entity={entity:?}; use mode=fast")
         }
@@ -1829,6 +1829,66 @@ fn run_otel(entity: Entity, cfg: &Config) -> RunResult {
                         for i in 0..n {
                             let idx = profile_index(profile, t, i, worker_attrs.len());
                             worker_counter.add(1, &worker_attrs[idx]);
+                        }
+                    },
+                    move || {
+                        let _ = exporter_provider.force_flush();
+                        let _ = exporter_exporter.get_finished_metrics();
+                        exporter_exporter.reset();
+                        0usize
+                    },
+                );
+
+            let _ = provider.force_flush();
+            let _ = exporter.get_finished_metrics();
+            RunResult {
+                final_count: expected_final_count,
+                record_seconds,
+                total_seconds,
+                export_count,
+                export_seconds,
+                cpu_usage,
+            }
+        }
+        Entity::DynamicCounterMulti => {
+            let counters: Arc<Vec<OTelCounter<u64>>> = Arc::new(
+                (0..batch_size)
+                    .map(|idx| {
+                        meter
+                            .u64_counter(format!("contention_dynamic_counter_{idx}"))
+                            .build()
+                    })
+                    .collect(),
+            );
+            let org_cardinality = usize::max(1, labels / 4);
+            let attrs: Arc<Vec<Vec<KeyValue>>> = Arc::new(
+                (0..labels)
+                    .map(|i| {
+                        let org_idx = i % org_cardinality;
+                        vec![
+                            KeyValue::new("endpoint_uuid", format!("ep{i}")),
+                            KeyValue::new("org_id", format!("org{org_idx}")),
+                        ]
+                    })
+                    .collect(),
+            );
+            let worker_counters = Arc::clone(&counters);
+            let worker_attrs = Arc::clone(&attrs);
+            let exporter_provider = Arc::clone(&provider);
+            let exporter_exporter = exporter.clone();
+
+            let (record_seconds, total_seconds, export_count, export_seconds, cpu_usage) =
+                run_with_threads(
+                    threads,
+                    iters,
+                    thread_affinity,
+                    export_interval_ms,
+                    move |t, n| {
+                        for i in 0..n {
+                            let idx = profile_index(profile, t, i, worker_attrs.len());
+                            for counter in worker_counters.iter() {
+                                counter.add(1, &worker_attrs[idx]);
+                            }
                         }
                     },
                     move || {

--- a/crates/fast-telemetry/src/lib.rs
+++ b/crates/fast-telemetry/src/lib.rs
@@ -52,13 +52,13 @@ pub mod __macro_support {
 pub use metric::ExportMetrics;
 pub use metric::{
     Counter, CounterSet, CounterSetBuffer, Distribution, DistributionSnapshot, DynamicCounter,
-    DynamicCounterSeries, DynamicDistribution, DynamicDistributionSeries, DynamicGauge,
-    DynamicGaugeI64, DynamicGaugeI64Series, DynamicGaugeSeries, DynamicHistogram,
-    DynamicHistogramSeries, DynamicHistogramSeriesView, DynamicLabelSet, Gauge, GaugeF64,
-    Histogram, HistogramSnapshot, LabelEnum, LabeledCounter, LabeledGauge, LabeledHistogram,
-    LabeledSampledTimer, MaxGauge, MaxGaugeF64, MetricKind, MetricLabel, MetricLabels,
-    MetricLabelsIter, MetricMeta, MetricVisitor, MinGauge, MinGaugeF64, SampledTimer,
-    SampledTimerGuard,
+    DynamicCounterSeries, DynamicCounterSet, DynamicCounterSetSeries, DynamicDistribution,
+    DynamicDistributionSeries, DynamicGauge, DynamicGaugeI64, DynamicGaugeI64Series,
+    DynamicGaugeSeries, DynamicHistogram, DynamicHistogramSeries, DynamicHistogramSeriesView,
+    DynamicLabelSet, Gauge, GaugeF64, Histogram, HistogramSnapshot, LabelEnum, LabeledCounter,
+    LabeledGauge, LabeledHistogram, LabeledSampledTimer, MaxGauge, MaxGaugeF64, MetricKind,
+    MetricLabel, MetricLabels, MetricLabelsIter, MetricMeta, MetricVisitor, MinGauge, MinGaugeF64,
+    SampledTimer, SampledTimerGuard,
 };
 #[cfg(feature = "eviction")]
 pub use metric::{advance_cycle, current_cycle};

--- a/crates/fast-telemetry/src/metric/counter.rs
+++ b/crates/fast-telemetry/src/metric/counter.rs
@@ -378,6 +378,53 @@ impl CounterSet {
         }
         total
     }
+
+    /// Returns one value per counter in index order.
+    #[inline]
+    pub fn snapshot(&self) -> Vec<isize> {
+        (0..self.counters).map(|idx| self.sum(idx)).collect()
+    }
+
+    /// Resets one counter to zero and returns its previous sum.
+    ///
+    /// # Eventual Consistency
+    ///
+    /// Writes that occur concurrently with `sum_and_reset()` may be attributed
+    /// to the next window rather than the current one. No counts are lost; they
+    /// simply shift to the next export window.
+    #[inline]
+    pub fn sum_and_reset(&self, counter_idx: usize) -> isize {
+        assert!(counter_idx < self.counters, "counter index out of bounds");
+        let shards = self.cells.len() / self.stride;
+        (0..shards)
+            .map(|shard| {
+                self.cell_at((shard * self.stride) + counter_idx)
+                    .swap(0, Ordering::Relaxed)
+            })
+            .sum()
+    }
+
+    /// Returns one value per counter in index order, then resets all counters.
+    ///
+    /// # Eventual Consistency
+    ///
+    /// Writes that occur concurrently with `snapshot_and_reset()` may be
+    /// attributed to the next window rather than the current one. No counts are
+    /// lost; they simply shift to the next export window.
+    #[inline]
+    pub fn snapshot_and_reset(&self) -> Vec<isize> {
+        let mut values = vec![0; self.counters];
+        let shards = self.cells.len() / self.stride;
+        for shard in 0..shards {
+            let offset = shard * self.stride;
+            for (counter_idx, value) in values.iter_mut().enumerate() {
+                *value += self
+                    .cell_at(offset + counter_idx)
+                    .swap(0, Ordering::Relaxed);
+            }
+        }
+        values
+    }
 }
 
 /// A local write buffer for a [`CounterSet`].
@@ -632,6 +679,29 @@ mod tests {
         assert_eq!(counters.sum(1), 8);
         assert_eq!(counters.sum(2), 9);
         assert_eq!(counters.sum_all(), 22);
+        assert_eq!(counters.snapshot(), vec![5, 8, 9]);
+    }
+
+    #[test]
+    fn counter_set_sum_and_reset_resets_one_counter() {
+        let counters = CounterSet::new(4, 3);
+
+        counters.add_values(&[2, 3, 4]);
+        counters.add_values(&[5, 6, 7]);
+
+        assert_eq!(counters.sum_and_reset(1), 9);
+        assert_eq!(counters.snapshot(), vec![7, 0, 11]);
+    }
+
+    #[test]
+    fn counter_set_snapshot_and_reset_resets_all_counters() {
+        let counters = CounterSet::new(4, 3);
+
+        counters.add_values(&[2, 3, 4]);
+        counters.add_values(&[5, 6, 7]);
+
+        assert_eq!(counters.snapshot_and_reset(), vec![7, 9, 11]);
+        assert_eq!(counters.snapshot(), vec![0, 0, 0]);
     }
 
     #[test]

--- a/crates/fast-telemetry/src/metric/dynamic/counter_set.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/counter_set.rs
@@ -1,0 +1,967 @@
+//! Runtime-labeled grouped counters for dynamic dimensions.
+
+use super::cache::{CacheableSeries, LabelCache, SERIES_CACHE_SIZE};
+#[cfg(feature = "eviction")]
+use super::current_cycle;
+use super::{COUNTER_IDS, DynamicIndexMap, DynamicLabelSet, dynamic_index_map, thread_id};
+use crossbeam_utils::CachePadded;
+use parking_lot::RwLock;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+#[cfg(feature = "eviction")]
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
+
+const DEFAULT_MAX_SERIES: usize = 2000;
+const OVERFLOW_LABEL_KEY: &str = "__ft_overflow";
+const OVERFLOW_LABEL_VALUE: &str = "true";
+
+struct CounterSetSeries {
+    cells: Vec<AtomicIsize>,
+    counters: usize,
+    stride: usize,
+    evicted: AtomicBool,
+    #[cfg(feature = "eviction")]
+    last_accessed_cycle: AtomicU32,
+}
+
+type CounterSetIndexShard = CachePadded<RwLock<DynamicIndexMap<Arc<CounterSetSeries>>>>;
+
+impl CounterSetSeries {
+    #[cfg(feature = "eviction")]
+    fn new(shards: usize, counters: usize, current_cycle: u32) -> Self {
+        let stride = counter_row_stride(counters);
+        Self {
+            cells: (0..(shards * stride))
+                .map(|_| AtomicIsize::new(0))
+                .collect(),
+            counters,
+            stride,
+            evicted: AtomicBool::new(false),
+            last_accessed_cycle: AtomicU32::new(current_cycle),
+        }
+    }
+
+    #[cfg(not(feature = "eviction"))]
+    fn new(shards: usize, counters: usize) -> Self {
+        let stride = counter_row_stride(counters);
+        Self {
+            cells: (0..(shards * stride))
+                .map(|_| AtomicIsize::new(0))
+                .collect(),
+            counters,
+            stride,
+            evicted: AtomicBool::new(false),
+        }
+    }
+
+    #[inline]
+    fn cell_at(&self, index: usize) -> &AtomicIsize {
+        if cfg!(debug_assertions) {
+            self.cells.get(index).expect("index out of bounds")
+        } else {
+            // SAFETY: callers compute indexes from checked counter indexes and
+            // row offsets derived from the shard mask.
+            unsafe { self.cells.get_unchecked(index) }
+        }
+    }
+
+    #[inline]
+    fn row_offset(&self, shard_idx: usize) -> usize {
+        shard_idx * self.stride
+    }
+
+    #[inline]
+    fn add_at(&self, shard_idx: usize, counter_idx: usize, value: isize) {
+        assert!(counter_idx < self.counters, "counter index out of bounds");
+        let offset = self.row_offset(shard_idx);
+        self.cell_at(offset + counter_idx)
+            .fetch_add(value, Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn add_index_values_at(&self, shard_idx: usize, updates: &[(usize, isize)]) {
+        let offset = self.row_offset(shard_idx);
+        for (counter_idx, value) in updates {
+            assert!(*counter_idx < self.counters, "counter index out of bounds");
+            self.cell_at(offset + *counter_idx)
+                .fetch_add(*value, Ordering::Relaxed);
+        }
+    }
+
+    #[inline(always)]
+    fn add_values_at(&self, shard_idx: usize, values: &[isize]) {
+        assert_eq!(values.len(), self.counters, "values must match counters");
+        let offset = self.row_offset(shard_idx);
+        match values {
+            [a] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+            }
+            [a, b] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+            }
+            [a, b, c] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+            }
+            [a, b, c, d] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+            }
+            [a, b, c, d, e] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+            }
+            [a, b, c, d, e, f] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+                self.cell_at(offset + 5).fetch_add(*f, Ordering::Relaxed);
+            }
+            [a, b, c, d, e, f, g] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+                self.cell_at(offset + 5).fetch_add(*f, Ordering::Relaxed);
+                self.cell_at(offset + 6).fetch_add(*g, Ordering::Relaxed);
+            }
+            [a, b, c, d, e, f, g, h] => {
+                self.cell_at(offset).fetch_add(*a, Ordering::Relaxed);
+                self.cell_at(offset + 1).fetch_add(*b, Ordering::Relaxed);
+                self.cell_at(offset + 2).fetch_add(*c, Ordering::Relaxed);
+                self.cell_at(offset + 3).fetch_add(*d, Ordering::Relaxed);
+                self.cell_at(offset + 4).fetch_add(*e, Ordering::Relaxed);
+                self.cell_at(offset + 5).fetch_add(*f, Ordering::Relaxed);
+                self.cell_at(offset + 6).fetch_add(*g, Ordering::Relaxed);
+                self.cell_at(offset + 7).fetch_add(*h, Ordering::Relaxed);
+            }
+            values => {
+                let row = if cfg!(debug_assertions) {
+                    self.cells
+                        .get(offset..offset + self.counters)
+                        .expect("row index out of bounds")
+                } else {
+                    // SAFETY: row_offset derives from a shard index masked by
+                    // the owning metric, and counters <= stride by construction.
+                    unsafe {
+                        std::slice::from_raw_parts(self.cells.as_ptr().add(offset), self.counters)
+                    }
+                };
+                for (cell, value) in row.iter().zip(values.iter().copied()) {
+                    cell.fetch_add(value, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn sum(&self, counter_idx: usize) -> isize {
+        assert!(counter_idx < self.counters, "counter index out of bounds");
+        let shards = self.cells.len() / self.stride;
+        (0..shards)
+            .map(|shard| {
+                self.cell_at((shard * self.stride) + counter_idx)
+                    .load(Ordering::Relaxed)
+            })
+            .sum()
+    }
+
+    #[inline]
+    fn values(&self) -> Vec<isize> {
+        (0..self.counters).map(|idx| self.sum(idx)).collect()
+    }
+
+    #[inline]
+    fn sum_all(&self) -> isize {
+        let shards = self.cells.len() / self.stride;
+        let mut total = 0isize;
+        for shard in 0..shards {
+            let offset = shard * self.stride;
+            for counter_idx in 0..self.counters {
+                total += self.cell_at(offset + counter_idx).load(Ordering::Relaxed);
+            }
+        }
+        total
+    }
+
+    #[inline]
+    fn sum_and_reset(&self, counter_idx: usize) -> isize {
+        assert!(counter_idx < self.counters, "counter index out of bounds");
+        let shards = self.cells.len() / self.stride;
+        (0..shards)
+            .map(|shard| {
+                self.cell_at((shard * self.stride) + counter_idx)
+                    .swap(0, Ordering::Relaxed)
+            })
+            .sum()
+    }
+
+    #[inline]
+    fn snapshot_and_reset(&self) -> Vec<isize> {
+        let mut values = vec![0; self.counters];
+        let shards = self.cells.len() / self.stride;
+        for shard in 0..shards {
+            let offset = shard * self.stride;
+            for (counter_idx, value) in values.iter_mut().enumerate() {
+                *value += self
+                    .cell_at(offset + counter_idx)
+                    .swap(0, Ordering::Relaxed);
+            }
+        }
+        values
+    }
+
+    #[cfg(feature = "eviction")]
+    #[inline]
+    fn touch(&self, cycle: u32) {
+        self.last_accessed_cycle.store(cycle, Ordering::Relaxed);
+    }
+
+    #[inline]
+    fn is_evicted(&self) -> bool {
+        self.evicted.load(Ordering::Relaxed)
+    }
+
+    #[cfg(feature = "eviction")]
+    fn mark_evicted(&self) {
+        self.evicted.store(true, Ordering::Relaxed);
+    }
+}
+
+impl CacheableSeries for CounterSetSeries {
+    fn is_evicted(&self) -> bool {
+        self.is_evicted()
+    }
+}
+
+/// A reusable handle to one dynamic-label grouped counter series.
+///
+/// Resolve this once with [`DynamicCounterSet::get_or_create`] or
+/// [`DynamicCounterSet::series`], then use index-based methods on hot paths.
+#[derive(Clone)]
+pub struct DynamicCounterSetSeries {
+    series: Arc<CounterSetSeries>,
+    names: Arc<Vec<String>>,
+    indexes: Arc<BTreeMap<String, usize>>,
+    shard_mask: usize,
+}
+
+impl DynamicCounterSetSeries {
+    /// Increment one named counter by 1.
+    #[inline]
+    pub fn inc(&self, counter: &str) {
+        self.add(counter, 1);
+    }
+
+    /// Add `value` to one named counter.
+    #[inline]
+    pub fn add(&self, counter: &str, value: isize) {
+        let counter_idx = self
+            .counter_index(counter)
+            .unwrap_or_else(|| panic!("unknown counter name: {counter}"));
+        self.add_index(counter_idx, value);
+    }
+
+    /// Add `value` to one pre-resolved counter index.
+    #[inline]
+    pub fn add_index(&self, counter_idx: usize, value: isize) {
+        let shard_idx = thread_id() & self.shard_mask;
+        self.series.add_at(shard_idx, counter_idx, value);
+    }
+
+    /// Add named counter values in one grouped call.
+    #[inline]
+    pub fn add_values(&self, updates: &[(&str, isize)]) {
+        let shard_idx = thread_id() & self.shard_mask;
+        for (counter, value) in updates {
+            let counter_idx = self
+                .counter_index(counter)
+                .unwrap_or_else(|| panic!("unknown counter name: {counter}"));
+            self.series.add_at(shard_idx, counter_idx, *value);
+        }
+    }
+
+    /// Add pre-resolved `(counter_idx, value)` updates in one grouped call.
+    #[inline]
+    pub fn add_index_values(&self, updates: &[(usize, isize)]) {
+        let shard_idx = thread_id() & self.shard_mask;
+        self.series.add_index_values_at(shard_idx, updates);
+    }
+
+    /// Add one value for every counter in index order.
+    #[inline]
+    pub fn add_all_values(&self, values: &[isize]) {
+        let shard_idx = thread_id() & self.shard_mask;
+        self.series.add_values_at(shard_idx, values);
+    }
+
+    /// Return the current total for one named counter.
+    #[inline]
+    pub fn get(&self, counter: &str) -> isize {
+        let counter_idx = self
+            .counter_index(counter)
+            .unwrap_or_else(|| panic!("unknown counter name: {counter}"));
+        self.get_index(counter_idx)
+    }
+
+    /// Return the current total for one pre-resolved counter index.
+    #[inline]
+    pub fn get_index(&self, counter_idx: usize) -> isize {
+        self.series.sum(counter_idx)
+    }
+
+    /// Return all current values in counter index order.
+    #[inline]
+    pub fn values(&self) -> Vec<isize> {
+        self.series.values()
+    }
+
+    /// Return the index for `counter`, if it exists in this grouped set.
+    #[inline]
+    pub fn counter_index(&self, counter: &str) -> Option<usize> {
+        self.indexes.get(counter).copied()
+    }
+
+    /// Return counter names in index order.
+    #[inline]
+    pub fn counter_names(&self) -> &[String] {
+        &self.names
+    }
+
+    /// Check if this series handle has been evicted.
+    ///
+    /// If true, writes go to a detached series that is no longer exported.
+    /// Callers holding long-lived handles can check this and re-resolve via
+    /// [`DynamicCounterSet::series`] if needed.
+    #[inline]
+    pub fn is_evicted(&self) -> bool {
+        self.series.is_evicted()
+    }
+}
+
+thread_local! {
+    static SERIES_CACHE: RefCell<LabelCache<Weak<CounterSetSeries>, SERIES_CACHE_SIZE>> =
+        RefCell::new(LabelCache::new());
+}
+
+/// Runtime-label grouped counters.
+///
+/// Use `DynamicCounterSet` when label values are discovered at runtime and one
+/// logical operation updates several related counters for the same label set.
+/// Resolve and cache a [`DynamicCounterSetSeries`] once per active label set,
+/// then use pre-resolved counter indexes on the hot path.
+///
+/// ```
+/// use fast_telemetry::DynamicCounterSet;
+///
+/// let counters = DynamicCounterSet::with_shards(
+///     4,
+///     ["requests", "bytes", "errors"],
+/// );
+/// let requests = counters.counter_index("requests").unwrap();
+/// let bytes = counters.counter_index("bytes").unwrap();
+///
+/// let series = counters.get_or_create(&[
+///     ("org", "eden"),
+///     ("endpoint", "ingest"),
+/// ]);
+/// series.add_index_values(&[(requests, 1), (bytes, 4096)]);
+///
+/// assert_eq!(series.get("requests"), 1);
+/// assert_eq!(series.get("bytes"), 4096);
+/// ```
+pub struct DynamicCounterSet {
+    id: usize,
+    shard_count: usize,
+    max_series: usize,
+    shard_mask: usize,
+    names: Arc<Vec<String>>,
+    indexes: Arc<BTreeMap<String, usize>>,
+    index_shards: Vec<CounterSetIndexShard>,
+    series_count: AtomicUsize,
+    overflow_count: AtomicU64,
+}
+
+impl DynamicCounterSet {
+    /// Creates a new dynamic grouped counter with a default shard count.
+    ///
+    /// Prefer [`DynamicCounterSet::with_shards`] in services that already know
+    /// the desired shard count.
+    pub fn new<I, S>(counter_names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self::with_shards(default_shard_count(), counter_names)
+    }
+
+    /// Creates a new dynamic grouped counter with `shard_count` shards.
+    pub fn with_shards<I, S>(shard_count: usize, counter_names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        Self::with_max_series(shard_count, DEFAULT_MAX_SERIES, counter_names)
+    }
+
+    /// Creates a new dynamic grouped counter with a series cardinality cap.
+    ///
+    /// When the number of unique label sets approximately reaches
+    /// `max_series`, new label sets are redirected into a single overflow
+    /// series (`__ft_overflow=true`). A `max_series` of 0 disables the cap.
+    pub fn with_max_series<I, S>(shard_count: usize, max_series: usize, counter_names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let shard_count = shard_count.next_power_of_two();
+        let (names, indexes) = build_counter_index(counter_names);
+        let id = COUNTER_IDS.fetch_add(1, Ordering::Relaxed);
+        Self {
+            id,
+            shard_count,
+            max_series,
+            shard_mask: shard_count - 1,
+            names: Arc::new(names),
+            indexes: Arc::new(indexes),
+            index_shards: (0..shard_count)
+                .map(|_| CachePadded::new(RwLock::new(dynamic_index_map())))
+                .collect(),
+            series_count: AtomicUsize::new(0),
+            overflow_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Resolve a reusable grouped series handle for `labels`.
+    pub fn series(&self, labels: &[(&str, &str)]) -> DynamicCounterSetSeries {
+        self.get_or_create(labels)
+    }
+
+    /// Resolve a reusable grouped series handle for `labels`.
+    pub fn get_or_create(&self, labels: &[(&str, &str)]) -> DynamicCounterSetSeries {
+        self.series_handle(self.cached_or_create_series(labels))
+    }
+
+    /// Increment one named counter for the series identified by `labels`.
+    #[inline]
+    pub fn inc(&self, labels: &[(&str, &str)], counter: &str) {
+        self.add(labels, counter, 1);
+    }
+
+    /// Add `value` to one named counter for the series identified by `labels`.
+    #[inline]
+    pub fn add(&self, labels: &[(&str, &str)], counter: &str, value: isize) {
+        let counter_idx = self
+            .counter_index(counter)
+            .unwrap_or_else(|| panic!("unknown counter name: {counter}"));
+        self.add_index(labels, counter_idx, value);
+    }
+
+    /// Add `value` to one pre-resolved counter index for `labels`.
+    #[inline]
+    pub fn add_index(&self, labels: &[(&str, &str)], counter_idx: usize, value: isize) {
+        let series = self.cached_or_create_series(labels);
+        let shard_idx = thread_id() & self.shard_mask;
+        series.add_at(shard_idx, counter_idx, value);
+    }
+
+    /// Add named counter values in one grouped call.
+    #[inline]
+    pub fn add_values(&self, labels: &[(&str, &str)], updates: &[(&str, isize)]) {
+        let series = self.cached_or_create_series(labels);
+        let shard_idx = thread_id() & self.shard_mask;
+        for (counter, value) in updates {
+            let counter_idx = self
+                .counter_index(counter)
+                .unwrap_or_else(|| panic!("unknown counter name: {counter}"));
+            series.add_at(shard_idx, counter_idx, *value);
+        }
+    }
+
+    /// Add pre-resolved `(counter_idx, value)` updates in one grouped call.
+    #[inline]
+    pub fn add_index_values(&self, labels: &[(&str, &str)], updates: &[(usize, isize)]) {
+        let series = self.cached_or_create_series(labels);
+        let shard_idx = thread_id() & self.shard_mask;
+        series.add_index_values_at(shard_idx, updates);
+    }
+
+    /// Add one value for every counter in index order.
+    #[inline]
+    pub fn add_all_values(&self, labels: &[(&str, &str)], values: &[isize]) {
+        let series = self.cached_or_create_series(labels);
+        let shard_idx = thread_id() & self.shard_mask;
+        series.add_values_at(shard_idx, values);
+    }
+
+    /// Get one named counter for `labels`.
+    pub fn get(&self, labels: &[(&str, &str)], counter: &str) -> isize {
+        let counter_idx = self
+            .counter_index(counter)
+            .unwrap_or_else(|| panic!("unknown counter name: {counter}"));
+        self.get_index(labels, counter_idx)
+    }
+
+    /// Get one pre-resolved counter index for `labels`.
+    pub fn get_index(&self, labels: &[(&str, &str)], counter_idx: usize) -> isize {
+        assert!(
+            counter_idx < self.names.len(),
+            "counter index out of bounds"
+        );
+        let key = DynamicLabelSet::from_pairs(labels);
+        let index_shard = self.index_shard_for(&key);
+        self.index_shards[index_shard]
+            .read()
+            .get(&key)
+            .map(|series| series.sum(counter_idx))
+            .unwrap_or(0)
+    }
+
+    /// Get all values for `labels` in counter index order.
+    pub fn values(&self, labels: &[(&str, &str)]) -> Vec<isize> {
+        let key = DynamicLabelSet::from_pairs(labels);
+        let index_shard = self.index_shard_for(&key);
+        self.index_shards[index_shard]
+            .read()
+            .get(&key)
+            .map(|series| series.values())
+            .unwrap_or_else(|| vec![0; self.names.len()])
+    }
+
+    /// Sums all counters across all dynamic series.
+    pub fn sum_all(&self) -> isize {
+        self.index_shards
+            .iter()
+            .map(|shard| {
+                let guard = shard.read();
+                guard.values().map(|series| series.sum_all()).sum::<isize>()
+            })
+            .sum()
+    }
+
+    /// Return a cumulative snapshot of all dynamic label sets.
+    pub fn snapshot(&self) -> Vec<(DynamicLabelSet, Vec<isize>)> {
+        let mut out = Vec::new();
+        for shard in &self.index_shards {
+            let guard = shard.read();
+            for (labels, series) in guard.iter() {
+                out.push((labels.clone(), series.values()));
+            }
+        }
+        out
+    }
+
+    /// Return a snapshot of all dynamic label sets and reset counters to zero.
+    ///
+    /// Writes that occur concurrently with this method may be attributed to the
+    /// next snapshot window rather than the current one. No counts are lost.
+    pub fn snapshot_and_reset(&self) -> Vec<(DynamicLabelSet, Vec<isize>)> {
+        let mut out = Vec::new();
+        for shard in &self.index_shards {
+            let guard = shard.read();
+            for (labels, series) in guard.iter() {
+                out.push((labels.clone(), series.snapshot_and_reset()));
+            }
+        }
+        out
+    }
+
+    /// Reset one counter index for all dynamic label sets and return its total.
+    pub fn sum_and_reset(&self, counter_idx: usize) -> isize {
+        assert!(
+            counter_idx < self.names.len(),
+            "counter index out of bounds"
+        );
+        self.index_shards
+            .iter()
+            .map(|shard| {
+                let guard = shard.read();
+                guard
+                    .values()
+                    .map(|series| series.sum_and_reset(counter_idx))
+                    .sum::<isize>()
+            })
+            .sum()
+    }
+
+    /// Iterate all counter values without cloning label sets.
+    ///
+    /// Calls `f(counter_name, labels, value)` for every counter in every
+    /// dynamic label set. The callback runs while a shard read lock is held; it
+    /// must be fast and must not call back into this metric.
+    pub fn visit_series(&self, mut f: impl FnMut(&str, &[(String, String)], isize)) {
+        for shard in &self.index_shards {
+            let guard = shard.read();
+            for (labels, series) in guard.iter() {
+                for (counter_idx, counter_name) in self.names.iter().enumerate() {
+                    f(
+                        counter_name.as_str(),
+                        labels.pairs(),
+                        series.sum(counter_idx),
+                    );
+                }
+            }
+        }
+    }
+
+    /// Returns counter names in index order.
+    #[inline]
+    pub fn counter_names(&self) -> &[String] {
+        &self.names
+    }
+
+    /// Return the index for `counter`, if it exists.
+    #[inline]
+    pub fn counter_index(&self, counter: &str) -> Option<usize> {
+        self.indexes.get(counter).copied()
+    }
+
+    /// Returns the current number of distinct dynamic label sets.
+    pub fn cardinality(&self) -> usize {
+        self.index_shards
+            .iter()
+            .map(|shard| shard.read().len())
+            .sum()
+    }
+
+    /// Returns the number of records routed to the overflow bucket.
+    pub fn overflow_count(&self) -> u64 {
+        self.overflow_count.load(Ordering::Relaxed)
+    }
+
+    /// Evict series that haven't been accessed for `max_staleness` cycles.
+    ///
+    /// Protected series (Arc::strong_count > 1) are never evicted because a
+    /// caller still holds a [`DynamicCounterSetSeries`] handle.
+    #[cfg(feature = "eviction")]
+    pub fn evict_stale(&self, max_staleness: u32) -> usize {
+        let cycle = current_cycle();
+        let mut removed = 0;
+
+        for shard in &self.index_shards {
+            let mut guard = shard.write();
+            guard.retain(|_labels, series| {
+                if Arc::strong_count(series) > 1 {
+                    return true;
+                }
+                let last = series.last_accessed_cycle.load(Ordering::Relaxed);
+                let stale = cycle.saturating_sub(last) > max_staleness;
+                if stale {
+                    series.mark_evicted();
+                    removed += 1;
+                    self.series_count.fetch_sub(1, Ordering::Relaxed);
+                }
+                !stale
+            });
+        }
+
+        removed
+    }
+
+    fn series_handle(&self, series: Arc<CounterSetSeries>) -> DynamicCounterSetSeries {
+        DynamicCounterSetSeries {
+            series,
+            names: Arc::clone(&self.names),
+            indexes: Arc::clone(&self.indexes),
+            shard_mask: self.shard_mask,
+        }
+    }
+
+    fn cached_or_create_series(&self, labels: &[(&str, &str)]) -> Arc<CounterSetSeries> {
+        if let Some(series) = self.cached_series(labels) {
+            return series;
+        }
+        let series = self.lookup_or_create(labels);
+        self.update_cache(labels, &series);
+        series
+    }
+
+    fn lookup_or_create(&self, labels: &[(&str, &str)]) -> Arc<CounterSetSeries> {
+        let requested_key = DynamicLabelSet::from_pairs(labels);
+        let requested_shard = self.index_shard_for(&requested_key);
+        #[cfg(feature = "eviction")]
+        let cycle = current_cycle();
+
+        if let Some(series) = self.index_shards[requested_shard]
+            .read()
+            .get(&requested_key)
+        {
+            #[cfg(feature = "eviction")]
+            series.touch(cycle);
+            return Arc::clone(series);
+        }
+
+        let key = if self.max_series > 0
+            && self.series_count.load(Ordering::Relaxed) >= self.max_series
+        {
+            self.overflow_count.fetch_add(1, Ordering::Relaxed);
+            DynamicLabelSet::from_pairs(&[(OVERFLOW_LABEL_KEY, OVERFLOW_LABEL_VALUE)])
+        } else {
+            requested_key
+        };
+        let shard = self.index_shard_for(&key);
+
+        if let Some(series) = self.index_shards[shard].read().get(&key) {
+            #[cfg(feature = "eviction")]
+            series.touch(cycle);
+            return Arc::clone(series);
+        }
+
+        let mut guard = self.index_shards[shard].write();
+        if let Some(series) = guard.get(&key) {
+            #[cfg(feature = "eviction")]
+            series.touch(cycle);
+            return Arc::clone(series);
+        }
+        #[cfg(feature = "eviction")]
+        let series = Arc::new(CounterSetSeries::new(
+            self.shard_count,
+            self.names.len(),
+            cycle,
+        ));
+        #[cfg(not(feature = "eviction"))]
+        let series = Arc::new(CounterSetSeries::new(self.shard_count, self.names.len()));
+        guard.insert(key, Arc::clone(&series));
+        self.series_count.fetch_add(1, Ordering::Relaxed);
+        series
+    }
+
+    fn index_shard_for(&self, key: &DynamicLabelSet) -> usize {
+        key.shard_index(self.shard_mask)
+    }
+
+    fn cached_series(&self, labels: &[(&str, &str)]) -> Option<Arc<CounterSetSeries>> {
+        SERIES_CACHE.with(|cache| {
+            let series = cache.borrow_mut().get(self.id, labels)?;
+            #[cfg(feature = "eviction")]
+            series.touch(current_cycle());
+            Some(series)
+        })
+    }
+
+    fn update_cache(&self, labels: &[(&str, &str)], series: &Arc<CounterSetSeries>) {
+        SERIES_CACHE.with(|cache| {
+            cache
+                .borrow_mut()
+                .insert(self.id, labels, Arc::downgrade(series));
+        });
+    }
+}
+
+fn build_counter_index<I, S>(counter_names: I) -> (Vec<String>, BTreeMap<String, usize>)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut names = Vec::new();
+    let mut indexes = BTreeMap::new();
+    for name in counter_names {
+        let name = name.as_ref();
+        assert!(!name.is_empty(), "counter names must not be empty");
+        let index = names.len();
+        let inserted = indexes.insert(name.to_string(), index);
+        assert!(inserted.is_none(), "duplicate counter name: {name}");
+        names.push(name.to_string());
+    }
+    assert!(!names.is_empty(), "counter_names must not be empty");
+    (names, indexes)
+}
+
+#[inline]
+fn counter_row_stride(counters: usize) -> usize {
+    let cells_per_padded_counter =
+        std::mem::size_of::<CachePadded<AtomicIsize>>() / std::mem::size_of::<AtomicIsize>();
+    let row_padding = cells_per_padded_counter.max(1);
+    counters.div_ceil(row_padding) * row_padding
+}
+
+#[inline]
+fn default_shard_count() -> usize {
+    std::thread::available_parallelism().map_or(4, usize::from)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "eviction")]
+    use super::super::{advance_cycle, lock_eviction_cycle_for_test};
+    use super::*;
+
+    #[test]
+    fn dynamic_counter_set_updates_named_counters() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests", "bytes", "errors"]);
+        let labels = &[("org", "eden"), ("endpoint", "ingest")];
+
+        counters.add_values(labels, &[("requests", 1), ("bytes", 4096)]);
+        counters.inc(labels, "errors");
+
+        assert_eq!(counters.get(labels, "requests"), 1);
+        assert_eq!(counters.get(labels, "bytes"), 4096);
+        assert_eq!(counters.get(labels, "errors"), 1);
+        assert_eq!(counters.values(labels), vec![1, 4096, 1]);
+        assert_eq!(counters.sum_all(), 4098);
+    }
+
+    #[test]
+    fn dynamic_counter_set_label_order_is_canonicalized() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests"]);
+
+        counters.inc(&[("org", "eden"), ("endpoint", "ingest")], "requests");
+
+        assert_eq!(
+            counters.get(&[("endpoint", "ingest"), ("org", "eden")], "requests"),
+            1
+        );
+    }
+
+    #[test]
+    fn dynamic_counter_set_series_handle_supports_index_updates() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests", "bytes", "errors"]);
+        let requests = counters.counter_index("requests").unwrap();
+        let bytes = counters.counter_index("bytes").unwrap();
+        let errors = counters.counter_index("errors").unwrap();
+        let series = counters.series(&[("org", "eden")]);
+
+        series.add_index_values(&[(requests, 2), (bytes, 512)]);
+        series.add_index(errors, 1);
+
+        assert_eq!(series.values(), vec![2, 512, 1]);
+        assert_eq!(counters.values(&[("org", "eden")]), vec![2, 512, 1]);
+    }
+
+    #[test]
+    fn dynamic_counter_set_add_all_values_uses_index_order() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests", "bytes", "errors"]);
+
+        counters.add_all_values(&[("org", "eden")], &[1, 1024, 0]);
+
+        assert_eq!(counters.values(&[("org", "eden")]), vec![1, 1024, 0]);
+    }
+
+    #[test]
+    fn dynamic_counter_set_snapshot_and_reset_returns_all_series() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests", "bytes"]);
+
+        counters.add_all_values(&[("org", "eden")], &[2, 10]);
+        counters.add_all_values(&[("org", "acme")], &[3, 15]);
+
+        let mut snapshot = counters.snapshot_and_reset();
+        snapshot.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(
+            snapshot[0].0.pairs()[0],
+            ("org".to_string(), "acme".to_string())
+        );
+        assert_eq!(snapshot[0].1, vec![3, 15]);
+        assert_eq!(
+            snapshot[1].0.pairs()[0],
+            ("org".to_string(), "eden".to_string())
+        );
+        assert_eq!(snapshot[1].1, vec![2, 10]);
+        assert_eq!(counters.sum_all(), 0);
+    }
+
+    #[test]
+    fn dynamic_counter_set_sum_and_reset_resets_one_counter_across_series() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests", "bytes"]);
+        let requests = counters.counter_index("requests").unwrap();
+
+        counters.add_all_values(&[("org", "eden")], &[2, 10]);
+        counters.add_all_values(&[("org", "acme")], &[3, 15]);
+
+        assert_eq!(counters.sum_and_reset(requests), 5);
+        assert_eq!(counters.values(&[("org", "eden")]), vec![0, 10]);
+        assert_eq!(counters.values(&[("org", "acme")]), vec![0, 15]);
+    }
+
+    #[test]
+    fn dynamic_counter_set_visit_series_exposes_counter_names() {
+        let counters = DynamicCounterSet::with_shards(4, ["requests", "bytes"]);
+        counters.add_all_values(&[("org", "eden")], &[2, 10]);
+
+        let mut visited = Vec::new();
+        counters.visit_series(|counter, labels, value| {
+            visited.push((counter.to_string(), labels.to_vec(), value));
+        });
+        visited.sort_by(|left, right| left.0.cmp(&right.0));
+
+        assert_eq!(visited.len(), 2);
+        assert_eq!(visited[0].0, "bytes");
+        assert_eq!(visited[0].2, 10);
+        assert_eq!(visited[1].0, "requests");
+        assert_eq!(visited[1].2, 2);
+    }
+
+    #[test]
+    fn dynamic_counter_set_overflow_bucket_routes_new_series_at_capacity() {
+        let counters = DynamicCounterSet::with_max_series(4, 2, ["requests"]);
+
+        counters.inc(&[("org", "1")], "requests");
+        counters.inc(&[("org", "2")], "requests");
+        counters.inc(&[("org", "3")], "requests");
+
+        assert_eq!(counters.cardinality(), 3);
+        assert_eq!(
+            counters.get(&[(OVERFLOW_LABEL_KEY, OVERFLOW_LABEL_VALUE)], "requests"),
+            1
+        );
+        assert!(counters.overflow_count() > 0);
+    }
+
+    #[test]
+    fn dynamic_counter_set_concurrent_index_updates() {
+        let counters = Arc::new(DynamicCounterSet::with_shards(
+            8,
+            ["requests", "bytes", "errors"],
+        ));
+        let requests = counters.counter_index("requests").unwrap();
+        let bytes = counters.counter_index("bytes").unwrap();
+
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let counters = Arc::clone(&counters);
+                scope.spawn(move || {
+                    let series = counters.series(&[("org", "eden")]);
+                    for _ in 0..10_000 {
+                        series.add_index_values(&[(requests, 1), (bytes, 2)]);
+                    }
+                });
+            }
+        });
+
+        assert_eq!(counters.get(&[("org", "eden")], "requests"), 80_000);
+        assert_eq!(counters.get(&[("org", "eden")], "bytes"), 160_000);
+    }
+
+    #[cfg(feature = "eviction")]
+    #[test]
+    fn dynamic_counter_set_eviction_tombstone_invalidates_cache() {
+        let _cycle_guard = lock_eviction_cycle_for_test();
+        let counters = DynamicCounterSet::with_shards(4, ["requests"]);
+        let labels = &[("org", "eden")];
+
+        counters.inc(labels, "requests");
+        counters.inc(labels, "requests");
+        assert_eq!(counters.get(labels, "requests"), 2);
+
+        advance_cycle();
+        advance_cycle();
+        counters.inc(&[("flush", "cache")], "requests");
+        assert_eq!(counters.evict_stale(1), 1);
+
+        counters.inc(labels, "requests");
+        assert_eq!(counters.get(labels, "requests"), 1);
+    }
+}

--- a/crates/fast-telemetry/src/metric/dynamic/mod.rs
+++ b/crates/fast-telemetry/src/metric/dynamic/mod.rs
@@ -12,12 +12,14 @@
 
 mod cache;
 mod counter;
+mod counter_set;
 mod distribution;
 mod gauge;
 mod gauge_i64;
 mod histogram;
 
 pub use counter::{DynamicCounter, DynamicCounterSeries};
+pub use counter_set::{DynamicCounterSet, DynamicCounterSetSeries};
 pub use distribution::{DynamicDistribution, DynamicDistributionSeries};
 pub use gauge::{DynamicGauge, DynamicGaugeSeries};
 pub use gauge_i64::{DynamicGaugeI64, DynamicGaugeI64Series};

--- a/crates/fast-telemetry/src/metric/mod.rs
+++ b/crates/fast-telemetry/src/metric/mod.rs
@@ -18,9 +18,10 @@ mod visitor;
 pub use counter::{Counter, CounterSet, CounterSetBuffer};
 pub use distribution::Distribution;
 pub use dynamic::{
-    DynamicCounter, DynamicCounterSeries, DynamicDistribution, DynamicDistributionSeries,
-    DynamicGauge, DynamicGaugeI64, DynamicGaugeI64Series, DynamicGaugeSeries, DynamicHistogram,
-    DynamicHistogramSeries, DynamicHistogramSeriesView, DynamicLabelSet,
+    DynamicCounter, DynamicCounterSeries, DynamicCounterSet, DynamicCounterSetSeries,
+    DynamicDistribution, DynamicDistributionSeries, DynamicGauge, DynamicGaugeI64,
+    DynamicGaugeI64Series, DynamicGaugeSeries, DynamicHistogram, DynamicHistogramSeries,
+    DynamicHistogramSeriesView, DynamicLabelSet,
 };
 #[cfg(feature = "eviction")]
 pub use dynamic::{advance_cycle, current_cycle};

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -212,7 +212,7 @@ sweep and then sum each dynamic metric's `evict_stale(...)` result.
 enable the export crate's `monoio` feature for monoio-native loops:
 
 ```toml
-fast-telemetry-export = { version = "0.7", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.8", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 Use `dogstatsd::run_monoio(...)`, `otlp::run_monoio(...)`, and

--- a/docs/metrics-and-spans.md
+++ b/docs/metrics-and-spans.md
@@ -76,6 +76,66 @@ threshold. `inc_all()`, `add_all(...)`, and `add_values(...)` finish the
 operation automatically. Buffers flush on drop, but explicit `flush()` is useful
 before export or at request/task boundaries when fresh totals matter.
 
+For delta collectors, `CounterSet` can return and reset the current window:
+
+```rust
+let window = counters.snapshot_and_reset();
+let request_delta = counters.sum_and_reset(REQUESTS);
+```
+
+Concurrent writes may move into the next window, matching `Counter::swap()`
+semantics. Counts are not lost.
+
+## Dynamic Grouped Counters
+
+Use dynamic grouped counters when one hot-path operation updates related
+counters for a label set discovered at runtime, such as org/endpoint/outcome
+gateway metrics.
+
+```rust
+use fast_telemetry::DynamicCounterSet;
+
+let counters = DynamicCounterSet::with_shards(
+    4,
+    ["requests", "bytes", "errors"],
+);
+
+let requests = counters.counter_index("requests").unwrap();
+let bytes = counters.counter_index("bytes").unwrap();
+let errors = counters.counter_index("errors").unwrap();
+
+let series = counters.get_or_create(&[
+    ("org", "eden"),
+    ("endpoint", "ingest"),
+    ("outcome", "ok"),
+]);
+
+series.add_index_values(&[(requests, 1), (bytes, 4096)]);
+
+if false {
+    series.add_index(errors, 1);
+}
+```
+
+`DynamicCounterSet` also has name-based helpers such as
+`add_values(labels, &[("requests", 1), ("bytes", bytes)])`, but production hot
+paths should resolve indexes once and use `DynamicCounterSetSeries` handles.
+
+For windowed export, use `snapshot_and_reset()` to collect one row per dynamic
+label set:
+
+```rust
+for (labels, values) in counters.snapshot_and_reset() {
+    let _ = (labels, values);
+}
+```
+
+For cumulative custom export, `visit_series(...)` walks each
+`(counter_name, labels, value)` observation without cloning label sets.
+
+Like other dynamic metrics, `with_max_series(...)` bounds cardinality and routes
+new label sets to `__ft_overflow=true` after the cap is reached.
+
 ## Labeled Metrics
 
 ### Compile-Time Labels (O(1) array lookup)
@@ -124,7 +184,8 @@ Dynamic metrics are useful when the active label set is only known at runtime,
 but they come with a lifecycle worth planning for:
 
 - `with_max_series(...)` bounds cardinality for `DynamicCounter`,
-  `DynamicDistribution`, `DynamicGauge`, and `DynamicGaugeI64`
+  `DynamicCounterSet`, `DynamicDistribution`, `DynamicGauge`, and
+  `DynamicGaugeI64`
 - `DynamicHistogram::with_limits(..., max_series)` provides the same cap for histograms
 - once the cap is hit, new label sets are redirected into a single overflow series
   and `overflow_count()` tells you how often that happened

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,6 +9,7 @@
 | `Counter`            | Totals that only go up                   | ~2ns (thread-local write) |
 | `CounterSet`         | Fixed groups of related counters         | ~0.2-0.4ns per buffered increment in grouped workloads |
 | `CounterSetBuffer`   | Local deltas for `CounterSet`            | Flushes to shared atomics every configured operation count |
+| `DynamicCounterSet`  | Runtime-labeled groups of related counters | One label lookup per cached series, then direct indexed updates |
 | `Histogram`          | Latency distributions with fixed buckets | ~2ns + bucket lookup      |
 | `Distribution`       | Exponential-bucket distributions         | ~2ns + bucket lookup      |
 | `Gauge` / `GaugeF64` | Point-in-time values                     | ~2ns (single atomic)      |
@@ -22,10 +23,11 @@
 | `LabeledCounter<L>`                | Compile-time enum, O(1) array index |
 | `LabeledHistogram<L>`              | Compile-time enum, O(1) array index |
 | `LabeledGauge<L>`                  | Compile-time enum, O(1) array index |
-| `DynamicCounter`                   | Runtime labels, HashMap lookup      |
-| `DynamicHistogram`                 | Runtime labels, HashMap lookup      |
-| `DynamicDistribution`              | Runtime labels, HashMap lookup      |
-| `DynamicGauge` / `DynamicGaugeI64` | Runtime labels, HashMap lookup      |
+| `DynamicCounter`                   | Runtime labels, dynamic index lookup |
+| `DynamicCounterSet`                | Runtime labels plus grouped counter indexes |
+| `DynamicHistogram`                 | Runtime labels, dynamic index lookup |
+| `DynamicDistribution`              | Runtime labels, dynamic index lookup |
+| `DynamicGauge` / `DynamicGaugeI64` | Runtime labels, dynamic index lookup |
 
 ### Derive Macros
 
@@ -55,6 +57,10 @@ Pass the number of shards to `Counter::new(n)` and other constructors:
 For `CounterSet::new(shards, counters)`, `counters` is the fixed number of
 related counter slots in each shard row. Store slot indexes as constants or enum
 discriminants so hot paths do not perform name lookup.
+
+For `DynamicCounterSet::with_shards(shards, names)`, resolve both the dynamic
+series handle and the counter indexes before entering the hot path. Use
+`snapshot_and_reset()` or `sum_and_reset(index)` for windowed delta collectors.
 
 ## Lineage
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -10,7 +10,7 @@ registration and a shared span collector so export setup happens once.
 
 ```toml
 [dependencies]
-fast-telemetry = { version = "0.7", features = ["runtime"] }
+fast-telemetry = { version = "0.8", features = ["runtime"] }
 ```
 
 ```rust


### PR DESCRIPTION
Adds DynamicCounterSet for runtime-labeled grouped counter updates and resettable CounterSet snapshots for the 0.8.0 release, closing #36.