### PR TITLE
Add acknowledged OTLP HTTP export for logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,15 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --workspace --all-features
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -30,7 +39,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-features -- -D warnings
       - run: cargo clippy -p fast-telemetry-export --no-default-features -- -D warnings
+      - run: cargo clippy -p fast-telemetry-export --no-default-features --features otlp-logs -- -D warnings
       - run: cargo clippy -p fast-telemetry-export --no-default-features --features monoio -- -D warnings
+      - run: cargo clippy -p fast-telemetry-export --no-default-features --features compio -- -D warnings
 
   test:
     name: Test
@@ -40,6 +51,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-features
+      - run: cargo test -p fast-telemetry-export --no-default-features --features otlp-logs
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings
 
   fmt:
     name: Formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Local crates
-fast-telemetry = { path = "crates/fast-telemetry", version = "0.8.1" }
-fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.8.1" }
-fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.8.1" }
+fast-telemetry = { path = "crates/fast-telemetry", version = "0.9.0" }
+fast-telemetry-macros = { path = "crates/fast-telemetry-macros", version = "0.9.0" }
+fast-telemetry-export = { path = "crates/fast-telemetry-export", version = "0.9.0" }
 
 # --- Core: fast-telemetry runtime dependencies ---
 crossbeam-utils = "0.8"
@@ -42,6 +42,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 
 # --- OTLP: fast-telemetry + fast-telemetry-export otlp feature ---
 flate2 = "1"
+httpdate = "1"
 prost = "0.13"                                                            # pinned by opentelemetry-proto 0.30
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 
@@ -51,6 +52,7 @@ klickhouse = { version = "0.14", default-features = false, features = ["derive",
 
 # --- Dev/test/bench only ---
 criterion = { version = "0.8", features = ["async_tokio", "html_reports"] }
+hegeltest = "=0.28.2"
 metrics = "0.24.3"
 metrics-util = { version = "0.20.1", features = ["registry", "storage"] }
 opentelemetry = "0.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 homepage = "https://github.com/eden-dev-inc/fast-telemetry"
 license = "Apache-2.0"
 repository = "https://github.com/eden-dev-inc/fast-telemetry"
-rust-version = "1.90.0"
+rust-version = "1.93.0"
 
 [workspace.dependencies]
 # Local crates

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ High-performance, cache-friendly telemetry for Rust.
 
 `fast-telemetry` provides thread-sharded counters, gauges, histograms,
 distributions, lightweight spans, derive macros, and production export adapters
-for Prometheus, DogStatsD, OTLP, ClickHouse, and custom in-process visitors.
+for Prometheus, DogStatsD, acknowledged OTLP metrics/logs/traces, ClickHouse,
+and custom in-process visitors.
 
 ## Crates
 
@@ -12,21 +13,21 @@ for Prometheus, DogStatsD, OTLP, ClickHouse, and custom in-process visitors.
 | --- | --- |
 | [`fast-telemetry`](crates/fast-telemetry) | Sharded metrics, spans, and format serialization |
 | [`fast-telemetry-macros`](crates/fast-telemetry-macros) | `ExportMetrics` and `LabelEnum` derive macros |
-| [`fast-telemetry-export`](crates/fast-telemetry-export) | DogStatsD, OTLP, ClickHouse, span export, and stale-series sweeping |
+| [`fast-telemetry-export`](crates/fast-telemetry-export) | DogStatsD, acknowledged OTLP/HTTP, ClickHouse, span export, and stale-series sweeping |
 
 ## Install
 
 ```toml
 [dependencies]
-fast-telemetry = "0.7"
-fast-telemetry-export = "0.7"
+fast-telemetry = "0.9"
+fast-telemetry-export = "0.9"
 ```
 
 Enable the shared runtime when a parent service should own telemetry and pass it
 to child crates:
 
 ```toml
-fast-telemetry = { version = "0.8", features = ["runtime"] }
+fast-telemetry = { version = "0.9", features = ["runtime"] }
 ```
 
 ## Why

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,7 +21,8 @@ Highlights:
   `fast_telemetry::otlp::build_log_export_request`.
 - Added `OtlpHttpConfig`, `OtlpTlsConfig`, and `OtlpHttpClient` with custom
   headers, request timeouts, gzip, additional CA bundles, mTLS client
-  identities, `Retry-After` parsing, and structured status classification.
+  identities, `Retry-After` parsing, a standard exporter `User-Agent`, bounded
+  response bodies, and OTLP-compliant status classification.
 - Added acknowledged `export_logs`, `export_metrics`, and `export_traces`
   operations. The one-shot client returns diagnostics as values and performs
   no logging or retries, so callers can safely compose their own queueing,
@@ -31,6 +32,9 @@ Highlights:
 - Corrected metric acknowledgement accounting to count OTLP data points and
   clamp invalid collector rejection counts so accepted and rejected totals
   always conserve the number sent.
+- Restricted automatic retry classification to transport failures and OTLP's
+  429/502/503/504 statuses; partial-success responses remain acknowledged and
+  are never candidates for replay.
 - Added deterministic unit coverage, a loopback Collector test for all three
   OTLP signals, and pinned Hegel properties for status policy, gzip,
   `Retry-After`, bounded diagnostics, and acknowledgement conservation.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,47 @@
 
 ## Unreleased
 
+Planned release: `0.9.0`.
+
+Published crates: `fast-telemetry`, `fast-telemetry-macros`,
+`fast-telemetry-export`.
+
+Why this is a 0.9.0 minor release:
+
+- it adds a public OTLP Logs model and acknowledged OTLP/HTTP transport API.
+- it moves Tokio metrics and span export onto the same reusable, non-logging
+  HTTP client.
+- it raises the workspace MSRV to Rust 1.93, which is required by the current
+  `compio-buf` dependency used by the optional Compio exporter.
+
+Highlights:
+
+- Added the `otlp-logs` feature and
+  `fast_telemetry::otlp::build_log_export_request`.
+- Added `OtlpHttpConfig`, `OtlpTlsConfig`, and `OtlpHttpClient` with custom
+  headers, request timeouts, gzip, additional CA bundles, mTLS client
+  identities, `Retry-After` parsing, and structured status classification.
+- Added acknowledged `export_logs`, `export_metrics`, and `export_traces`
+  operations. The one-shot client returns diagnostics as values and performs
+  no logging or retries, so callers can safely compose their own queueing,
+  retry, ordering, and health policies.
+- Preserved the existing metrics and span exporter APIs while moving their
+  Tokio HTTP transport onto the shared client.
+- Corrected metric acknowledgement accounting to count OTLP data points and
+  clamp invalid collector rejection counts so accepted and rejected totals
+  always conserve the number sent.
+- Added deterministic unit coverage, a loopback Collector test for all three
+  OTLP signals, and pinned Hegel properties for status policy, gzip,
+  `Retry-After`, bounded diagnostics, and acknowledgement conservation.
+
+Install:
+
+```toml
+[dependencies]
+fast-telemetry = { version = "0.9", features = ["otlp-logs"] }
+fast-telemetry-export = { version = "0.9", default-features = false, features = ["otlp-logs"] }
+```
+
 ## 0.8.1 - 2026-07-22
 
 Published crates: `fast-telemetry`, `fast-telemetry-macros`, `fast-telemetry-export`.

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fast-telemetry-export"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Export adapters for fast-telemetry metrics: DogStatsD, OTLP, ClickHouse, span export, and stale-series sweeping"
+description = "Export adapters for fast-telemetry metrics, spans, and acknowledged OTLP logs"
 documentation = "https://docs.rs/fast-telemetry-export"
 keywords = ["telemetry", "metrics", "dogstatsd", "otlp", "tracing"]
 readme = "README.md"
@@ -19,7 +19,8 @@ all-features = true
 default = ["dogstatsd", "otlp"]
 tokio-runtime = ["dep:tokio", "dep:tokio-util"]
 dogstatsd = ["dep:memchr", "tokio-runtime"]
-otlp = ["dep:flate2", "dep:prost", "dep:reqwest", "fast-telemetry/otlp", "tokio-runtime"]
+otlp = ["dep:flate2", "dep:httpdate", "dep:prost", "dep:reqwest", "fast-telemetry/otlp", "tokio-runtime"]
+otlp-logs = ["otlp", "fast-telemetry/otlp-logs"]
 clickhouse = ["dep:klickhouse", "dep:indexmap", "fast-telemetry/otlp", "fast-telemetry/clickhouse", "tokio-runtime"]
 monoio = ["dep:monoio", "tokio-runtime"]
 compio = ["dep:compio", "dep:futures-util", "dep:memchr"]
@@ -38,6 +39,7 @@ tokio-util = { workspace = true, optional = true }
 
 # otlp
 flate2 = { workspace = true, optional = true }
+httpdate = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 
@@ -47,6 +49,7 @@ klickhouse = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+hegeltest.workspace = true
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/fast-telemetry-export/Cargo.toml
+++ b/crates/fast-telemetry-export/Cargo.toml
@@ -58,3 +58,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 name = "clickhouse_export"
 harness = false
 required-features = ["clickhouse", "otlp"]
+
+[[test]]
+name = "otlp_http"
+required-features = ["otlp-logs"]

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -35,7 +35,9 @@ The `otlp::OtlpHttpClient` is the shared, non-logging transport used by the
 Tokio metric and span loops. With `otlp-logs`, callers can submit an
 `ExportLogsServiceRequest` and receive a structured acknowledgement, partial
 rejection, retry classification, and `Retry-After` value. The client validates
-headers and TLS/mTLS material at construction and never retries on its own.
+headers and TLS/mTLS material at construction, emits an OTLP exporter
+`User-Agent`, bounds response bodies to 64 KiB by default, and never retries on
+its own. `with_max_response_bytes` can lower or raise that response limit.
 
 ```rust,no_run
 use fast_telemetry::otlp::{build_log_export_request, build_resource, pb};
@@ -64,8 +66,11 @@ assert_eq!(outcome.accepted + outcome.rejected, 1);
 ```
 
 `is_retryable`, `is_invalid_payload`, and `is_terminal` form a complete,
-non-overlapping policy for transport failures. A caller that retries after a
-lost response must tolerate duplicate delivery.
+non-overlapping policy. Following OTLP/HTTP, only transport failures and status
+429, 502, 503, or 504 are retryable; 400/413 identify invalid payloads and all
+other HTTP failures are terminal. Partial-success responses are successful
+acknowledgements and must not be retried. A caller that retries after a lost
+response must tolerate duplicate delivery.
 
 The ClickHouse exporter ships two layers:
 

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -8,6 +8,7 @@ This crate provides:
 - DogStatsD export over UDP
 - OTLP metrics export over HTTP/protobuf
 - OTLP span export over HTTP/protobuf
+- acknowledged OTLP log requests through a reusable HTTP client
 - ClickHouse metrics export over the native TCP protocol (via [`klickhouse`])
 - stale-series sweeping for dynamic metrics
 
@@ -17,6 +18,7 @@ This crate provides:
 | ------------ | ------- | ------------------------------------------------------------------------------------ |
 | `dogstatsd`  | ✓       | DogStatsD UDP exporter                                                               |
 | `otlp`       | ✓       | OTLP HTTP/protobuf metrics + span exporters                                          |
+| `otlp-logs`  |         | OTLP Logs protobuf types and acknowledged `OtlpHttpClient::export_logs`              |
 | `clickhouse` |         | Native-TCP ClickHouse exporter — first-party rows, generic primitive, and OTel schema |
 | `monoio`     |         | Monoio-native DogStatsD, OTLP HTTP/protobuf, sweeper, and span-flush helper          |
 | `compio`     |         | Compio-native DogStatsD and sweeper; span-flush helper with `otlp`                   |
@@ -28,6 +30,12 @@ application's logging setup by default. Enable `logging` to emit internal
 diagnostics through `eden_logger`; add `logging-debug` when per-export debug
 messages are useful. Runtime filtering follows `eden_logger`'s
 `EDEN_LOG_LEVEL` configuration.
+
+The `otlp::OtlpHttpClient` is the shared, non-logging transport used by the
+Tokio metric and span loops. With `otlp-logs`, callers can submit an
+`ExportLogsServiceRequest` and receive a structured acknowledgement, partial
+rejection, retry classification, and `Retry-After` value. The client validates
+headers and TLS/mTLS material at construction and never retries on its own.
 
 The ClickHouse exporter ships two layers:
 
@@ -54,7 +62,7 @@ columns with defaults. Summary metrics are ignored.
 Enable the `monoio` feature to run exporter loops on a monoio runtime:
 
 ```toml
-fast-telemetry-export = { version = "0.8", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
+fast-telemetry-export = { version = "0.9", default-features = false, features = ["dogstatsd", "otlp", "monoio"] }
 ```
 
 The monoio entry points mirror the Tokio ones:
@@ -77,7 +85,7 @@ Enable the `compio` feature to run the DogStatsD UDP exporter and sweeper on a
 compio runtime without pulling in Tokio:
 
 ```toml
-fast-telemetry-export = { version = "0.8", default-features = false, features = ["compio"] }
+fast-telemetry-export = { version = "0.9", default-features = false, features = ["compio"] }
 ```
 
 The compio entry points are:

--- a/crates/fast-telemetry-export/README.md
+++ b/crates/fast-telemetry-export/README.md
@@ -37,6 +37,36 @@ Tokio metric and span loops. With `otlp-logs`, callers can submit an
 rejection, retry classification, and `Retry-After` value. The client validates
 headers and TLS/mTLS material at construction and never retries on its own.
 
+```rust,no_run
+use fast_telemetry::otlp::{build_log_export_request, build_resource, pb};
+use fast_telemetry_export::otlp::{OtlpHttpClient, OtlpHttpConfig};
+
+# async fn export() -> Result<(), Box<dyn std::error::Error>> {
+let client = OtlpHttpClient::new(
+    OtlpHttpConfig::new("https://otel-collector:4318")
+        .with_header("Authorization", "Bearer <token>"),
+)?;
+let resource = build_resource("checkout", &[("service.instance.id", "checkout-1")]);
+let request = build_log_export_request(
+    &resource,
+    "checkout",
+    vec![pb::LogRecord {
+        body: Some(pb::AnyValue {
+            value: Some(pb::any_value::Value::StringValue("ready".to_string())),
+        }),
+        ..Default::default()
+    }],
+);
+let outcome = client.export_logs(&request).await?;
+assert_eq!(outcome.accepted + outcome.rejected, 1);
+# Ok(())
+# }
+```
+
+`is_retryable`, `is_invalid_payload`, and `is_terminal` form a complete,
+non-overlapping policy for transport failures. A caller that retries after a
+lost response must tolerate duplicate delivery.
+
 The ClickHouse exporter ships two layers:
 
 - `clickhouse::run<R, F, T>` — generic over a caller-supplied `klickhouse::Row`

--- a/crates/fast-telemetry-export/src/lib.rs
+++ b/crates/fast-telemetry-export/src/lib.rs
@@ -1,8 +1,8 @@
-//! Export adapters for fast-telemetry metrics.
+//! Export adapters for fast-telemetry signals.
 //!
 //! This crate provides the I/O layer for getting fast-telemetry metrics out of your
 //! process: DogStatsD over UDP, OTLP over HTTP/protobuf, ClickHouse native TCP,
-//! span export, and stale-series sweeping.
+//! span export, acknowledged OTLP log requests, and stale-series sweeping.
 //!
 //! Exporters are generic — they accept closures for metric serialization so
 //! they work with any metrics struct, not just a specific `AllMetrics` type.
@@ -27,6 +27,8 @@
 //!
 //! - `dogstatsd` (default) — DogStatsD UDP exporter
 //! - `otlp` (default) — OTLP HTTP/protobuf metrics and span exporters
+//! - `otlp-logs` — OTLP Logs protobuf support on the reusable acknowledged
+//!   HTTP client
 //! - `clickhouse` — ClickHouse native-protocol metrics exporter, including
 //!   first-party rows and OTel-standard table support (via `klickhouse`)
 //! - `monoio` — monoio-native exporter loops for monoio applications

--- a/crates/fast-telemetry-export/src/otlp.rs
+++ b/crates/fast-telemetry-export/src/otlp.rs
@@ -11,12 +11,20 @@
 //! The actual metric collection is provided by the caller via a closure,
 //! making this exporter work with any metrics struct.
 
+pub mod http;
+
 use std::time::Duration;
 
-use fast_telemetry::otlp::{build_export_request, build_resource, pb};
+use fast_telemetry::otlp::{build_export_request, build_resource};
 use prost::Message;
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
+
+pub use fast_telemetry::otlp::pb;
+pub use http::{
+    OtlpExportOutcome, OtlpHttpClient, OtlpHttpConfig, OtlpHttpError, OtlpHttpErrorKind,
+    OtlpTlsConfig,
+};
 
 /// Configuration for the OTLP HTTP metrics exporter.
 #[derive(Clone)]
@@ -103,12 +111,14 @@ const BASE_BACKOFF: Duration = Duration::from_secs(5);
 
 /// Minimum payload size (bytes) before gzip compression is applied.
 /// Below this threshold, compression overhead exceeds savings.
+#[cfg(feature = "monoio")]
 const GZIP_THRESHOLD: usize = 1024;
 
 /// Gzip-compress `data` into `out` using fast compression (level 1).
 ///
 /// Returns `true` if compression was applied, `false` if the payload was below
 /// the threshold (in which case `out` is untouched).
+#[cfg(feature = "monoio")]
 fn gzip_compress(data: &[u8], out: &mut Vec<u8>) -> bool {
     if data.len() < GZIP_THRESHOLD {
         return false;
@@ -122,32 +132,6 @@ fn gzip_compress(data: &[u8], out: &mut Vec<u8>) -> bool {
     let _ = encoder.write_all(data);
     let _ = encoder.finish();
     true
-}
-
-/// Send a protobuf-encoded body, applying gzip when beneficial.
-async fn send_otlp(
-    client: &reqwest::Client,
-    url: &str,
-    body: &[u8],
-    gzip_buf: &mut Vec<u8>,
-    extra_headers: &[(String, String)],
-) -> Result<reqwest::Response, reqwest::Error> {
-    let mut req = client
-        .post(url)
-        .header("Content-Type", "application/x-protobuf");
-
-    for (name, value) in extra_headers {
-        req = req.header(name, value);
-    }
-
-    if gzip_compress(body, gzip_buf) {
-        req.header("Content-Encoding", "gzip")
-            .body(gzip_buf.clone())
-            .send()
-            .await
-    } else {
-        req.body(body.to_vec()).send().await
-    }
 }
 
 /// Run the OTLP metrics export loop.
@@ -200,7 +184,11 @@ where
         .collect();
     let resource = build_resource(&config.service_name, &attr_refs);
 
-    let client = match reqwest::Client::builder().timeout(config.timeout).build() {
+    let mut http_config = OtlpHttpConfig::new(&config.endpoint).with_timeout(config.timeout);
+    for (name, value) in &config.headers {
+        http_config = http_config.with_header(name, value);
+    }
+    let client = match OtlpHttpClient::new(http_config) {
         Ok(c) => c,
         Err(e) => {
             crate::logging::log_error!("Failed to build HTTP client for OTLP exporter: {e}");
@@ -213,14 +201,10 @@ where
     interval.tick().await;
 
     let mut consecutive_failures: u32 = 0;
-    let mut bufs = ExportBufs::default();
-
     let ctx = ExportContext {
         client: &client,
-        url: &url,
         resource: &resource,
         scope_name: &config.scope_name,
-        extra_headers: &config.headers,
     };
 
     loop {
@@ -228,7 +212,7 @@ where
             _ = interval.tick() => {}
             _ = cancel.cancelled() => {
                 crate::logging::log_info!("OTLP metrics exporter shutting down, performing final export");
-                export_once(&ctx, &mut collect_fn, &mut bufs).await;
+                export_once(&ctx, &mut collect_fn).await;
                 return;
             }
         }
@@ -242,7 +226,7 @@ where
             tokio::select! {
                 _ = tokio::time::sleep(backoff) => {}
                 _ = cancel.cancelled() => {
-                    export_once(&ctx, &mut collect_fn, &mut bufs).await;
+                    export_once(&ctx, &mut collect_fn).await;
                     return;
                 }
             }
@@ -258,25 +242,25 @@ where
         let metric_count = metric_messages.len();
         let request = build_export_request(&resource, &config.scope_name, metric_messages);
 
-        bufs.encode.clear();
-        if let Err(e) = request.encode(&mut bufs.encode) {
-            crate::logging::log_warn!("OTLP protobuf encode failed: {e}");
-            continue;
-        }
-        let body_len = bufs.encode.len();
+        let body_len = request.encoded_len();
 
-        match send_otlp(&client, &url, &bufs.encode, &mut bufs.gzip, &config.headers).await {
-            Ok(resp) if resp.status().is_success() => {
+        match client.export_metrics(&request).await {
+            Ok(outcome) if outcome.rejected == 0 => {
                 consecutive_failures = 0;
                 crate::logging::log_debug!(
                     "Exported {metric_count} OTLP metrics ({body_len} bytes)"
                 );
             }
-            Ok(resp) => {
+            Ok(outcome) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                crate::logging::log_warn!("OTLP export failed: status={status}, body={body}");
+                crate::logging::log_warn!(
+                    "OTLP export partially rejected {} data points: {}",
+                    outcome.rejected,
+                    outcome
+                        .message
+                        .as_deref()
+                        .unwrap_or("collector did not provide a reason")
+                );
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
@@ -412,20 +396,19 @@ where
 }
 
 struct ExportContext<'a> {
-    client: &'a reqwest::Client,
-    url: &'a str,
+    client: &'a OtlpHttpClient,
     resource: &'a pb::Resource,
     scope_name: &'a str,
-    extra_headers: &'a [(String, String)],
 }
 
 #[derive(Default)]
+#[cfg(feature = "monoio")]
 struct ExportBufs {
     encode: Vec<u8>,
     gzip: Vec<u8>,
 }
 
-async fn export_once<F>(ctx: &ExportContext<'_>, collect_fn: &mut F, bufs: &mut ExportBufs)
+async fn export_once<F>(ctx: &ExportContext<'_>, collect_fn: &mut F)
 where
     F: FnMut(&mut Vec<pb::Metric>),
 {
@@ -438,25 +421,16 @@ where
 
     let request = build_export_request(ctx.resource, ctx.scope_name, metric_messages);
 
-    bufs.encode.clear();
-    if let Err(e) = request.encode(&mut bufs.encode) {
-        crate::logging::log_warn!("Final OTLP protobuf encode failed: {e}");
-        return;
-    }
-
-    match send_otlp(
-        ctx.client,
-        ctx.url,
-        &bufs.encode,
-        &mut bufs.gzip,
-        ctx.extra_headers,
-    )
-    .await
-    {
-        Ok(resp) if !resp.status().is_success() => {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            crate::logging::log_warn!("Final OTLP export returned {status}: {body}");
+    match ctx.client.export_metrics(&request).await {
+        Ok(outcome) if outcome.rejected > 0 => {
+            crate::logging::log_warn!(
+                "Final OTLP export partially rejected {} data points: {}",
+                outcome.rejected,
+                outcome
+                    .message
+                    .as_deref()
+                    .unwrap_or("collector did not provide a reason")
+            );
         }
         Err(e) => crate::logging::log_warn!("Final OTLP export failed: {e}"),
         _ => {}

--- a/crates/fast-telemetry-export/src/otlp/http.rs
+++ b/crates/fast-telemetry-export/src/otlp/http.rs
@@ -17,7 +17,12 @@ use reqwest::header::{
 use super::pb;
 
 const DEFAULT_GZIP_THRESHOLD: usize = 1024;
+const DEFAULT_MAX_RESPONSE_BYTES: usize = 64 * 1024;
 const MAX_ERROR_BODY_BYTES: usize = 8 * 1024;
+const USER_AGENT: &str = concat!(
+    "OTel-OTLP-Exporter-Rust/fast-telemetry-export-",
+    env!("CARGO_PKG_VERSION")
+);
 
 /// TLS material for an OTLP HTTP client.
 #[derive(Clone, Default)]
@@ -39,6 +44,8 @@ pub struct OtlpHttpConfig {
     pub headers: Vec<(String, String)>,
     /// Minimum uncompressed protobuf size before gzip is used.
     pub gzip_threshold: usize,
+    /// Maximum response body retained in memory.
+    pub max_response_bytes: usize,
     /// Optional additional trust roots and mTLS identity.
     pub tls: OtlpTlsConfig,
 }
@@ -50,6 +57,7 @@ impl Default for OtlpHttpConfig {
             timeout: Duration::from_secs(10),
             headers: Vec::new(),
             gzip_threshold: DEFAULT_GZIP_THRESHOLD,
+            max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
             tls: OtlpTlsConfig::default(),
         }
     }
@@ -75,6 +83,11 @@ impl OtlpHttpConfig {
 
     pub fn with_gzip_threshold(mut self, threshold: usize) -> Self {
         self.gzip_threshold = threshold;
+        self
+    }
+
+    pub fn with_max_response_bytes(mut self, maximum: usize) -> Self {
+        self.max_response_bytes = maximum;
         self
     }
 
@@ -183,10 +196,23 @@ pub struct OtlpHttpClient {
     endpoint: String,
     headers: HeaderMap,
     gzip_threshold: usize,
+    max_response_bytes: usize,
 }
 
 impl OtlpHttpClient {
     pub fn new(config: OtlpHttpConfig) -> Result<Self, OtlpHttpError> {
+        if config.timeout.is_zero() {
+            return Err(OtlpHttpError::new(
+                OtlpHttpErrorKind::Configuration,
+                "OTLP request timeout must be greater than zero",
+            ));
+        }
+        if config.max_response_bytes == 0 {
+            return Err(OtlpHttpError::new(
+                OtlpHttpErrorKind::Configuration,
+                "OTLP maximum response bytes must be greater than zero",
+            ));
+        }
         let parsed =
             reqwest::Url::parse(config.endpoint.trim_end_matches('/')).map_err(|error| {
                 OtlpHttpError::new(
@@ -224,7 +250,9 @@ impl OtlpHttpClient {
             headers.append(name, value);
         }
 
-        let mut builder = reqwest::Client::builder().timeout(config.timeout);
+        let mut builder = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .user_agent(USER_AGENT);
         for bundle in config.tls.ca_certificates_pem {
             let certificates = reqwest::Certificate::from_pem_bundle(&bundle).map_err(|error| {
                 OtlpHttpError::new(
@@ -255,6 +283,7 @@ impl OtlpHttpClient {
             endpoint: parsed.as_str().trim_end_matches('/').to_string(),
             headers,
             gzip_threshold: config.gzip_threshold,
+            max_response_bytes: config.max_response_bytes,
         })
     }
 
@@ -340,7 +369,7 @@ impl OtlpHttpClient {
             request = request.header(CONTENT_ENCODING, "gzip");
         }
 
-        let response = request.body(body).send().await.map_err(|error| {
+        let mut response = request.body(body).send().await.map_err(|error| {
             OtlpHttpError::new(
                 OtlpHttpErrorKind::Transport,
                 format!("OTLP request failed: {error}"),
@@ -348,16 +377,15 @@ impl OtlpHttpClient {
         })?;
         let status = response.status();
         let retry_after = parse_retry_after(response.headers().get(RETRY_AFTER));
-        let response_body = response.bytes().await.map_err(|error| {
-            OtlpHttpError::new(
-                OtlpHttpErrorKind::Transport,
-                format!("failed to read OTLP response: {error}"),
-            )
-        })?;
+        let (response_body, response_truncated) =
+            read_bounded_body(&mut response, self.max_response_bytes, status.is_success()).await?;
 
         if !status.is_success() {
             let kind = classify_status(status.as_u16());
-            let mut error = OtlpHttpError::new(kind, body_text(&response_body));
+            let mut error = OtlpHttpError::new(
+                kind,
+                body_text_with_truncation(&response_body, response_truncated),
+            );
             error.status = Some(status.as_u16());
             error.retry_after = retry_after;
             return Err(error);
@@ -370,6 +398,53 @@ impl OtlpHttpClient {
             )
         })
     }
+}
+
+async fn read_bounded_body(
+    response: &mut reqwest::Response,
+    maximum: usize,
+    success: bool,
+) -> Result<(Vec<u8>, bool), OtlpHttpError> {
+    if success
+        && response
+            .content_length()
+            .is_some_and(|length| length > maximum as u64)
+    {
+        return Err(OtlpHttpError::new(
+            OtlpHttpErrorKind::Decode,
+            format!("OTLP response exceeded the configured {maximum}-byte limit"),
+        ));
+    }
+
+    let capacity = response
+        .content_length()
+        .and_then(|length| usize::try_from(length).ok())
+        .unwrap_or_default()
+        .min(maximum);
+    let mut body = Vec::with_capacity(capacity);
+    let mut truncated = false;
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        OtlpHttpError::new(
+            OtlpHttpErrorKind::Transport,
+            format!("failed to read OTLP response: {error}"),
+        )
+    })? {
+        let remaining = maximum.saturating_sub(body.len());
+        if chunk.len() > remaining {
+            body.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    if success && truncated {
+        return Err(OtlpHttpError::new(
+            OtlpHttpErrorKind::Decode,
+            format!("OTLP response exceeded the configured {maximum}-byte limit"),
+        ));
+    }
+    Ok((body, truncated))
 }
 
 fn metric_data_point_count(metric: &pb::Metric) -> u64 {
@@ -420,7 +495,7 @@ fn gzip(body: &[u8], threshold: usize) -> Result<(Vec<u8>, bool), OtlpHttpError>
 fn classify_status(status: u16) -> OtlpHttpErrorKind {
     match status {
         400 | 413 => OtlpHttpErrorKind::InvalidPayload,
-        408 | 425 | 429 | 500..=599 => OtlpHttpErrorKind::RetryableStatus,
+        429 | 502..=504 => OtlpHttpErrorKind::RetryableStatus,
         _ => OtlpHttpErrorKind::TerminalStatus,
     }
 }
@@ -434,12 +509,17 @@ fn parse_retry_after(value: Option<&HeaderValue>) -> Option<Duration> {
     deadline.duration_since(SystemTime::now()).ok()
 }
 
+#[cfg(test)]
 fn body_text(body: &[u8]) -> String {
+    body_text_with_truncation(body, false)
+}
+
+fn body_text_with_truncation(body: &[u8], response_truncated: bool) -> String {
     let truncated = &body[..body.len().min(MAX_ERROR_BODY_BYTES)];
     let mut text = String::from_utf8_lossy(truncated).into_owned();
     if text.is_empty() {
         text = "collector rejected OTLP request".to_string();
-    } else if truncated.len() != body.len() {
+    } else if response_truncated || truncated.len() != body.len() {
         text.push('…');
     }
     text
@@ -457,6 +537,18 @@ mod tests {
     #[test]
     fn validates_endpoint_and_headers() {
         assert!(OtlpHttpClient::new(OtlpHttpConfig::new("not a url")).is_err());
+        assert!(
+            OtlpHttpClient::new(
+                OtlpHttpConfig::new("http://localhost:4318").with_timeout(Duration::ZERO)
+            )
+            .is_err()
+        );
+        assert!(
+            OtlpHttpClient::new(
+                OtlpHttpConfig::new("http://localhost:4318").with_max_response_bytes(0)
+            )
+            .is_err()
+        );
         assert!(
             OtlpHttpClient::new(
                 OtlpHttpConfig::new("http://localhost:4318").with_header("bad\nname", "value")
@@ -490,7 +582,13 @@ mod tests {
         assert_eq!(classify_status(400), OtlpHttpErrorKind::InvalidPayload);
         assert_eq!(classify_status(413), OtlpHttpErrorKind::InvalidPayload);
         assert_eq!(classify_status(429), OtlpHttpErrorKind::RetryableStatus);
+        assert_eq!(classify_status(502), OtlpHttpErrorKind::RetryableStatus);
         assert_eq!(classify_status(503), OtlpHttpErrorKind::RetryableStatus);
+        assert_eq!(classify_status(504), OtlpHttpErrorKind::RetryableStatus);
+        assert_eq!(classify_status(408), OtlpHttpErrorKind::TerminalStatus);
+        assert_eq!(classify_status(425), OtlpHttpErrorKind::TerminalStatus);
+        assert_eq!(classify_status(500), OtlpHttpErrorKind::TerminalStatus);
+        assert_eq!(classify_status(505), OtlpHttpErrorKind::TerminalStatus);
         assert_eq!(classify_status(401), OtlpHttpErrorKind::TerminalStatus);
     }
 
@@ -508,7 +606,7 @@ mod tests {
         let status = tc.draw(gs::integers::<u16>());
         let expected = match status {
             400 | 413 => OtlpHttpErrorKind::InvalidPayload,
-            408 | 425 | 429 | 500..=599 => OtlpHttpErrorKind::RetryableStatus,
+            429 | 502..=504 => OtlpHttpErrorKind::RetryableStatus,
             _ => OtlpHttpErrorKind::TerminalStatus,
         };
         let kind = classify_status(status);

--- a/crates/fast-telemetry-export/src/otlp/http.rs
+++ b/crates/fast-telemetry-export/src/otlp/http.rs
@@ -92,21 +92,32 @@ impl OtlpHttpConfig {
 /// Classification used by retrying exporters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OtlpHttpErrorKind {
+    /// The endpoint, header, timeout, or TLS configuration is invalid.
     Configuration,
+    /// The protobuf request or gzip body could not be encoded.
     Encode,
+    /// The request could not be sent or its response body could not be read.
     Transport,
+    /// The collector returned a status that callers may safely retry.
     RetryableStatus,
+    /// The collector rejected the request payload as invalid or too large.
     InvalidPayload,
+    /// The collector returned a permanent HTTP status.
     TerminalStatus,
+    /// A successful response contained invalid protobuf.
     Decode,
 }
 
 /// A structured OTLP request failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OtlpHttpError {
+    /// Stable error classification for retry and health decisions.
     pub kind: OtlpHttpErrorKind,
+    /// Human-readable diagnostic that is safe to surface outside logging.
     pub message: String,
+    /// HTTP status when the collector returned a non-success response.
     pub status: Option<u16>,
+    /// Collector-provided retry delay, when present and valid.
     pub retry_after: Option<Duration>,
 }
 
@@ -135,6 +146,7 @@ impl OtlpHttpError {
         matches!(
             self.kind,
             OtlpHttpErrorKind::Configuration
+                | OtlpHttpErrorKind::Encode
                 | OtlpHttpErrorKind::TerminalStatus
                 | OtlpHttpErrorKind::Decode
         )
@@ -156,8 +168,11 @@ impl std::error::Error for OtlpHttpError {}
 /// Acknowledged result from an OTLP request.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OtlpExportOutcome {
+    /// Signal items accepted by the collector.
     pub accepted: u64,
+    /// Signal items rejected by the collector.
     pub rejected: u64,
+    /// Optional collector warning or partial-rejection diagnostic.
     pub message: Option<String>,
 }
 
@@ -258,18 +273,9 @@ impl OtlpHttpClient {
             self.send_protobuf("/v1/logs", request).await?;
         let (rejected, message) = response
             .partial_success
-            .map(|partial| {
-                (
-                    partial.rejected_log_records.max(0) as u64,
-                    non_empty(partial.error_message),
-                )
-            })
+            .map(|partial| (partial.rejected_log_records, partial.error_message))
             .unwrap_or_default();
-        Ok(OtlpExportOutcome {
-            accepted: sent.saturating_sub(rejected),
-            rejected,
-            message,
-        })
+        Ok(export_outcome(sent, rejected, message))
     }
 
     pub async fn export_metrics(
@@ -280,24 +286,16 @@ impl OtlpHttpClient {
             .resource_metrics
             .iter()
             .flat_map(|resource| &resource.scope_metrics)
-            .map(|scope| scope.metrics.len() as u64)
+            .flat_map(|scope| &scope.metrics)
+            .map(metric_data_point_count)
             .sum();
         let response: pb::ExportMetricsServiceResponse =
             self.send_protobuf("/v1/metrics", request).await?;
         let (rejected, message) = response
             .partial_success
-            .map(|partial| {
-                (
-                    partial.rejected_data_points.max(0) as u64,
-                    non_empty(partial.error_message),
-                )
-            })
+            .map(|partial| (partial.rejected_data_points, partial.error_message))
             .unwrap_or_default();
-        Ok(OtlpExportOutcome {
-            accepted: sent.saturating_sub(rejected),
-            rejected,
-            message,
-        })
+        Ok(export_outcome(sent, rejected, message))
     }
 
     pub async fn export_traces(
@@ -314,18 +312,9 @@ impl OtlpHttpClient {
             self.send_protobuf("/v1/traces", request).await?;
         let (rejected, message) = response
             .partial_success
-            .map(|partial| {
-                (
-                    partial.rejected_spans.max(0) as u64,
-                    non_empty(partial.error_message),
-                )
-            })
+            .map(|partial| (partial.rejected_spans, partial.error_message))
             .unwrap_or_default();
-        Ok(OtlpExportOutcome {
-            accepted: sent.saturating_sub(rejected),
-            rejected,
-            message,
-        })
+        Ok(export_outcome(sent, rejected, message))
     }
 
     async fn send_protobuf<M, R>(&self, path: &str, message: &M) -> Result<R, OtlpHttpError>
@@ -380,6 +369,27 @@ impl OtlpHttpClient {
                 format!("failed to decode OTLP response: {error}"),
             )
         })
+    }
+}
+
+fn metric_data_point_count(metric: &pb::Metric) -> u64 {
+    let count = match metric.data.as_ref() {
+        Some(pb::metric::Data::Gauge(data)) => data.data_points.len(),
+        Some(pb::metric::Data::Sum(data)) => data.data_points.len(),
+        Some(pb::metric::Data::Histogram(data)) => data.data_points.len(),
+        Some(pb::metric::Data::ExponentialHistogram(data)) => data.data_points.len(),
+        Some(pb::metric::Data::Summary(data)) => data.data_points.len(),
+        None => 0,
+    };
+    count.try_into().unwrap_or(u64::MAX)
+}
+
+fn export_outcome(sent: u64, reported_rejected: i64, message: String) -> OtlpExportOutcome {
+    let rejected = u64::try_from(reported_rejected).unwrap_or(0).min(sent);
+    OtlpExportOutcome {
+        accepted: sent - rejected,
+        rejected,
+        message: non_empty(message),
     }
 }
 
@@ -561,5 +571,86 @@ mod tests {
                     .saturating_add('…'.len_utf8())
         );
         assert_eq!(text.ends_with('…'), body.len() > MAX_ERROR_BODY_BYTES);
+    }
+
+    #[hegel::test(test_cases = 300)]
+    fn generated_outcomes_conserve_the_sent_signal_count(tc: TestCase) {
+        let sent = tc.draw(gs::integers::<u32>()) as u64;
+        let reported_rejected = tc.draw(gs::integers::<i32>()) as i64;
+        let include_message = tc.draw(gs::booleans());
+        let message = if include_message {
+            "collector warning".to_string()
+        } else {
+            String::new()
+        };
+        let outcome = export_outcome(sent, reported_rejected, message);
+
+        assert_eq!(outcome.accepted.saturating_add(outcome.rejected), sent);
+        assert!(outcome.rejected <= sent);
+        assert_eq!(outcome.message.is_some(), include_message);
+    }
+
+    #[test]
+    fn counts_metric_data_points_instead_of_metric_messages() {
+        let metrics = [
+            pb::Metric {
+                data: Some(pb::metric::Data::Gauge(pb::OtlpGauge {
+                    data_points: vec![pb::NumberDataPoint::default(); 2],
+                })),
+                ..Default::default()
+            },
+            pb::Metric {
+                data: Some(pb::metric::Data::Sum(pb::Sum {
+                    data_points: vec![pb::NumberDataPoint::default(); 3],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            pb::Metric {
+                data: Some(pb::metric::Data::Histogram(pb::OtlpHistogram {
+                    data_points: vec![pb::HistogramDataPoint::default(); 4],
+                    ..Default::default()
+                })),
+                ..Default::default()
+            },
+            pb::Metric {
+                data: Some(pb::metric::Data::ExponentialHistogram(
+                    pb::OtlpExpHistogram {
+                        data_points: vec![pb::ExponentialHistogramDataPoint::default(); 5],
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            },
+            pb::Metric {
+                data: Some(pb::metric::Data::Summary(pb::Summary {
+                    data_points: vec![pb::SummaryDataPoint::default(); 6],
+                })),
+                ..Default::default()
+            },
+        ];
+
+        assert_eq!(metrics.iter().map(metric_data_point_count).sum::<u64>(), 20);
+    }
+
+    #[test]
+    fn every_error_kind_has_one_exporter_action() {
+        for kind in [
+            OtlpHttpErrorKind::Configuration,
+            OtlpHttpErrorKind::Encode,
+            OtlpHttpErrorKind::Transport,
+            OtlpHttpErrorKind::RetryableStatus,
+            OtlpHttpErrorKind::InvalidPayload,
+            OtlpHttpErrorKind::TerminalStatus,
+            OtlpHttpErrorKind::Decode,
+        ] {
+            let error = OtlpHttpError::new(kind, "classification");
+            let actions = [
+                error.is_retryable(),
+                error.is_invalid_payload(),
+                error.is_terminal(),
+            ];
+            assert_eq!(actions.into_iter().filter(|selected| *selected).count(), 1);
+        }
     }
 }

--- a/crates/fast-telemetry-export/src/otlp/http.rs
+++ b/crates/fast-telemetry-export/src/otlp/http.rs
@@ -1,0 +1,565 @@
+//! Reusable acknowledged OTLP/HTTP protobuf transport.
+//!
+//! This module deliberately does not log or retry. Callers decide how to
+//! surface diagnostics and when a request is safe to retry.
+
+use std::fmt;
+use std::io::Write;
+use std::time::{Duration, SystemTime};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use prost::Message;
+use reqwest::header::{
+    CONTENT_ENCODING, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, RETRY_AFTER,
+};
+
+use super::pb;
+
+const DEFAULT_GZIP_THRESHOLD: usize = 1024;
+const MAX_ERROR_BODY_BYTES: usize = 8 * 1024;
+
+/// TLS material for an OTLP HTTP client.
+#[derive(Clone, Default)]
+pub struct OtlpTlsConfig {
+    /// Additional PEM-encoded CA certificate bundles.
+    pub ca_certificates_pem: Vec<Vec<u8>>,
+    /// PEM containing a client certificate chain and private key.
+    pub client_identity_pem: Option<Vec<u8>>,
+}
+
+/// Shared configuration for acknowledged OTLP HTTP requests.
+#[derive(Clone)]
+pub struct OtlpHttpConfig {
+    /// Collector base endpoint. Signal paths are appended automatically.
+    pub endpoint: String,
+    /// Request timeout.
+    pub timeout: Duration,
+    /// Headers applied to every request.
+    pub headers: Vec<(String, String)>,
+    /// Minimum uncompressed protobuf size before gzip is used.
+    pub gzip_threshold: usize,
+    /// Optional additional trust roots and mTLS identity.
+    pub tls: OtlpTlsConfig,
+}
+
+impl Default for OtlpHttpConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "http://localhost:4318".to_string(),
+            timeout: Duration::from_secs(10),
+            headers: Vec::new(),
+            gzip_threshold: DEFAULT_GZIP_THRESHOLD,
+            tls: OtlpTlsConfig::default(),
+        }
+    }
+}
+
+impl OtlpHttpConfig {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            ..Self::default()
+        }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((name.into(), value.into()));
+        self
+    }
+
+    pub fn with_gzip_threshold(mut self, threshold: usize) -> Self {
+        self.gzip_threshold = threshold;
+        self
+    }
+
+    pub fn with_ca_certificate_pem(mut self, pem: impl Into<Vec<u8>>) -> Self {
+        self.tls.ca_certificates_pem.push(pem.into());
+        self
+    }
+
+    pub fn with_client_identity_pem(mut self, pem: impl Into<Vec<u8>>) -> Self {
+        self.tls.client_identity_pem = Some(pem.into());
+        self
+    }
+}
+
+/// Classification used by retrying exporters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtlpHttpErrorKind {
+    Configuration,
+    Encode,
+    Transport,
+    RetryableStatus,
+    InvalidPayload,
+    TerminalStatus,
+    Decode,
+}
+
+/// A structured OTLP request failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtlpHttpError {
+    pub kind: OtlpHttpErrorKind,
+    pub message: String,
+    pub status: Option<u16>,
+    pub retry_after: Option<Duration>,
+}
+
+impl OtlpHttpError {
+    fn new(kind: OtlpHttpErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            status: None,
+            retry_after: None,
+        }
+    }
+
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self.kind,
+            OtlpHttpErrorKind::Transport | OtlpHttpErrorKind::RetryableStatus
+        )
+    }
+
+    pub const fn is_invalid_payload(&self) -> bool {
+        matches!(self.kind, OtlpHttpErrorKind::InvalidPayload)
+    }
+
+    pub const fn is_terminal(&self) -> bool {
+        matches!(
+            self.kind,
+            OtlpHttpErrorKind::Configuration
+                | OtlpHttpErrorKind::TerminalStatus
+                | OtlpHttpErrorKind::Decode
+        )
+    }
+}
+
+impl fmt::Display for OtlpHttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(status) = self.status {
+            write!(f, "OTLP HTTP {status}: {}", self.message)
+        } else {
+            f.write_str(&self.message)
+        }
+    }
+}
+
+impl std::error::Error for OtlpHttpError {}
+
+/// Acknowledged result from an OTLP request.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OtlpExportOutcome {
+    pub accepted: u64,
+    pub rejected: u64,
+    pub message: Option<String>,
+}
+
+/// Cloneable OTLP HTTP client shared by logs, metrics, and traces.
+#[derive(Clone)]
+pub struct OtlpHttpClient {
+    client: reqwest::Client,
+    endpoint: String,
+    headers: HeaderMap,
+    gzip_threshold: usize,
+}
+
+impl OtlpHttpClient {
+    pub fn new(config: OtlpHttpConfig) -> Result<Self, OtlpHttpError> {
+        let parsed =
+            reqwest::Url::parse(config.endpoint.trim_end_matches('/')).map_err(|error| {
+                OtlpHttpError::new(
+                    OtlpHttpErrorKind::Configuration,
+                    format!("invalid OTLP endpoint: {error}"),
+                )
+            })?;
+        if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+            return Err(OtlpHttpError::new(
+                OtlpHttpErrorKind::Configuration,
+                "OTLP endpoint must be an absolute http:// or https:// URL",
+            ));
+        }
+        if parsed.query().is_some() || parsed.fragment().is_some() {
+            return Err(OtlpHttpError::new(
+                OtlpHttpErrorKind::Configuration,
+                "OTLP endpoint must not contain a query or fragment",
+            ));
+        }
+
+        let mut headers = HeaderMap::new();
+        for (name, value) in config.headers {
+            let name = HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
+                OtlpHttpError::new(
+                    OtlpHttpErrorKind::Configuration,
+                    format!("invalid OTLP header name: {error}"),
+                )
+            })?;
+            let value = HeaderValue::from_str(&value).map_err(|error| {
+                OtlpHttpError::new(
+                    OtlpHttpErrorKind::Configuration,
+                    format!("invalid OTLP header value: {error}"),
+                )
+            })?;
+            headers.append(name, value);
+        }
+
+        let mut builder = reqwest::Client::builder().timeout(config.timeout);
+        for bundle in config.tls.ca_certificates_pem {
+            let certificates = reqwest::Certificate::from_pem_bundle(&bundle).map_err(|error| {
+                OtlpHttpError::new(
+                    OtlpHttpErrorKind::Configuration,
+                    format!("invalid OTLP CA certificate bundle: {error}"),
+                )
+            })?;
+            builder = builder.tls_certs_merge(certificates);
+        }
+        if let Some(identity_pem) = config.tls.client_identity_pem {
+            let identity = reqwest::Identity::from_pem(&identity_pem).map_err(|error| {
+                OtlpHttpError::new(
+                    OtlpHttpErrorKind::Configuration,
+                    format!("invalid OTLP client identity: {error}"),
+                )
+            })?;
+            builder = builder.identity(identity);
+        }
+        let client = builder.build().map_err(|error| {
+            OtlpHttpError::new(
+                OtlpHttpErrorKind::Configuration,
+                format!("failed to build OTLP HTTP client: {error}"),
+            )
+        })?;
+
+        Ok(Self {
+            client,
+            endpoint: parsed.as_str().trim_end_matches('/').to_string(),
+            headers,
+            gzip_threshold: config.gzip_threshold,
+        })
+    }
+
+    #[cfg(feature = "otlp-logs")]
+    pub async fn export_logs(
+        &self,
+        request: &pb::ExportLogsServiceRequest,
+    ) -> Result<OtlpExportOutcome, OtlpHttpError> {
+        let sent: u64 = request
+            .resource_logs
+            .iter()
+            .flat_map(|resource| &resource.scope_logs)
+            .map(|scope| scope.log_records.len() as u64)
+            .sum();
+        let response: pb::ExportLogsServiceResponse =
+            self.send_protobuf("/v1/logs", request).await?;
+        let (rejected, message) = response
+            .partial_success
+            .map(|partial| {
+                (
+                    partial.rejected_log_records.max(0) as u64,
+                    non_empty(partial.error_message),
+                )
+            })
+            .unwrap_or_default();
+        Ok(OtlpExportOutcome {
+            accepted: sent.saturating_sub(rejected),
+            rejected,
+            message,
+        })
+    }
+
+    pub async fn export_metrics(
+        &self,
+        request: &pb::ExportMetricsServiceRequest,
+    ) -> Result<OtlpExportOutcome, OtlpHttpError> {
+        let sent: u64 = request
+            .resource_metrics
+            .iter()
+            .flat_map(|resource| &resource.scope_metrics)
+            .map(|scope| scope.metrics.len() as u64)
+            .sum();
+        let response: pb::ExportMetricsServiceResponse =
+            self.send_protobuf("/v1/metrics", request).await?;
+        let (rejected, message) = response
+            .partial_success
+            .map(|partial| {
+                (
+                    partial.rejected_data_points.max(0) as u64,
+                    non_empty(partial.error_message),
+                )
+            })
+            .unwrap_or_default();
+        Ok(OtlpExportOutcome {
+            accepted: sent.saturating_sub(rejected),
+            rejected,
+            message,
+        })
+    }
+
+    pub async fn export_traces(
+        &self,
+        request: &pb::ExportTraceServiceRequest,
+    ) -> Result<OtlpExportOutcome, OtlpHttpError> {
+        let sent: u64 = request
+            .resource_spans
+            .iter()
+            .flat_map(|resource| &resource.scope_spans)
+            .map(|scope| scope.spans.len() as u64)
+            .sum();
+        let response: pb::ExportTraceServiceResponse =
+            self.send_protobuf("/v1/traces", request).await?;
+        let (rejected, message) = response
+            .partial_success
+            .map(|partial| {
+                (
+                    partial.rejected_spans.max(0) as u64,
+                    non_empty(partial.error_message),
+                )
+            })
+            .unwrap_or_default();
+        Ok(OtlpExportOutcome {
+            accepted: sent.saturating_sub(rejected),
+            rejected,
+            message,
+        })
+    }
+
+    async fn send_protobuf<M, R>(&self, path: &str, message: &M) -> Result<R, OtlpHttpError>
+    where
+        M: Message,
+        R: Message + Default,
+    {
+        let mut body = Vec::with_capacity(message.encoded_len());
+        message.encode(&mut body).map_err(|error| {
+            OtlpHttpError::new(
+                OtlpHttpErrorKind::Encode,
+                format!("failed to encode OTLP protobuf: {error}"),
+            )
+        })?;
+
+        let (body, compressed) = gzip(&body, self.gzip_threshold)?;
+        let mut request = self
+            .client
+            .post(format!("{}{path}", self.endpoint))
+            .headers(self.headers.clone())
+            .header(CONTENT_TYPE, "application/x-protobuf");
+        if compressed {
+            request = request.header(CONTENT_ENCODING, "gzip");
+        }
+
+        let response = request.body(body).send().await.map_err(|error| {
+            OtlpHttpError::new(
+                OtlpHttpErrorKind::Transport,
+                format!("OTLP request failed: {error}"),
+            )
+        })?;
+        let status = response.status();
+        let retry_after = parse_retry_after(response.headers().get(RETRY_AFTER));
+        let response_body = response.bytes().await.map_err(|error| {
+            OtlpHttpError::new(
+                OtlpHttpErrorKind::Transport,
+                format!("failed to read OTLP response: {error}"),
+            )
+        })?;
+
+        if !status.is_success() {
+            let kind = classify_status(status.as_u16());
+            let mut error = OtlpHttpError::new(kind, body_text(&response_body));
+            error.status = Some(status.as_u16());
+            error.retry_after = retry_after;
+            return Err(error);
+        }
+
+        R::decode(response_body.as_ref()).map_err(|error| {
+            OtlpHttpError::new(
+                OtlpHttpErrorKind::Decode,
+                format!("failed to decode OTLP response: {error}"),
+            )
+        })
+    }
+}
+
+fn non_empty(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn gzip(body: &[u8], threshold: usize) -> Result<(Vec<u8>, bool), OtlpHttpError> {
+    if body.len() < threshold {
+        return Ok((body.to_vec(), false));
+    }
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    encoder.write_all(body).map_err(|error| {
+        OtlpHttpError::new(
+            OtlpHttpErrorKind::Encode,
+            format!("failed to gzip OTLP request: {error}"),
+        )
+    })?;
+    let compressed = encoder.finish().map_err(|error| {
+        OtlpHttpError::new(
+            OtlpHttpErrorKind::Encode,
+            format!("failed to finish OTLP gzip stream: {error}"),
+        )
+    })?;
+    Ok((compressed, true))
+}
+
+fn classify_status(status: u16) -> OtlpHttpErrorKind {
+    match status {
+        400 | 413 => OtlpHttpErrorKind::InvalidPayload,
+        408 | 425 | 429 | 500..=599 => OtlpHttpErrorKind::RetryableStatus,
+        _ => OtlpHttpErrorKind::TerminalStatus,
+    }
+}
+
+fn parse_retry_after(value: Option<&HeaderValue>) -> Option<Duration> {
+    let value = value?.to_str().ok()?;
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+    let deadline = httpdate::parse_http_date(value).ok()?;
+    deadline.duration_since(SystemTime::now()).ok()
+}
+
+fn body_text(body: &[u8]) -> String {
+    let truncated = &body[..body.len().min(MAX_ERROR_BODY_BYTES)];
+    let mut text = String::from_utf8_lossy(truncated).into_owned();
+    if text.is_empty() {
+        text = "collector rejected OTLP request".to_string();
+    } else if truncated.len() != body.len() {
+        text.push('…');
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use hegel::TestCase;
+    use hegel::generators as gs;
+
+    use super::*;
+
+    #[test]
+    fn validates_endpoint_and_headers() {
+        assert!(OtlpHttpClient::new(OtlpHttpConfig::new("not a url")).is_err());
+        assert!(
+            OtlpHttpClient::new(
+                OtlpHttpConfig::new("http://localhost:4318").with_header("bad\nname", "value")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn validates_tls_material_at_construction() {
+        let ca_error = OtlpHttpClient::new(
+            OtlpHttpConfig::new("https://localhost:4318").with_ca_certificate_pem(
+                b"-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----\n".to_vec(),
+            ),
+        )
+        .err()
+        .expect("invalid CA material must fail");
+        assert_eq!(ca_error.kind, OtlpHttpErrorKind::Configuration);
+
+        let identity_error = OtlpHttpClient::new(
+            OtlpHttpConfig::new("https://localhost:4318")
+                .with_client_identity_pem(b"not an identity".to_vec()),
+        )
+        .err()
+        .expect("invalid client identity must fail");
+        assert_eq!(identity_error.kind, OtlpHttpErrorKind::Configuration);
+    }
+
+    #[test]
+    fn classifies_statuses() {
+        assert_eq!(classify_status(400), OtlpHttpErrorKind::InvalidPayload);
+        assert_eq!(classify_status(413), OtlpHttpErrorKind::InvalidPayload);
+        assert_eq!(classify_status(429), OtlpHttpErrorKind::RetryableStatus);
+        assert_eq!(classify_status(503), OtlpHttpErrorKind::RetryableStatus);
+        assert_eq!(classify_status(401), OtlpHttpErrorKind::TerminalStatus);
+    }
+
+    #[test]
+    fn parses_retry_after_seconds() {
+        let value = HeaderValue::from_static("12");
+        assert_eq!(
+            parse_retry_after(Some(&value)),
+            Some(Duration::from_secs(12))
+        );
+    }
+
+    #[hegel::test(test_cases = 500)]
+    fn generated_statuses_follow_retry_and_payload_policy(tc: TestCase) {
+        let status = tc.draw(gs::integers::<u16>());
+        let expected = match status {
+            400 | 413 => OtlpHttpErrorKind::InvalidPayload,
+            408 | 425 | 429 | 500..=599 => OtlpHttpErrorKind::RetryableStatus,
+            _ => OtlpHttpErrorKind::TerminalStatus,
+        };
+        let kind = classify_status(status);
+        let error = OtlpHttpError::new(kind, "generated status");
+
+        assert_eq!(kind, expected);
+        assert_eq!(
+            error.is_retryable(),
+            kind == OtlpHttpErrorKind::RetryableStatus
+        );
+        assert_eq!(
+            error.is_invalid_payload(),
+            kind == OtlpHttpErrorKind::InvalidPayload
+        );
+        assert_eq!(
+            error.is_terminal(),
+            kind == OtlpHttpErrorKind::TerminalStatus
+        );
+    }
+
+    #[hegel::test(test_cases = 250)]
+    fn generated_gzip_payloads_round_trip_at_every_threshold(tc: TestCase) {
+        let body = tc.draw(gs::binary().max_size(16 * 1024));
+        let threshold = tc.draw(gs::integers::<u16>().max_value(16 * 1024)) as usize;
+        let (encoded, compressed) = gzip(&body, threshold).expect("in-memory gzip");
+
+        assert_eq!(compressed, body.len() >= threshold);
+        if compressed {
+            let mut decoded = Vec::new();
+            flate2::read::GzDecoder::new(encoded.as_slice())
+                .read_to_end(&mut decoded)
+                .expect("decode generated gzip payload");
+            assert_eq!(decoded, body);
+        } else {
+            assert_eq!(encoded, body);
+        }
+    }
+
+    #[hegel::test(test_cases = 250)]
+    fn generated_retry_after_seconds_are_preserved(tc: TestCase) {
+        let seconds = tc.draw(gs::integers::<u32>()) as u64;
+        let value = HeaderValue::from_str(&seconds.to_string()).expect("numeric header value");
+
+        assert_eq!(
+            parse_retry_after(Some(&value)),
+            Some(Duration::from_secs(seconds))
+        );
+    }
+
+    #[hegel::test(test_cases = 250)]
+    fn generated_error_bodies_are_bounded_and_mark_truncation(tc: TestCase) {
+        let body = tc.draw(gs::binary().max_size(MAX_ERROR_BODY_BYTES * 2));
+        let text = body_text(&body);
+
+        assert!(!text.is_empty());
+        assert!(
+            text.len()
+                <= MAX_ERROR_BODY_BYTES
+                    .saturating_mul(3)
+                    .saturating_add('…'.len_utf8())
+        );
+        assert_eq!(text.ends_with('…'), body.len() > MAX_ERROR_BODY_BYTES);
+    }
+}

--- a/crates/fast-telemetry-export/src/spans.rs
+++ b/crates/fast-telemetry-export/src/spans.rs
@@ -101,49 +101,6 @@ const MAX_BACKOFF: Duration = Duration::from_secs(300);
 /// Base backoff delay after the first failure.
 const BASE_BACKOFF: Duration = Duration::from_secs(5);
 
-/// Minimum payload size (bytes) before gzip compression is applied.
-const GZIP_THRESHOLD: usize = 1024;
-
-fn gzip_compress(data: &[u8], out: &mut Vec<u8>) -> bool {
-    if data.len() < GZIP_THRESHOLD {
-        return false;
-    }
-    use flate2::Compression;
-    use flate2::write::GzEncoder;
-    use std::io::Write;
-
-    out.clear();
-    let mut encoder = GzEncoder::new(out, Compression::fast());
-    let _ = encoder.write_all(data);
-    let _ = encoder.finish();
-    true
-}
-
-async fn send_otlp(
-    client: &reqwest::Client,
-    url: &str,
-    body: &[u8],
-    gzip_buf: &mut Vec<u8>,
-    extra_headers: &[(String, String)],
-) -> Result<reqwest::Response, reqwest::Error> {
-    let mut req = client
-        .post(url)
-        .header("Content-Type", "application/x-protobuf");
-
-    for (name, value) in extra_headers {
-        req = req.header(name, value);
-    }
-
-    if gzip_compress(body, gzip_buf) {
-        req.header("Content-Encoding", "gzip")
-            .body(gzip_buf.clone())
-            .send()
-            .await
-    } else {
-        req.body(body.to_vec()).send().await
-    }
-}
-
 /// Spawn the span exporter on a dedicated thread with its own single-threaded
 /// tokio runtime, matching the original design that avoids contending with the
 /// application's async runtime.
@@ -279,7 +236,12 @@ pub async fn run(
         .collect();
     let resource = build_resource(&config.service_name, &attr_refs);
 
-    let client = match reqwest::Client::builder().timeout(config.timeout).build() {
+    let mut http_config =
+        crate::otlp::OtlpHttpConfig::new(&config.endpoint).with_timeout(config.timeout);
+    for (name, value) in &config.headers {
+        http_config = http_config.with_header(name, value);
+    }
+    let client = match crate::otlp::OtlpHttpClient::new(http_config) {
         Ok(c) => c,
         Err(e) => {
             crate::logging::log_error!("Failed to build HTTP client for span exporter: {e}");
@@ -294,13 +256,10 @@ pub async fn run(
     let mut consecutive_failures: u32 = 0;
     let mut bufs = SpanExportBufs {
         spans: Vec::with_capacity(config.max_batch_size),
-        encode: Vec::new(),
-        gzip: Vec::new(),
     };
 
     let ctx = SpanExportContext {
         client: &client,
-        url: &url,
         collector: &collector,
         resource: &resource,
         config: &config,
@@ -352,24 +311,23 @@ pub async fn run(
         let otlp_spans: Vec<_> = bufs.spans.iter().map(|s| s.to_otlp()).collect();
         let request = build_trace_export_request(&resource, &config.scope_name, otlp_spans);
 
-        bufs.encode.clear();
-        if let Err(e) = request.encode(&mut bufs.encode) {
-            crate::logging::log_warn!("Span protobuf encode failed: {e}");
-            continue;
-        }
+        let body_len = request.encoded_len();
 
-        let body_len = bufs.encode.len();
-
-        match send_otlp(&client, &url, &bufs.encode, &mut bufs.gzip, &config.headers).await {
-            Ok(resp) if resp.status().is_success() => {
+        match client.export_traces(&request).await {
+            Ok(outcome) if outcome.rejected == 0 => {
                 consecutive_failures = 0;
                 crate::logging::log_debug!("Exported {span_count} spans ({body_len} bytes)");
             }
-            Ok(resp) => {
+            Ok(outcome) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                let status = resp.status();
-                let body = resp.text().await.unwrap_or_default();
-                crate::logging::log_warn!("Span export failed: status={status}, body={body}");
+                crate::logging::log_warn!(
+                    "Span export partially rejected {} spans: {}",
+                    outcome.rejected,
+                    outcome
+                        .message
+                        .as_deref()
+                        .unwrap_or("collector did not provide a reason")
+                );
             }
             Err(e) => {
                 consecutive_failures = consecutive_failures.saturating_add(1);
@@ -380,8 +338,7 @@ pub async fn run(
 }
 
 struct SpanExportContext<'a> {
-    client: &'a reqwest::Client,
-    url: &'a str,
+    client: &'a crate::otlp::OtlpHttpClient,
     collector: &'a SpanCollector,
     resource: &'a pb::Resource,
     config: &'a SpanExportConfig,
@@ -389,8 +346,6 @@ struct SpanExportContext<'a> {
 
 struct SpanExportBufs {
     spans: Vec<fast_telemetry::span::CompletedSpan>,
-    encode: Vec<u8>,
-    gzip: Vec<u8>,
 }
 
 async fn export_once(ctx: &SpanExportContext<'_>, bufs: &mut SpanExportBufs) {
@@ -404,25 +359,16 @@ async fn export_once(ctx: &SpanExportContext<'_>, bufs: &mut SpanExportBufs) {
     let otlp_spans: Vec<_> = bufs.spans.iter().map(|s| s.to_otlp()).collect();
     let request = build_trace_export_request(ctx.resource, &ctx.config.scope_name, otlp_spans);
 
-    bufs.encode.clear();
-    if let Err(e) = request.encode(&mut bufs.encode) {
-        crate::logging::log_warn!("Final span protobuf encode failed: {e}");
-        return;
-    }
-
-    match send_otlp(
-        ctx.client,
-        ctx.url,
-        &bufs.encode,
-        &mut bufs.gzip,
-        &ctx.config.headers,
-    )
-    .await
-    {
-        Ok(resp) if !resp.status().is_success() => {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            crate::logging::log_warn!("Final span export returned {status}: {body}");
+    match ctx.client.export_traces(&request).await {
+        Ok(outcome) if outcome.rejected > 0 => {
+            crate::logging::log_warn!(
+                "Final span export partially rejected {} spans: {}",
+                outcome.rejected,
+                outcome
+                    .message
+                    .as_deref()
+                    .unwrap_or("collector did not provide a reason")
+            );
         }
         Err(e) => crate::logging::log_warn!("Final span export failed: {e}"),
         _ => {}

--- a/crates/fast-telemetry-export/tests/otlp_http.rs
+++ b/crates/fast-telemetry-export/tests/otlp_http.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use fast_telemetry::otlp::{
     build_export_request, build_log_export_request, build_resource, build_trace_export_request, pb,
 };
-use fast_telemetry_export::otlp::{OtlpHttpClient, OtlpHttpConfig};
+use fast_telemetry_export::otlp::{OtlpHttpClient, OtlpHttpConfig, OtlpHttpErrorKind};
 use flate2::read::GzDecoder;
 use prost::Message;
 
@@ -38,6 +38,33 @@ fn collector(
                 )
                 .expect("write response");
         }
+    });
+    (format!("http://{address}"), captured_rx, task)
+}
+
+fn collector_response(
+    status: &str,
+    body: Vec<u8>,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind collector");
+    let address = listener.local_addr().expect("collector address");
+    let (captured_tx, captured_rx) = mpsc::channel();
+    let status = status.to_string();
+    let task = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        captured_tx
+            .send(read_request(&mut stream))
+            .expect("capture request");
+        let head = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/x-protobuf\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = stream.write_all(head.as_bytes());
+        let _ = stream.write_all(&body);
     });
     (format!("http://{address}"), captured_rx, task)
 }
@@ -149,6 +176,7 @@ async fn exports_logs_metrics_and_traces_through_the_shared_client() {
         let head = request.head.to_ascii_lowercase();
         assert!(head.contains("x-tenant: tenant-a"));
         assert!(head.contains("content-encoding: gzip"));
+        assert!(head.contains("user-agent: otel-otlp-exporter-rust/fast-telemetry-export-"));
     }
     assert!(log_request.head.starts_with("POST /v1/logs "));
     assert!(metric_request.head.starts_with("POST /v1/metrics "));
@@ -160,5 +188,40 @@ async fn exports_logs_metrics_and_traces_through_the_shared_client() {
     pb::ExportTraceServiceRequest::decode(decoded_body(&trace_request).as_slice())
         .expect("decode traces");
 
+    server.join().expect("collector thread");
+}
+
+#[tokio::test]
+async fn bounds_success_and_error_response_bodies() {
+    let resource = build_resource("checkout", &[]);
+    let logs = build_log_export_request(&resource, "integration", vec![pb::LogRecord::default()]);
+
+    let (endpoint, captured, server) = collector_response("200 OK", vec![b'x'; 4 * 1024]);
+    let client = OtlpHttpClient::new(OtlpHttpConfig::new(endpoint).with_max_response_bytes(128))
+        .expect("HTTP client");
+    let error = client
+        .export_logs(&logs)
+        .await
+        .expect_err("oversized success response");
+    assert_eq!(error.kind, OtlpHttpErrorKind::Decode);
+    captured
+        .recv_timeout(Duration::from_secs(1))
+        .expect("captured success request");
+    server.join().expect("collector thread");
+
+    let (endpoint, captured, server) =
+        collector_response("503 Service Unavailable", vec![b'y'; 4 * 1024]);
+    let client = OtlpHttpClient::new(OtlpHttpConfig::new(endpoint).with_max_response_bytes(128))
+        .expect("HTTP client");
+    let error = client
+        .export_logs(&logs)
+        .await
+        .expect_err("bounded retryable response");
+    assert_eq!(error.kind, OtlpHttpErrorKind::RetryableStatus);
+    assert!(error.message.len() <= 128 + '…'.len_utf8());
+    assert!(error.message.ends_with('…'));
+    captured
+        .recv_timeout(Duration::from_secs(1))
+        .expect("captured error request");
     server.join().expect("collector thread");
 }

--- a/crates/fast-telemetry-export/tests/otlp_http.rs
+++ b/crates/fast-telemetry-export/tests/otlp_http.rs
@@ -1,0 +1,164 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use fast_telemetry::otlp::{
+    build_export_request, build_log_export_request, build_resource, build_trace_export_request, pb,
+};
+use fast_telemetry_export::otlp::{OtlpHttpClient, OtlpHttpConfig};
+use flate2::read::GzDecoder;
+use prost::Message;
+
+struct CapturedRequest {
+    head: String,
+    body: Vec<u8>,
+}
+
+fn collector(
+    requests: usize,
+) -> (
+    String,
+    mpsc::Receiver<CapturedRequest>,
+    thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind collector");
+    let address = listener.local_addr().expect("collector address");
+    let (captured_tx, captured_rx) = mpsc::channel();
+    let task = thread::spawn(move || {
+        for _ in 0..requests {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            captured_tx
+                .send(read_request(&mut stream))
+                .expect("capture request");
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/x-protobuf\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .expect("write response");
+        }
+    });
+    (format!("http://{address}"), captured_rx, task)
+}
+
+fn read_request(stream: &mut TcpStream) -> CapturedRequest {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("read timeout");
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut buffer).expect("read headers");
+        assert!(read > 0, "request closed before headers");
+        bytes.extend_from_slice(&buffer[..read]);
+        if let Some(position) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+    let head = String::from_utf8(bytes[..header_end].to_vec()).expect("ASCII headers");
+    let content_length = head
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().expect("content length"))
+        })
+        .expect("content-length header");
+    while bytes.len() < header_end + content_length {
+        let read = stream.read(&mut buffer).expect("read body");
+        assert!(read > 0, "request closed before body");
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    CapturedRequest {
+        head,
+        body: bytes[header_end..header_end + content_length].to_vec(),
+    }
+}
+
+fn decoded_body(request: &CapturedRequest) -> Vec<u8> {
+    if !request
+        .head
+        .to_ascii_lowercase()
+        .contains("content-encoding: gzip")
+    {
+        return request.body.clone();
+    }
+    let mut body = Vec::new();
+    GzDecoder::new(request.body.as_slice())
+        .read_to_end(&mut body)
+        .expect("decode gzip request");
+    body
+}
+
+#[tokio::test]
+async fn exports_logs_metrics_and_traces_through_the_shared_client() {
+    let (endpoint, captured, server) = collector(3);
+    let client = OtlpHttpClient::new(
+        OtlpHttpConfig::new(endpoint)
+            .with_header("x-tenant", "tenant-a")
+            .with_gzip_threshold(0),
+    )
+    .expect("HTTP client");
+    let resource = build_resource("checkout", &[("service.instance.id", "checkout-1")]);
+
+    let logs = build_log_export_request(
+        &resource,
+        "integration",
+        vec![pb::LogRecord {
+            body: Some(pb::AnyValue {
+                value: Some(pb::any_value::Value::StringValue("ready".to_string())),
+            }),
+            ..Default::default()
+        }],
+    );
+    let log_outcome = client.export_logs(&logs).await.expect("export logs");
+    assert_eq!((log_outcome.accepted, log_outcome.rejected), (1, 0));
+
+    let metrics = build_export_request(
+        &resource,
+        "integration",
+        vec![pb::Metric {
+            data: Some(pb::metric::Data::Gauge(pb::OtlpGauge {
+                data_points: vec![pb::NumberDataPoint::default(); 2],
+            })),
+            ..Default::default()
+        }],
+    );
+    let metric_outcome = client
+        .export_metrics(&metrics)
+        .await
+        .expect("export metrics");
+    assert_eq!((metric_outcome.accepted, metric_outcome.rejected), (2, 0));
+
+    let traces =
+        build_trace_export_request(&resource, "integration", vec![pb::OtlpSpan::default()]);
+    let trace_outcome = client.export_traces(&traces).await.expect("export traces");
+    assert_eq!((trace_outcome.accepted, trace_outcome.rejected), (1, 0));
+
+    let log_request = captured
+        .recv_timeout(Duration::from_secs(1))
+        .expect("log request");
+    let metric_request = captured
+        .recv_timeout(Duration::from_secs(1))
+        .expect("metric request");
+    let trace_request = captured
+        .recv_timeout(Duration::from_secs(1))
+        .expect("trace request");
+    for request in [&log_request, &metric_request, &trace_request] {
+        let head = request.head.to_ascii_lowercase();
+        assert!(head.contains("x-tenant: tenant-a"));
+        assert!(head.contains("content-encoding: gzip"));
+    }
+    assert!(log_request.head.starts_with("POST /v1/logs "));
+    assert!(metric_request.head.starts_with("POST /v1/metrics "));
+    assert!(trace_request.head.starts_with("POST /v1/traces "));
+    pb::ExportLogsServiceRequest::decode(decoded_body(&log_request).as_slice())
+        .expect("decode logs");
+    pb::ExportMetricsServiceRequest::decode(decoded_body(&metric_request).as_slice())
+        .expect("decode metrics");
+    pb::ExportTraceServiceRequest::decode(decoded_body(&trace_request).as_slice())
+        .expect("decode traces");
+
+    server.join().expect("collector thread");
+}

--- a/crates/fast-telemetry-macros/Cargo.toml
+++ b/crates/fast-telemetry-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry-macros"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/fast-telemetry/Cargo.toml
+++ b/crates/fast-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-telemetry"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 authors.workspace = true
 homepage.workspace = true
@@ -19,7 +19,8 @@ all-features = true
 default = ["macros"]
 macros = ["dep:fast-telemetry-macros"]
 runtime = []
-otlp = ["dep:opentelemetry-proto", "dep:prost"]
+otlp = ["dep:opentelemetry-proto", "dep:prost", "opentelemetry-proto/gen-tonic", "opentelemetry-proto/gen-tonic-messages", "opentelemetry-proto/metrics", "opentelemetry-proto/trace"]
+otlp-logs = ["otlp", "opentelemetry-proto/logs"]
 clickhouse = ["dep:indexmap", "dep:klickhouse"]
 shuttle-tests = ["dep:shuttle"]
 bench-tools = ["dep:libc", "dep:metrics", "dep:metrics-util", "dep:opentelemetry", "dep:opentelemetry_sdk"]
@@ -35,7 +36,7 @@ libc = { version = "0.2", optional = true }
 metrics = { workspace = true, optional = true }
 metrics-util = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
-opentelemetry-proto = { version = "0.30", default-features = false, features = ["gen-tonic", "gen-tonic-messages", "metrics", "trace"], optional = true }
+opentelemetry-proto = { version = "0.30", default-features = false, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true, features = ["testing"] }
 parking_lot = { workspace = true }
 prost = { version = "0.13", optional = true }

--- a/crates/fast-telemetry/src/export/otlp.rs
+++ b/crates/fast-telemetry/src/export/otlp.rs
@@ -16,10 +16,20 @@ use crate::{
 
 /// Re-export proto types so downstream crates (and the derive macro) can reference them.
 pub mod pb {
+    #[cfg(feature = "otlp-logs")]
+    pub use opentelemetry_proto::tonic::collector::logs::v1::{
+        ExportLogsPartialSuccess, ExportLogsServiceRequest, ExportLogsServiceResponse,
+    };
     pub use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+    pub use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceResponse;
     pub use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+    pub use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceResponse;
     pub use opentelemetry_proto::tonic::common::v1::{
         AnyValue, InstrumentationScope, KeyValue, any_value,
+    };
+    #[cfg(feature = "otlp-logs")]
+    pub use opentelemetry_proto::tonic::logs::v1::{
+        LogRecord, ResourceLogs, ScopeLogs, SeverityNumber,
     };
     pub use opentelemetry_proto::tonic::metrics::v1::{
         self, AggregationTemporality, ExponentialHistogram as OtlpExpHistogram,
@@ -158,6 +168,29 @@ pub fn build_export_request(
                     ..Default::default()
                 }),
                 metrics,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// Wrap OTLP log records into an `ExportLogsServiceRequest`.
+#[cfg(feature = "otlp-logs")]
+pub fn build_log_export_request(
+    resource: &pb::Resource,
+    scope_name: &str,
+    logs: Vec<pb::LogRecord>,
+) -> pb::ExportLogsServiceRequest {
+    pb::ExportLogsServiceRequest {
+        resource_logs: vec![pb::ResourceLogs {
+            resource: Some(resource.clone()),
+            scope_logs: vec![pb::ScopeLogs {
+                scope: Some(pb::InstrumentationScope {
+                    name: scope_name.to_string(),
+                    ..Default::default()
+                }),
+                log_records: logs,
                 ..Default::default()
             }],
             ..Default::default()
@@ -1090,6 +1123,42 @@ mod tests {
         let scope = sm.scope.as_ref().expect("missing scope");
         assert_eq!(scope.name, "fast-telemetry");
         assert_eq!(sm.metrics.len(), 1);
+    }
+
+    #[cfg(feature = "otlp-logs")]
+    #[test]
+    fn test_build_log_export_request() {
+        let resource = build_resource("test-service", &[("version", "1.0")]);
+        let record = pb::LogRecord {
+            body: Some(pb::AnyValue {
+                value: Some(pb::any_value::Value::StringValue("hello".to_string())),
+            }),
+            ..Default::default()
+        };
+
+        let request = build_log_export_request(&resource, "fast-telemetry", vec![record]);
+
+        assert_eq!(request.resource_logs.len(), 1);
+        let resource_logs = &request.resource_logs[0];
+        assert_eq!(
+            resource_logs
+                .resource
+                .as_ref()
+                .expect("resource")
+                .attributes
+                .len(),
+            2
+        );
+        assert_eq!(resource_logs.scope_logs.len(), 1);
+        assert_eq!(resource_logs.scope_logs[0].log_records.len(), 1);
+        assert_eq!(
+            resource_logs.scope_logs[0]
+                .scope
+                .as_ref()
+                .expect("scope")
+                .name,
+            "fast-telemetry"
+        );
     }
 
     #[test]

--- a/crates/fast-telemetry/src/export/otlp.rs
+++ b/crates/fast-telemetry/src/export/otlp.rs
@@ -34,8 +34,8 @@ pub mod pb {
     pub use opentelemetry_proto::tonic::metrics::v1::{
         self, AggregationTemporality, ExponentialHistogram as OtlpExpHistogram,
         ExponentialHistogramDataPoint, Gauge as OtlpGauge, Histogram as OtlpHistogram,
-        HistogramDataPoint, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum,
-        exponential_histogram_data_point, metric, number_data_point,
+        HistogramDataPoint, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum, Summary,
+        SummaryDataPoint, exponential_histogram_data_point, metric, number_data_point,
     };
     pub use opentelemetry_proto::tonic::resource::v1::Resource;
     pub use opentelemetry_proto::tonic::trace::v1::{

--- a/crates/fast-telemetry/src/metric/counter.rs
+++ b/crates/fast-telemetry/src/metric/counter.rs
@@ -1,7 +1,7 @@
 //! Thread-sharded atomic counter.
 //!
-//! Forked from https://crates.io/crates/fast-counter (MIT/Apache licensed)
-//! Originally authored by https://crates.io/users/JackThomson2
+//! Forked from <https://crates.io/crates/fast-counter> (MIT/Apache licensed)
+//! Originally authored by <https://crates.io/users/JackThomson2>
 //! Modified to use crossbeam's CachePadded for more correct cache line sizing,
 //! and to support swap operations and export operations.
 

--- a/crates/fast-telemetry/src/span/collector.rs
+++ b/crates/fast-telemetry/src/span/collector.rs
@@ -289,7 +289,8 @@ impl SpanCollector {
     /// Call this before [`drain_into`](Self::drain_into) when running on the
     /// same thread that submitted spans (e.g., in tests or single-threaded
     /// exporters).  In production, thread-local buffers are flushed
-    /// automatically when they reach [`FLUSH_THRESHOLD`] or on thread exit.
+    /// automatically when they reach the internal flush threshold or on thread
+    /// exit.
     pub fn flush_local(&self) {
         LOCAL.with(|cell| {
             // SAFETY: see LOCAL definition.

--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -7,7 +7,7 @@ batching, compression, backoff, and graceful shutdown.
 
 ```toml
 [dependencies]
-fast-telemetry-export = "0.7"
+fast-telemetry-export = "0.9"
 ```
 
 ### DogStatsD
@@ -76,6 +76,63 @@ let config = SpanExportConfig::new("http://otel-collector:4318")
 
 spawn(collector, config, cancel);
 ```
+
+### Acknowledged OTLP HTTP and Logs
+
+Enable `otlp-logs` when a caller needs to submit OTLP log records directly or
+share one transport policy across logs, metrics, and traces:
+
+```toml
+[dependencies]
+fast-telemetry = { version = "0.9", features = ["otlp-logs"] }
+fast-telemetry-export = { version = "0.9", default-features = false, features = ["otlp-logs"] }
+```
+
+```rust,no_run
+use fast_telemetry::otlp::{build_log_export_request, build_resource, pb};
+use fast_telemetry_export::otlp::{OtlpHttpClient, OtlpHttpConfig};
+
+# async fn export() -> Result<(), Box<dyn std::error::Error>> {
+let client = OtlpHttpClient::new(
+    OtlpHttpConfig::new("https://otel-collector:4318")
+        .with_header("Authorization", "Bearer <token>")
+        .with_gzip_threshold(1024),
+)?;
+let resource = build_resource("checkout", &[("service.instance.id", "checkout-1")]);
+let request = build_log_export_request(
+    &resource,
+    "checkout",
+    vec![pb::LogRecord {
+        body: Some(pb::AnyValue {
+            value: Some(pb::any_value::Value::StringValue("ready".to_string())),
+        }),
+        ..Default::default()
+    }],
+);
+let outcome = client.export_logs(&request).await?;
+assert_eq!(outcome.accepted + outcome.rejected, 1);
+# Ok(())
+# }
+```
+
+The same client exposes `export_metrics` and `export_traces`. It validates its
+endpoint, headers, and TLS/mTLS material at construction, then performs exactly
+one request per call. It never retries or logs internally.
+
+Use the returned classification to drive the caller's policy:
+
+| Result | Caller action |
+| --- | --- |
+| `Ok` with `rejected == 0` | Advance the caller's checkpoint or mark the batch delivered |
+| `Ok` with `rejected > 0` | Inspect `message`; isolate invalid records when ordering must continue |
+| `error.is_retryable()` | Retry transport errors, 408, 425, 429, and 5xx; honor `retry_after` |
+| `error.is_invalid_payload()` | Split or reject HTTP 400/413 payloads |
+| `error.is_terminal()` | Stop and surface configuration, encoding, authentication, other permanent HTTP, or decode failures |
+
+Additional CA bundles and mTLS identities are configured with
+`with_ca_certificate_pem` and `with_client_identity_pem`. The client uses
+at-least-once request semantics: a lost response can cause a caller to resend a
+batch, so stable event identity remains the caller's responsibility.
 
 ### ClickHouse (native TCP)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -43,6 +43,7 @@
 | Prometheus text | `export_prometheus()`                                                                                           | Serve at `/metrics`                             |
 | DogStatsD       | `export_dogstatsd()`, `export_dogstatsd_delta()`, or `export_dogstatsd_with_temporality(..., Temporality, ...)` | UDP via `fast-telemetry-export`                 |
 | OTLP protobuf   | `export_otlp()` (requires `#[otlp]` on struct)                                                                  | HTTP via `fast-telemetry-export`                |
+| OTLP logs       | `build_log_export_request()` (requires `otlp-logs`)                                                            | Acknowledged HTTP via `OtlpHttpClient`           |
 | ClickHouse rows | `export_clickhouse()` (requires `#[clickhouse]` on struct) or `ClickHouseExport`; `export_otlp()` fallback also supported | Native TCP via `fast-telemetry-export[clickhouse]` |
 
 ## Shard Count
@@ -70,9 +71,11 @@ This project has since evolved substantially.
 
 ## Scope
 
-fast-telemetry is **metrics and lightweight spans**. It does not cover:
+fast-telemetry provides **metrics, lightweight spans, and reusable OTLP
+transport**. Its log support accepts caller-built OTLP records; it does not
+provide a structured logging API. It does not cover:
 
-- Structured logging
+- Log macros, contextual record construction, or log filtering
 - Distributed trace backends (ingestion, storage, query)
 - Automatic cross-service context propagation
 - Alerting or dashboarding


### PR DESCRIPTION
## Summary

- add the `otlp-logs` feature and re-export the OTLP Logs protobuf model
- add reusable, non-logging `OtlpHttpConfig` and `OtlpHttpClient` APIs with headers, timeouts, gzip, additional CAs, mTLS, `Retry-After`, and acknowledged log/metric/trace exports
- move the existing Tokio metric and span exporters onto the shared one-shot HTTP client without breaking their public APIs
- bound collector response bodies to 64 KiB by default, expose a configurable limit, and emit a standard OTLP exporter `User-Agent`
- apply OTLP-compliant response policy: transport errors plus 429/502/503/504 are retryable, 400/413 are invalid-payload responses, and other HTTP failures are terminal
- return partial-success accepted/rejected counts as acknowledged outcomes that callers must not replay
- complete 0.9 release notes, exporter documentation, feature-matrix CI, Hegel coverage, and strict lint/rustdoc gates

## Why

`eden_logger_export` and shard-stream need an acknowledged OTLP/HTTP transport they can compose with their own queueing, retry, ordering, or HA policies. Keeping transport here avoids duplicating HTTP, TLS, compression, status policy, and bounded response handling. The one-shot client returns diagnostics as values, never logs internally, and never retries on its own.

## Delivery contract

- successful responses conserve accepted plus rejected signal-item counts
- partial-success responses are acknowledged once and must not be retried
- transport errors and HTTP 429/502/503/504 are retryable; `Retry-After` is preserved
- HTTP 400/413 are invalid-payload errors suitable for caller-side batch reduction or bisection
- configuration, encoding, authentication/permanent HTTP, response-decode, and oversized successful-response failures are terminal
- response bodies are memory-bounded; non-success diagnostics are truncated and successful responses over the limit are rejected
- callers that retry after a lost response must tolerate duplicate delivery

## Validation

Validated on the declared Rust 1.93.0 MSRV against the exact pushed source:

- `cargo test --workspace --all-features`: 260 unit/integration tests passed, including three real ClickHouse container round trips and bounded OTLP logs/metrics/traces loopback coverage
- 1,550 generated Hegel cases pass per run
- strict workspace all-target, all-feature Clippy with `-D warnings`
- isolated no-feature, `otlp`, and `otlp-logs` feature checks
- warning-free workspace rustdoc with all features
- formatting and diff checks passed

## Release

The complete planned 0.9.0 entry is in `RELEASE_NOTES.md`. Publish `fast-telemetry`, `fast-telemetry-macros`, and `fast-telemetry-export` 0.9 before publishing `eden_logger_export` from [eden-logger#1](https://github.com/eden-dev-inc/eden-logger/pull/1).