### PR TITLE
fix: prepare 0.8.1 logging fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-features -- -D warnings
+      - run: cargo clippy -p fast-telemetry-export --no-default-features -- -D warnings
+      - run: cargo clippy -p fast-telemetry-export --no-default-features --features monoio -- -D warnings
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.8.0" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.8.0" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.8.0" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.8.1" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.8.1" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.8.1" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"
@@ -32,7 +32,7 @@ quote = "1"
 syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 
 # --- Export: fast-telemetry-export runtime dependencies ---
-log = "0.4"
+eden_logger = { version = "0.1.1", default-features = false, features = ["log-debug", "log-info", "log-warn", "log-error", "log-internal"] }
 compio = { version = "0.18", default-features = false }
 futures-util = "0.3"
 memchr = "2"                                                              # dogstatsd feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ quote = "1"
 syn = { version = "2", features = ["extra-traits", "full", "parsing"] }
 
 # --- Export: fast-telemetry-export runtime dependencies ---
-eden_logger = { version = "0.1.1", default-features = false, features = ["log-debug", "log-info", "log-warn", "log-error", "log-internal"] }
+eden_logger = { version = "0.1.1", default-features = false }
 compio = { version = "0.18", default-features = false }
 futures-util = "0.3"
 memchr = "2"                                                              # dogstatsd feature

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,8 +18,10 @@ Highlights:
   a repeated warning on every delta export; it remains observable through the exported
   `__ft_overflow=true` series, each dynamic metric's `overflow_count()`, and
   `MetricVisitor::dynamic_overflow(...)`.
-- Replaced direct `log` facade calls in `fast-telemetry-export` with `eden_logger` internal-audience
-  logs for DogStatsD, OTLP metrics, span export, ClickHouse export, and stale-series sweeping.
+- Replaced direct `log` facade calls in `fast-telemetry-export` with opt-in `eden_logger`
+  internal-audience diagnostics for DogStatsD, OTLP metrics, span export, ClickHouse export,
+  and stale-series sweeping. Enable the `logging` feature for info/warn/error diagnostics and
+  `logging-debug` for debug output; exporters remain quiet by default.
 
 Install:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,11 +2,32 @@
 
 ## Unreleased
 
+## 0.8.1 - 2026-07-22
+
+Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.
+
+Why this is a 0.8.1 patch:
+
+- this release fixes a downstream compile-time dependency leak in derive-generated DogStatsD delta export methods.
+- `fast-telemetry-export` now uses `eden_logger` for internal exporter diagnostics instead of the `log` facade.
+
+Highlights:
+
 - Fixed `ExportMetrics` dynamic-metric expansion so downstream crates no longer need a direct
   `log` dependency to compile DogStatsD delta export methods. Cardinality overflow no longer emits
   a repeated warning on every delta export; it remains observable through the exported
   `__ft_overflow=true` series, each dynamic metric's `overflow_count()`, and
   `MetricVisitor::dynamic_overflow(...)`.
+- Replaced direct `log` facade calls in `fast-telemetry-export` with `eden_logger` internal-audience
+  logs for DogStatsD, OTLP metrics, span export, ClickHouse export, and stale-series sweeping.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = "0.8.1"
+fast-telemetry-export = "0.8.1"
+```
 
 ## 0.8.0 - 2026-07-09
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Fixed `ExportMetrics` dynamic-metric expansion so downstream crates no longer need a direct
+  `log` dependency to compile DogStatsD delta export methods. Cardinality overflow no longer emits
+  a repeated warning on every delta export; it remains observable through the exported
+  `__ft_overflow=true` series, each dynamic metric's `overflow_count()`, and
+  `MetricVisitor::dynamic_overflow(...)`.
+
 ## 0.8.0 - 2026-07-09
 
 Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -23,11 +23,13 @@ otlp = ["dep:flate2", "dep:prost", "dep:reqwest", "fast-telemetry/otlp", "tokio-
 clickhouse = ["dep:klickhouse", "dep:indexmap", "fast-telemetry/otlp", "fast-telemetry/clickhouse", "tokio-runtime"]
 monoio = ["dep:monoio", "tokio-runtime"]
 compio = ["dep:compio", "dep:futures-util", "dep:memchr"]
+logging = ["dep:eden_logger", "eden_logger/log-info", "eden_logger/log-warn", "eden_logger/log-error", "eden_logger/log-internal"]
+logging-debug = ["logging", "eden_logger/log-debug"]
 
 [dependencies]
 compio = { workspace = true, features = ["runtime", "io", "net", "time", "io-uring"], optional = true }
 futures-util = { workspace = true, optional = true }
-eden_logger = { workspace = true }
+eden_logger = { workspace = true, optional = true }
 memchr = { workspace = true, optional = true }
 monoio = { workspace = true, optional = true }
 fast-telemetry = { workspace = true }

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true
@@ -27,7 +27,7 @@ compio = ["dep:compio", "dep:futures-util", "dep:memchr"]
 [dependencies]
 compio = { workspace = true, features = ["runtime", "io", "net", "time", "io-uring"], optional = true }
 futures-util = { workspace = true, optional = true }
-log = { workspace = true }
+eden_logger = { workspace = true }
 memchr = { workspace = true, optional = true }
 monoio = { workspace = true, optional = true }
 fast-telemetry = { workspace = true }

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -20,6 +20,14 @@ This crate provides:
 | `clickhouse` |         | Native-TCP ClickHouse exporter — first-party rows, generic primitive, and OTel schema |
 | `monoio`     |         | Monoio-native DogStatsD, OTLP HTTP/protobuf, sweeper, and span-flush helper          |
 | `compio`     |         | Compio-native DogStatsD and sweeper; span-flush helper with `otlp`                   |
+| `logging`    |         | Internal exporter info, warning, and error diagnostics through `eden_logger`         |
+| `logging-debug` |      | Adds debug diagnostics; also enables `logging`                                       |
+
+Exporter logging is opt-in so the crate does not write to stderr or bypass the
+application's logging setup by default. Enable `logging` to emit internal
+diagnostics through `eden_logger`; add `logging-debug` when per-export debug
+messages are useful. Runtime filtering follows `eden_logger`'s
+`EDEN_LOG_LEVEL` configuration.
 
 The ClickHouse exporter ships two layers:
 

--- a/crates/fast-telemetry-export/src/clickhouse/mod.rs
+++ b/crates/fast-telemetry-export/src/clickhouse/mod.rs
@@ -219,7 +219,7 @@ pub async fn run<R, F, T>(
         qualified_table(&config.database, &table)
     );
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting ClickHouse exporter, endpoint={}, table={}.{}, interval={}s",
         config.endpoint,
         config.database,
@@ -230,7 +230,7 @@ pub async fn run<R, F, T>(
     let mut client = match connect(&config).await {
         Ok(c) => c,
         Err(e) => {
-            log::error!(
+            crate::logging::log_error!(
                 "Failed to connect to ClickHouse at {}: {e}",
                 config.endpoint
             );
@@ -249,7 +249,7 @@ pub async fn run<R, F, T>(
         tokio::select! {
             _ = interval_timer.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("ClickHouse exporter shutting down, performing final export");
+                crate::logging::log_info!("ClickHouse exporter shutting down, performing final export");
                 let _ = export_once(
                     &client,
                     &query,
@@ -263,7 +263,7 @@ pub async fn run<R, F, T>(
 
         if consecutive_failures > 0 {
             let backoff = backoff_with_jitter(consecutive_failures);
-            log::debug!(
+            crate::logging::log_debug!(
                 "ClickHouse export backing off {}ms (failures={consecutive_failures})",
                 backoff.as_millis()
             );
@@ -285,12 +285,12 @@ pub async fn run<R, F, T>(
         if client.is_closed() {
             match connect(&config).await {
                 Ok(c) => {
-                    log::info!("Reconnected to ClickHouse");
+                    crate::logging::log_info!("Reconnected to ClickHouse");
                     client = c;
                 }
                 Err(e) => {
                     consecutive_failures = consecutive_failures.saturating_add(1);
-                    log::warn!("ClickHouse reconnect failed: {e}");
+                    crate::logging::log_warn!("ClickHouse reconnect failed: {e}");
                     continue;
                 }
             }
@@ -308,11 +308,11 @@ pub async fn run<R, F, T>(
             Ok(0) => {}
             Ok(n) => {
                 consecutive_failures = 0;
-                log::debug!("Exported {n} rows to ClickHouse");
+                crate::logging::log_debug!("Exported {n} rows to ClickHouse");
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!("ClickHouse insert failed: {e}");
+                crate::logging::log_warn!("ClickHouse insert failed: {e}");
             }
         }
     }

--- a/crates/fast-telemetry-export/src/clickhouse/otel_standard.rs
+++ b/crates/fast-telemetry-export/src/clickhouse/otel_standard.rs
@@ -673,7 +673,7 @@ pub async fn run<F>(config: OtelStandardConfig, cancel: CancellationToken, mut c
 where
     F: FnMut(&mut Vec<pb::Metric>),
 {
-    log::info!(
+    crate::logging::log_info!(
         "Starting ClickHouse OTel-standard exporter, endpoint={}, database={}, interval={}s",
         config.clickhouse.endpoint,
         config.clickhouse.database,
@@ -689,7 +689,7 @@ where
     let mut client = match connect_and_prepare(&config).await {
         Ok(c) => c,
         Err(e) => {
-            log::error!(
+            crate::logging::log_error!(
                 "Failed to connect to ClickHouse at {} or create ClickHouse metric tables: {e}",
                 config.clickhouse.endpoint
             );
@@ -709,7 +709,7 @@ where
         tokio::select! {
             _ = interval_timer.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("ClickHouse OTel-standard exporter shutting down, performing final export");
+                crate::logging::log_info!("ClickHouse OTel-standard exporter shutting down, performing final export");
                 let _ = export_once(
                     &client,
                     &config,
@@ -724,7 +724,7 @@ where
 
         if consecutive_failures > 0 {
             let backoff = backoff_with_jitter(consecutive_failures);
-            log::debug!(
+            crate::logging::log_debug!(
                 "ClickHouse export backing off {}ms (failures={consecutive_failures})",
                 backoff.as_millis()
             );
@@ -747,12 +747,12 @@ where
         if client.is_closed() {
             match connect(&config.clickhouse).await {
                 Ok(c) => {
-                    log::info!("Reconnected to ClickHouse");
+                    crate::logging::log_info!("Reconnected to ClickHouse");
                     client = c;
                 }
                 Err(e) => {
                     consecutive_failures = consecutive_failures.saturating_add(1);
-                    log::warn!("ClickHouse reconnect failed: {e}");
+                    crate::logging::log_warn!("ClickHouse reconnect failed: {e}");
                     continue;
                 }
             }
@@ -781,11 +781,11 @@ where
         match insert_batches(&client, &config, &mut batches).await {
             Ok(_) => {
                 consecutive_failures = 0;
-                log::debug!("Exported {row_count} rows to ClickHouse");
+                crate::logging::log_debug!("Exported {row_count} rows to ClickHouse");
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!("ClickHouse insert failed: {e}");
+                crate::logging::log_warn!("ClickHouse insert failed: {e}");
             }
         }
     }
@@ -807,7 +807,7 @@ pub async fn run_first_party<F>(
 ) where
     F: FnMut(&mut ClickHouseMetricBatch, u64),
 {
-    log::info!(
+    crate::logging::log_info!(
         "Starting first-party ClickHouse OTel-standard exporter, endpoint={}, database={}, interval={}s",
         config.clickhouse.endpoint,
         config.clickhouse.database,
@@ -817,7 +817,7 @@ pub async fn run_first_party<F>(
     let mut client = match connect_and_prepare(&config).await {
         Ok(c) => c,
         Err(e) => {
-            log::error!(
+            crate::logging::log_error!(
                 "Failed to connect to ClickHouse at {} or create ClickHouse metric tables: {e}",
                 config.clickhouse.endpoint
             );
@@ -841,7 +841,7 @@ pub async fn run_first_party<F>(
         tokio::select! {
             _ = interval_timer.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("First-party ClickHouse exporter shutting down, performing final export");
+                crate::logging::log_info!("First-party ClickHouse exporter shutting down, performing final export");
                 let _ = export_first_party_once(
                     &client,
                     &config,
@@ -854,7 +854,7 @@ pub async fn run_first_party<F>(
 
         if consecutive_failures > 0 {
             let backoff = backoff_with_jitter(consecutive_failures);
-            log::debug!(
+            crate::logging::log_debug!(
                 "ClickHouse export backing off {}ms (failures={consecutive_failures})",
                 backoff.as_millis()
             );
@@ -875,12 +875,12 @@ pub async fn run_first_party<F>(
         if client.is_closed() {
             match connect(&config.clickhouse).await {
                 Ok(c) => {
-                    log::info!("Reconnected to ClickHouse");
+                    crate::logging::log_info!("Reconnected to ClickHouse");
                     client = c;
                 }
                 Err(e) => {
                     consecutive_failures = consecutive_failures.saturating_add(1);
-                    log::warn!("ClickHouse reconnect failed: {e}");
+                    crate::logging::log_warn!("ClickHouse reconnect failed: {e}");
                     continue;
                 }
             }
@@ -896,11 +896,11 @@ pub async fn run_first_party<F>(
         match insert_metric_batch(&client, &config, &mut batch).await {
             Ok(_) => {
                 consecutive_failures = 0;
-                log::debug!("Exported {row_count} rows to ClickHouse");
+                crate::logging::log_debug!("Exported {row_count} rows to ClickHouse");
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!("ClickHouse insert failed: {e}");
+                crate::logging::log_warn!("ClickHouse insert failed: {e}");
             }
         }
     }
@@ -937,7 +937,7 @@ where
     }
 
     if let Err(e) = insert_batches(client, config, batches).await {
-        log::warn!("Final ClickHouse insert failed: {e}");
+        crate::logging::log_warn!("Final ClickHouse insert failed: {e}");
         return Err(e);
     }
     Ok(())
@@ -959,7 +959,7 @@ where
     }
 
     if let Err(e) = insert_metric_batch(client, config, batch).await {
-        log::warn!("Final ClickHouse insert failed: {e}");
+        crate::logging::log_warn!("Final ClickHouse insert failed: {e}");
         return Err(e);
     }
     Ok(())

--- a/crates/fast-telemetry-export/src/dogstatsd.rs
+++ b/crates/fast-telemetry-export/src/dogstatsd.rs
@@ -92,18 +92,18 @@ pub async fn run<F>(
     use tokio::net::UdpSocket;
     use tokio::time::MissedTickBehavior;
 
-    log::info!("Starting DogStatsD exporter, endpoint={}", config.endpoint);
+    crate::logging::log_info!("Starting DogStatsD exporter, endpoint={}", config.endpoint);
 
     let socket = match UdpSocket::bind("0.0.0.0:0").await {
         Ok(s) => s,
         Err(e) => {
-            log::error!("Failed to bind UDP socket for DogStatsD export: {e}");
+            crate::logging::log_error!("Failed to bind UDP socket for DogStatsD export: {e}");
             return;
         }
     };
 
     if let Err(e) = socket.connect(&config.endpoint).await {
-        log::error!("Failed to connect UDP socket to {}: {e}", config.endpoint);
+        crate::logging::log_error!("Failed to connect UDP socket to {}: {e}", config.endpoint);
         return;
     }
 
@@ -119,7 +119,7 @@ pub async fn run<F>(
         tokio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("DogStatsD exporter shutting down");
+                crate::logging::log_info!("DogStatsD exporter shutting down");
                 return;
             }
         }
@@ -146,7 +146,7 @@ pub async fn run<F>(
             metric_count += 1;
 
             if line_len > max_packet_size {
-                log::warn!(
+                crate::logging::log_warn!(
                     "Dropping oversized metric line ({line_len} bytes, max {max_packet_size})"
                 );
                 start = end;
@@ -159,7 +159,7 @@ pub async fn run<F>(
                         total_sent += n;
                         batch_count += 1;
                     }
-                    Err(e) => log::warn!("Failed to send DogStatsD batch: {e}"),
+                    Err(e) => crate::logging::log_warn!("Failed to send DogStatsD batch: {e}"),
                 }
                 batch.clear();
             }
@@ -181,13 +181,13 @@ pub async fn run<F>(
                             total_sent += n;
                             batch_count += 1;
                         }
-                        Err(e) => log::warn!("Failed to send DogStatsD batch: {e}"),
+                        Err(e) => crate::logging::log_warn!("Failed to send DogStatsD batch: {e}"),
                     }
                     batch.clear();
                 }
                 batch.extend_from_slice(line);
             } else {
-                log::warn!("Dropping oversized trailing metric ({line_len} bytes)");
+                crate::logging::log_warn!("Dropping oversized trailing metric ({line_len} bytes)");
             }
         }
 
@@ -197,11 +197,11 @@ pub async fn run<F>(
                     total_sent += n;
                     batch_count += 1;
                 }
-                Err(e) => log::warn!("Failed to send final DogStatsD batch: {e}"),
+                Err(e) => crate::logging::log_warn!("Failed to send final DogStatsD batch: {e}"),
             }
         }
 
-        log::debug!(
+        crate::logging::log_debug!(
             "DogStatsD export: {metric_count} metrics, {batch_count} batches, {total_sent} bytes"
         );
     }
@@ -225,7 +225,7 @@ pub async fn run_monoio<F>(
     use monoio::net::udp::UdpSocket;
     use monoio::time::MissedTickBehavior;
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting monoio DogStatsD exporter, endpoint={}",
         config.endpoint
     );
@@ -234,12 +234,12 @@ pub async fn run_monoio<F>(
         Ok(mut addrs) => match addrs.next() {
             Some(addr) => addr,
             None => {
-                log::error!("DogStatsD endpoint resolved to no addresses");
+                crate::logging::log_error!("DogStatsD endpoint resolved to no addresses");
                 return;
             }
         },
         Err(e) => {
-            log::error!(
+            crate::logging::log_error!(
                 "Failed to resolve DogStatsD endpoint {}: {e}",
                 config.endpoint
             );
@@ -258,13 +258,15 @@ pub async fn run_monoio<F>(
     let socket = match UdpSocket::bind(bind_addr) {
         Ok(s) => s,
         Err(e) => {
-            log::error!("Failed to bind monoio UDP socket for DogStatsD export: {e}");
+            crate::logging::log_error!(
+                "Failed to bind monoio UDP socket for DogStatsD export: {e}"
+            );
             return;
         }
     };
 
     if let Err(e) = socket.connect(endpoint).await {
-        log::error!("Failed to connect monoio UDP socket to {endpoint}: {e}");
+        crate::logging::log_error!("Failed to connect monoio UDP socket to {endpoint}: {e}");
         return;
     }
 
@@ -280,7 +282,7 @@ pub async fn run_monoio<F>(
         monoio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("monoio DogStatsD exporter shutting down");
+                crate::logging::log_info!("monoio DogStatsD exporter shutting down");
                 return;
             }
         }
@@ -307,7 +309,7 @@ pub async fn run_monoio<F>(
             metric_count += 1;
 
             if line_len > max_packet_size {
-                log::warn!(
+                crate::logging::log_warn!(
                     "Dropping oversized metric line ({line_len} bytes, max {max_packet_size})"
                 );
                 start = end;
@@ -341,7 +343,7 @@ pub async fn run_monoio<F>(
                 }
                 batch.extend_from_slice(line);
             } else {
-                log::warn!("Dropping oversized trailing metric ({line_len} bytes)");
+                crate::logging::log_warn!("Dropping oversized trailing metric ({line_len} bytes)");
             }
         }
 
@@ -352,7 +354,7 @@ pub async fn run_monoio<F>(
             batch_count += 1;
         }
 
-        log::debug!(
+        crate::logging::log_debug!(
             "monoio DogStatsD export: {metric_count} metrics, {batch_count} batches, {total_sent} bytes"
         );
     }
@@ -377,7 +379,7 @@ pub async fn run_compio<F>(
     use compio::net::UdpSocket;
     use futures_util::{FutureExt as _, select};
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting compio DogStatsD exporter, endpoint={}",
         config.endpoint
     );
@@ -386,12 +388,12 @@ pub async fn run_compio<F>(
         Ok(mut addrs) => match addrs.next() {
             Some(addr) => addr,
             None => {
-                log::error!("DogStatsD endpoint resolved to no addresses");
+                crate::logging::log_error!("DogStatsD endpoint resolved to no addresses");
                 return;
             }
         },
         Err(e) => {
-            log::error!(
+            crate::logging::log_error!(
                 "Failed to resolve DogStatsD endpoint {}: {e}",
                 config.endpoint
             );
@@ -410,13 +412,15 @@ pub async fn run_compio<F>(
     let socket = match UdpSocket::bind(bind_addr).await {
         Ok(s) => s,
         Err(e) => {
-            log::error!("Failed to bind compio UDP socket for DogStatsD export: {e}");
+            crate::logging::log_error!(
+                "Failed to bind compio UDP socket for DogStatsD export: {e}"
+            );
             return;
         }
     };
 
     if let Err(e) = socket.connect(endpoint).await {
-        log::error!("Failed to connect compio UDP socket to {endpoint}: {e}");
+        crate::logging::log_error!("Failed to connect compio UDP socket to {endpoint}: {e}");
         return;
     }
 
@@ -435,7 +439,7 @@ pub async fn run_compio<F>(
         select! {
             _ = tick.fuse() => {},
             _ = cancel.as_mut() => {
-                log::info!("compio DogStatsD exporter shutting down");
+                crate::logging::log_info!("compio DogStatsD exporter shutting down");
                 return;
             }
         }
@@ -462,7 +466,7 @@ pub async fn run_compio<F>(
             metric_count += 1;
 
             if line_len > max_packet_size {
-                log::warn!(
+                crate::logging::log_warn!(
                     "Dropping oversized metric line ({line_len} bytes, max {max_packet_size})"
                 );
                 start = end;
@@ -496,7 +500,7 @@ pub async fn run_compio<F>(
                 }
                 batch.extend_from_slice(line);
             } else {
-                log::warn!("Dropping oversized trailing metric ({line_len} bytes)");
+                crate::logging::log_warn!("Dropping oversized trailing metric ({line_len} bytes)");
             }
         }
 
@@ -507,7 +511,7 @@ pub async fn run_compio<F>(
             batch_count += 1;
         }
 
-        log::debug!(
+        crate::logging::log_debug!(
             "compio DogStatsD export: {metric_count} metrics, {batch_count} batches, {total_sent} bytes"
         );
     }
@@ -527,7 +531,7 @@ async fn send_monoio_batch(
     match result {
         Ok(n) => Some(n),
         Err(e) => {
-            log::warn!("Failed to send monoio {context}: {e}");
+            crate::logging::log_warn!("Failed to send monoio {context}: {e}");
             None
         }
     }
@@ -547,7 +551,7 @@ async fn send_compio_batch(
     match result {
         Ok(n) => Some(n),
         Err(e) => {
-            log::warn!("Failed to send compio {context}: {e}");
+            crate::logging::log_warn!("Failed to send compio {context}: {e}");
             None
         }
     }

--- a/crates/fast-telemetry-export/src/lib.rs
+++ b/crates/fast-telemetry-export/src/lib.rs
@@ -32,6 +32,8 @@
 //! - `monoio` — monoio-native exporter loops for monoio applications
 //! - `compio` — compio-native exporter loops for compio applications
 
+mod logging;
+
 #[cfg(feature = "clickhouse")]
 pub mod clickhouse;
 

--- a/crates/fast-telemetry-export/src/logging.rs
+++ b/crates/fast-telemetry-export/src/logging.rs
@@ -1,53 +1,86 @@
+#[allow(unused_macros)]
 macro_rules! log_debug {
     ($($arg:tt)+) => {{
-        if ::eden_logger::should_log(::eden_logger::LogLevel::Debug) {
-            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
-            ::eden_logger::log_debug!(
-                __ft_ctx,
-                ::std::format!($($arg)+),
-                audience = ::eden_logger::LogAudience::Internal
-            );
+        #[cfg(feature = "logging-debug")]
+        {
+            if ::eden_logger::should_log(::eden_logger::LogLevel::Debug) {
+                let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+                ::eden_logger::log_debug!(
+                    __ft_ctx,
+                    ::std::format!($($arg)+),
+                    audience = ::eden_logger::LogAudience::Internal
+                );
+            }
+        }
+        #[cfg(not(feature = "logging-debug"))]
+        if false {
+            let _ = ::std::format!($($arg)+);
         }
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! log_error {
     ($($arg:tt)+) => {{
-        if ::eden_logger::should_log(::eden_logger::LogLevel::Error) {
-            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
-            ::eden_logger::log_error!(
-                __ft_ctx,
-                ::std::format!($($arg)+),
-                audience = ::eden_logger::LogAudience::Internal
-            );
+        #[cfg(feature = "logging")]
+        {
+            if ::eden_logger::should_log(::eden_logger::LogLevel::Error) {
+                let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+                ::eden_logger::log_error!(
+                    __ft_ctx,
+                    ::std::format!($($arg)+),
+                    audience = ::eden_logger::LogAudience::Internal
+                );
+            }
+        }
+        #[cfg(not(feature = "logging"))]
+        if false {
+            let _ = ::std::format!($($arg)+);
         }
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! log_info {
     ($($arg:tt)+) => {{
-        if ::eden_logger::should_log(::eden_logger::LogLevel::Info) {
-            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
-            ::eden_logger::log_info!(
-                __ft_ctx,
-                ::std::format!($($arg)+),
-                audience = ::eden_logger::LogAudience::Internal
-            );
+        #[cfg(feature = "logging")]
+        {
+            if ::eden_logger::should_log(::eden_logger::LogLevel::Info) {
+                let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+                ::eden_logger::log_info!(
+                    __ft_ctx,
+                    ::std::format!($($arg)+),
+                    audience = ::eden_logger::LogAudience::Internal
+                );
+            }
+        }
+        #[cfg(not(feature = "logging"))]
+        if false {
+            let _ = ::std::format!($($arg)+);
         }
     }};
 }
 
+#[allow(unused_macros)]
 macro_rules! log_warn {
     ($($arg:tt)+) => {{
-        if ::eden_logger::should_log(::eden_logger::LogLevel::Warn) {
-            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
-            ::eden_logger::log_warn!(
-                __ft_ctx,
-                ::std::format!($($arg)+),
-                audience = ::eden_logger::LogAudience::Internal
-            );
+        #[cfg(feature = "logging")]
+        {
+            if ::eden_logger::should_log(::eden_logger::LogLevel::Warn) {
+                let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+                ::eden_logger::log_warn!(
+                    __ft_ctx,
+                    ::std::format!($($arg)+),
+                    audience = ::eden_logger::LogAudience::Internal
+                );
+            }
+        }
+        #[cfg(not(feature = "logging"))]
+        if false {
+            let _ = ::std::format!($($arg)+);
         }
     }};
 }
 
+#[allow(unused_imports)]
 pub(crate) use {log_debug, log_error, log_info, log_warn};

--- a/crates/fast-telemetry-export/src/logging.rs
+++ b/crates/fast-telemetry-export/src/logging.rs
@@ -1,0 +1,53 @@
+macro_rules! log_debug {
+    ($($arg:tt)+) => {{
+        if ::eden_logger::should_log(::eden_logger::LogLevel::Debug) {
+            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+            ::eden_logger::log_debug!(
+                __ft_ctx,
+                ::std::format!($($arg)+),
+                audience = ::eden_logger::LogAudience::Internal
+            );
+        }
+    }};
+}
+
+macro_rules! log_error {
+    ($($arg:tt)+) => {{
+        if ::eden_logger::should_log(::eden_logger::LogLevel::Error) {
+            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+            ::eden_logger::log_error!(
+                __ft_ctx,
+                ::std::format!($($arg)+),
+                audience = ::eden_logger::LogAudience::Internal
+            );
+        }
+    }};
+}
+
+macro_rules! log_info {
+    ($($arg:tt)+) => {{
+        if ::eden_logger::should_log(::eden_logger::LogLevel::Info) {
+            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+            ::eden_logger::log_info!(
+                __ft_ctx,
+                ::std::format!($($arg)+),
+                audience = ::eden_logger::LogAudience::Internal
+            );
+        }
+    }};
+}
+
+macro_rules! log_warn {
+    ($($arg:tt)+) => {{
+        if ::eden_logger::should_log(::eden_logger::LogLevel::Warn) {
+            let __ft_ctx = ::eden_logger::LogContext::<()>::new().with_feature(module_path!());
+            ::eden_logger::log_warn!(
+                __ft_ctx,
+                ::std::format!($($arg)+),
+                audience = ::eden_logger::LogAudience::Internal
+            );
+        }
+    }};
+}
+
+pub(crate) use {log_debug, log_error, log_info, log_warn};

--- a/crates/fast-telemetry-export/src/otlp.rs
+++ b/crates/fast-telemetry-export/src/otlp.rs
@@ -188,7 +188,7 @@ where
 {
     let url = format!("{}/v1/metrics", config.endpoint.trim_end_matches('/'));
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting OTLP metrics exporter, endpoint={url}, interval={}s",
         config.interval.as_secs()
     );
@@ -203,7 +203,7 @@ where
     let client = match reqwest::Client::builder().timeout(config.timeout).build() {
         Ok(c) => c,
         Err(e) => {
-            log::error!("Failed to build HTTP client for OTLP exporter: {e}");
+            crate::logging::log_error!("Failed to build HTTP client for OTLP exporter: {e}");
             return;
         }
     };
@@ -227,7 +227,7 @@ where
         tokio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("OTLP metrics exporter shutting down, performing final export");
+                crate::logging::log_info!("OTLP metrics exporter shutting down, performing final export");
                 export_once(&ctx, &mut collect_fn, &mut bufs).await;
                 return;
             }
@@ -235,7 +235,7 @@ where
 
         if consecutive_failures > 0 {
             let backoff = backoff_with_jitter(consecutive_failures);
-            log::debug!(
+            crate::logging::log_debug!(
                 "OTLP export backing off {}ms (failures={consecutive_failures})",
                 backoff.as_millis()
             );
@@ -260,7 +260,7 @@ where
 
         bufs.encode.clear();
         if let Err(e) = request.encode(&mut bufs.encode) {
-            log::warn!("OTLP protobuf encode failed: {e}");
+            crate::logging::log_warn!("OTLP protobuf encode failed: {e}");
             continue;
         }
         let body_len = bufs.encode.len();
@@ -268,17 +268,19 @@ where
         match send_otlp(&client, &url, &bufs.encode, &mut bufs.gzip, &config.headers).await {
             Ok(resp) if resp.status().is_success() => {
                 consecutive_failures = 0;
-                log::debug!("Exported {metric_count} OTLP metrics ({body_len} bytes)");
+                crate::logging::log_debug!(
+                    "Exported {metric_count} OTLP metrics ({body_len} bytes)"
+                );
             }
             Ok(resp) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
                 let status = resp.status();
                 let body = resp.text().await.unwrap_or_default();
-                log::warn!("OTLP export failed: status={status}, body={body}");
+                crate::logging::log_warn!("OTLP export failed: status={status}, body={body}");
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!("OTLP export request failed: {e}");
+                crate::logging::log_warn!("OTLP export request failed: {e}");
             }
         }
     }
@@ -304,12 +306,12 @@ where
     let target = match MonoioHttpTarget::parse(&url) {
         Ok(target) => target,
         Err(e) => {
-            log::error!("Invalid monoio OTLP endpoint {url}: {e}");
+            crate::logging::log_error!("Invalid monoio OTLP endpoint {url}: {e}");
             return;
         }
     };
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting monoio OTLP metrics exporter, endpoint={url}, interval={}s",
         config.interval.as_secs()
     );
@@ -340,7 +342,7 @@ where
         monoio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("monoio OTLP metrics exporter shutting down, performing final export");
+                crate::logging::log_info!("monoio OTLP metrics exporter shutting down, performing final export");
                 export_once_monoio(&ctx, &mut collect_fn, &mut bufs).await;
                 return;
             }
@@ -348,7 +350,7 @@ where
 
         if consecutive_failures > 0 {
             let backoff = backoff_with_jitter(consecutive_failures);
-            log::debug!(
+            crate::logging::log_debug!(
                 "monoio OTLP export backing off {}ms (failures={consecutive_failures})",
                 backoff.as_millis()
             );
@@ -373,7 +375,7 @@ where
 
         bufs.encode.clear();
         if let Err(e) = request.encode(&mut bufs.encode) {
-            log::warn!("monoio OTLP protobuf encode failed: {e}");
+            crate::logging::log_warn!("monoio OTLP protobuf encode failed: {e}");
             continue;
         }
         let body_len = bufs.encode.len();
@@ -389,11 +391,13 @@ where
         {
             Ok(resp) if resp.is_success() => {
                 consecutive_failures = 0;
-                log::debug!("Exported {metric_count} monoio OTLP metrics ({body_len} bytes)");
+                crate::logging::log_debug!(
+                    "Exported {metric_count} monoio OTLP metrics ({body_len} bytes)"
+                );
             }
             Ok(resp) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!(
+                crate::logging::log_warn!(
                     "monoio OTLP export failed: status={}, body={}",
                     resp.status,
                     resp.body_text_lossy()
@@ -401,7 +405,7 @@ where
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!("monoio OTLP export request failed: {e}");
+                crate::logging::log_warn!("monoio OTLP export request failed: {e}");
             }
         }
     }
@@ -436,7 +440,7 @@ where
 
     bufs.encode.clear();
     if let Err(e) = request.encode(&mut bufs.encode) {
-        log::warn!("Final OTLP protobuf encode failed: {e}");
+        crate::logging::log_warn!("Final OTLP protobuf encode failed: {e}");
         return;
     }
 
@@ -452,9 +456,9 @@ where
         Ok(resp) if !resp.status().is_success() => {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            log::warn!("Final OTLP export returned {status}: {body}");
+            crate::logging::log_warn!("Final OTLP export returned {status}: {body}");
         }
-        Err(e) => log::warn!("Final OTLP export failed: {e}"),
+        Err(e) => crate::logging::log_warn!("Final OTLP export failed: {e}"),
         _ => {}
     }
 }
@@ -487,7 +491,7 @@ async fn export_once_monoio<F>(
 
     bufs.encode.clear();
     if let Err(e) = request.encode(&mut bufs.encode) {
-        log::warn!("Final monoio OTLP protobuf encode failed: {e}");
+        crate::logging::log_warn!("Final monoio OTLP protobuf encode failed: {e}");
         return;
     }
 
@@ -501,13 +505,13 @@ async fn export_once_monoio<F>(
     .await
     {
         Ok(resp) if !resp.is_success() => {
-            log::warn!(
+            crate::logging::log_warn!(
                 "Final monoio OTLP export returned {}: {}",
                 resp.status,
                 resp.body_text_lossy()
             );
         }
-        Err(e) => log::warn!("Final monoio OTLP export failed: {e}"),
+        Err(e) => crate::logging::log_warn!("Final monoio OTLP export failed: {e}"),
         _ => {}
     }
 }

--- a/crates/fast-telemetry-export/src/spans.rs
+++ b/crates/fast-telemetry-export/src/spans.rs
@@ -267,7 +267,7 @@ pub async fn run(
 ) {
     let url = format!("{}/v1/traces", config.endpoint.trim_end_matches('/'));
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting OTLP span exporter, endpoint={url}, service={}",
         config.service_name
     );
@@ -282,7 +282,7 @@ pub async fn run(
     let client = match reqwest::Client::builder().timeout(config.timeout).build() {
         Ok(c) => c,
         Err(e) => {
-            log::error!("Failed to build HTTP client for span exporter: {e}");
+            crate::logging::log_error!("Failed to build HTTP client for span exporter: {e}");
             return;
         }
     };
@@ -310,7 +310,7 @@ pub async fn run(
         tokio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("Span exporter shutting down, performing final export");
+                crate::logging::log_info!("Span exporter shutting down, performing final export");
                 export_once(&ctx, &mut bufs).await;
                 return;
             }
@@ -318,7 +318,7 @@ pub async fn run(
 
         if consecutive_failures > 0 {
             let backoff = backoff_with_jitter(consecutive_failures);
-            log::debug!(
+            crate::logging::log_debug!(
                 "Span export backing off {}ms (failures={consecutive_failures})",
                 backoff.as_millis()
             );
@@ -344,7 +344,9 @@ pub async fn run(
         let span_count = bufs.spans.len();
 
         if dropped > 0 {
-            log::debug!("Span export dropped {dropped} excess spans (exported {span_count})");
+            crate::logging::log_debug!(
+                "Span export dropped {dropped} excess spans (exported {span_count})"
+            );
         }
 
         let otlp_spans: Vec<_> = bufs.spans.iter().map(|s| s.to_otlp()).collect();
@@ -352,7 +354,7 @@ pub async fn run(
 
         bufs.encode.clear();
         if let Err(e) = request.encode(&mut bufs.encode) {
-            log::warn!("Span protobuf encode failed: {e}");
+            crate::logging::log_warn!("Span protobuf encode failed: {e}");
             continue;
         }
 
@@ -361,17 +363,17 @@ pub async fn run(
         match send_otlp(&client, &url, &bufs.encode, &mut bufs.gzip, &config.headers).await {
             Ok(resp) if resp.status().is_success() => {
                 consecutive_failures = 0;
-                log::debug!("Exported {span_count} spans ({body_len} bytes)");
+                crate::logging::log_debug!("Exported {span_count} spans ({body_len} bytes)");
             }
             Ok(resp) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
                 let status = resp.status();
                 let body = resp.text().await.unwrap_or_default();
-                log::warn!("Span export failed: status={status}, body={body}");
+                crate::logging::log_warn!("Span export failed: status={status}, body={body}");
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                log::warn!("Span export request failed: {e}");
+                crate::logging::log_warn!("Span export request failed: {e}");
             }
         }
     }
@@ -404,7 +406,7 @@ async fn export_once(ctx: &SpanExportContext<'_>, bufs: &mut SpanExportBufs) {
 
     bufs.encode.clear();
     if let Err(e) = request.encode(&mut bufs.encode) {
-        log::warn!("Final span protobuf encode failed: {e}");
+        crate::logging::log_warn!("Final span protobuf encode failed: {e}");
         return;
     }
 
@@ -420,9 +422,9 @@ async fn export_once(ctx: &SpanExportContext<'_>, bufs: &mut SpanExportBufs) {
         Ok(resp) if !resp.status().is_success() => {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            log::warn!("Final span export returned {status}: {body}");
+            crate::logging::log_warn!("Final span export returned {status}: {body}");
         }
-        Err(e) => log::warn!("Final span export failed: {e}"),
+        Err(e) => crate::logging::log_warn!("Final span export failed: {e}"),
         _ => {}
     }
 }

--- a/crates/fast-telemetry-export/src/sweeper.rs
+++ b/crates/fast-telemetry-export/src/sweeper.rs
@@ -87,7 +87,7 @@ where
 {
     use tokio::time::MissedTickBehavior;
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting stale-series sweeper, interval={}s, eviction_threshold={}",
         config.interval.as_secs(),
         config.eviction_threshold
@@ -101,7 +101,7 @@ where
         tokio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("Stale-series sweeper shutting down");
+                crate::logging::log_info!("Stale-series sweeper shutting down");
                 return;
             }
         }
@@ -109,7 +109,7 @@ where
         let evicted = sweep_fn(config.eviction_threshold);
 
         if evicted > 0 {
-            log::debug!("Evicted {evicted} stale metric series");
+            crate::logging::log_debug!("Evicted {evicted} stale metric series");
         }
     }
 }
@@ -126,7 +126,7 @@ where
 {
     use monoio::time::MissedTickBehavior;
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting monoio stale-series sweeper, interval={}s, eviction_threshold={}",
         config.interval.as_secs(),
         config.eviction_threshold
@@ -140,7 +140,7 @@ where
         monoio::select! {
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
-                log::info!("monoio stale-series sweeper shutting down");
+                crate::logging::log_info!("monoio stale-series sweeper shutting down");
                 return;
             }
         }
@@ -148,7 +148,7 @@ where
         let evicted = sweep_fn(config.eviction_threshold);
 
         if evicted > 0 {
-            log::debug!("Evicted {evicted} stale metric series");
+            crate::logging::log_debug!("Evicted {evicted} stale metric series");
         }
     }
 }
@@ -168,7 +168,7 @@ pub async fn run_compio<F>(
 {
     use futures_util::{FutureExt as _, select};
 
-    log::info!(
+    crate::logging::log_info!(
         "Starting compio stale-series sweeper, interval={}s, eviction_threshold={}",
         config.interval.as_secs(),
         config.eviction_threshold
@@ -186,7 +186,7 @@ pub async fn run_compio<F>(
         select! {
             _ = tick.fuse() => {},
             _ = cancel.as_mut() => {
-                log::info!("compio stale-series sweeper shutting down");
+                crate::logging::log_info!("compio stale-series sweeper shutting down");
                 return;
             }
         }
@@ -194,7 +194,7 @@ pub async fn run_compio<F>(
         let evicted = sweep_fn(config.eviction_threshold);
 
         if evicted > 0 {
-            log::debug!("Evicted {evicted} stale metric series");
+            crate::logging::log_debug!("Evicted {evicted} stale metric series");
         }
     }
 }

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry-macros/src/lib.rs
+++ b/crates/fast-telemetry-macros/src/lib.rs
@@ -497,14 +497,6 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 state_fields.push(quote! { #field_name: std::collections::HashMap<fast_telemetry::DynamicLabelSet, isize>, });
                 state_inits.push(quote! { #field_name: std::collections::HashMap::new(), });
                 delta_exports.push(quote! {
-                    let overflow = self.#field_name.overflow_count();
-                    if overflow > 0 {
-                        log::warn!(
-                            "fast-telemetry: {} hit cardinality cap, {} records routed to overflow",
-                            #statsd_metric_name,
-                            overflow
-                        );
-                    }
                     let mut current_keys = std::collections::HashSet::new();
                     self.#field_name.visit_series(|labels, current| {
                         let key = fast_telemetry::DynamicLabelSet::from_canonical_pairs(labels);
@@ -577,14 +569,6 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 state_inits
                     .push(quote! { #buckets_state_field: std::collections::HashMap::new(), });
                 delta_exports.push(quote! {
-                    let overflow = self.#field_name.overflow_count();
-                    if overflow > 0 {
-                        log::warn!(
-                            "fast-telemetry: {} hit cardinality cap, {} records routed to overflow",
-                            #statsd_metric_name,
-                            overflow
-                        );
-                    }
                     let mut current_keys = std::collections::HashSet::new();
                     self.#field_name.visit_series(|labels, _count, _sum, snap| {
                         let key = fast_telemetry::DynamicLabelSet::from_canonical_pairs(labels);
@@ -645,14 +629,6 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 state_label_count_exprs.push(quote! { 0usize });
                 // Gauges are point-in-time, no delta tracking needed (always export current value)
                 delta_exports.push(quote! {
-                    let overflow = self.#field_name.overflow_count();
-                    if overflow > 0 {
-                        log::warn!(
-                            "fast-telemetry: {} hit cardinality cap, {} records routed to overflow",
-                            #statsd_metric_name,
-                            overflow
-                        );
-                    }
                     fast_telemetry::DogStatsDExport::export_dogstatsd(&self.#field_name, output, #statsd_metric_name, tags);
                 });
             }
@@ -703,14 +679,6 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 state_label_count_exprs.push(quote! { 0usize });
                 // i64 Gauges are point-in-time, no delta tracking needed (always export current value)
                 delta_exports.push(quote! {
-                    let overflow = self.#field_name.overflow_count();
-                    if overflow > 0 {
-                        log::warn!(
-                            "fast-telemetry: {} hit cardinality cap, {} records routed to overflow",
-                            #statsd_metric_name,
-                            overflow
-                        );
-                    }
                     fast_telemetry::DogStatsDExport::export_dogstatsd(&self.#field_name, output, #statsd_metric_name, tags);
                 });
             }
@@ -770,14 +738,6 @@ fn derive_export_metrics_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 state_inits.push(quote! { #count_state_field: std::collections::HashMap::new(), });
                 state_inits.push(quote! { #sum_state_field: std::collections::HashMap::new(), });
                 delta_exports.push(quote! {
-                    let overflow = self.#field_name.overflow_count();
-                    if overflow > 0 {
-                        log::warn!(
-                            "fast-telemetry: {} hit cardinality cap, {} records routed to overflow",
-                            #statsd_metric_name,
-                            overflow
-                        );
-                    }
                     let mut current_keys = std::collections::HashSet::new();
                     self.#field_name.visit_series(|labels, series| {
                         let key = fast_telemetry::DynamicLabelSet::from_canonical_pairs(labels);

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true
@@ -46,7 +46,6 @@ uuid = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 flate2 = { workspace = true }
-log = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 statsd-parser = { workspace = true }

--- a/crates/fast-telemetry/tests/dynamic_labels_test.rs
+++ b/crates/fast-telemetry/tests/dynamic_labels_test.rs
@@ -101,6 +101,22 @@ fn test_dynamic_counter_delta_export() {
     assert!(output.contains("api.requests:3|c|#endpoint_uuid:ep-1,org_id:org-a\n"));
 }
 
+#[test]
+fn test_dynamic_counter_delta_export_reports_cardinality_overflow() {
+    let metrics = DynamicMetrics {
+        requests: DynamicCounter::with_max_series(1, 1),
+    };
+    let mut state = DynamicMetricsDogStatsDState::new();
+
+    metrics.requests.inc(&[("org_id", "org-a")]);
+    metrics.requests.inc(&[("org_id", "org-b")]);
+    assert_eq!(metrics.requests.overflow_count(), 1);
+
+    let mut output = String::new();
+    metrics.export_dogstatsd_delta(&mut output, &[], &mut state);
+    assert!(output.contains("api.requests:1|c|#__ft_overflow:true\n"));
+}
+
 struct ParsedPrometheus {
     help: BTreeMap<String, String>,
     metric_type: BTreeMap<String, String>,

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -8,7 +8,5 @@ publish = false
 [dependencies]
 fast-telemetry = { workspace = true, features = ["macros", "otlp"] }
 fast-telemetry-export = { workspace = true }
-log = { workspace = true }
-env_logger = "0.11"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tokio-util = { workspace = true }

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -181,8 +181,6 @@ fn simulate_spans(collector: Arc<SpanCollector>) {
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
-
     let metrics = Arc::new(AppMetrics::new());
     let collector = Arc::new(SpanCollector::new(4, 4096));
     let cancel = CancellationToken::new();


### PR DESCRIPTION
Prepare 0.8.1 by removing the derive-generated downstream log requirement and moving fast-telemetry-export diagnostics to opt-in eden_logger features.